### PR TITLE
Feature/locale string selector

### DIFF
--- a/src/redux/selectors/locale.js
+++ b/src/redux/selectors/locale.js
@@ -1,17 +1,19 @@
-import en from '../../i18n/translations/en';
-import fi from '../../i18n/translations/fi';
-import sv from '../../i18n/translations/sv';
 
 const getLocale = store => store.locale;
 
 // This returns correct string according to locale
-const translate = (state, id) => {
-  const locale = getLocale(state);
-  const translations = { fi, en, sv };
-  return translations[locale][id];
+const getLocaleString = (locale, obj) => {
+  // Default rerturned string is the first one lsited (probably always finnish)
+  let value = obj[Object.keys(obj)[0]];
+  Object.keys(obj).forEach((key) => {
+    if (key === locale) {
+      value = obj[key];
+    }
+  });
+  return value;
 };
 
 export {
-  translate,
+  getLocaleString,
   getLocale,
 };

--- a/src/redux/selectors/locale.js
+++ b/src/redux/selectors/locale.js
@@ -2,7 +2,8 @@
 const getLocale = store => store.locale;
 
 // This returns correct string according to locale
-const getLocaleString = (locale, obj) => {
+const getLocaleString = (state, obj) => {
+  const locale = getLocale(state);
   // Default rerturned string is the first one lsited (probably always finnish)
   let value = obj[Object.keys(obj)[0]];
   Object.keys(obj).forEach((key) => {

--- a/src/views/Map/MapContainer.js
+++ b/src/views/Map/MapContainer.js
@@ -6,7 +6,7 @@ import { getMapType } from '../../redux/selectors/map';
 import getDistricts from '../../redux/selectors/district';
 import { fetchDistrictsData } from '../../redux/actions/district';
 import MapView from './components/MapView';
-import { getLocale, getLocaleString } from '../../redux/selectors/locale';
+import { getLocaleString } from '../../redux/selectors/locale';
 import CreateMap from './utils/createMap';
 import { mapOptions } from './constants/mapConstants';
 import fetchStops from './utils/fetchStops';
@@ -106,7 +106,7 @@ class MapContainer extends React.Component {
 
   render() {
     const {
-      mapType, unitList, locale, districts,
+      mapType, unitList, districts, getLocaleText,
     } = this.props;
     const { initialMap, transitStops } = this.state;
     if (initialMap) {
@@ -120,7 +120,7 @@ class MapContainer extends React.Component {
           fetchTransitStops={this.fetchTransitStops}
           clearTransitStops={this.clearTransitStops}
           transitStops={transitStops}
-          getLocaleString={object => getLocaleString(locale, object)}
+          getLocaleText={textObject => getLocaleText(textObject)}
           // TODO: think about better styling location for map
           style={{ width: '100%', height: '100%', position: 'relative' }}
         />
@@ -132,14 +132,14 @@ class MapContainer extends React.Component {
 // Listen to redux state
 const mapStateToProps = (state) => {
   const mapType = getMapType(state);
-  const locale = getLocale(state);
   const districts = getDistricts(state);
+  const getLocaleText = textObject => getLocaleString(state, textObject);
   // const unitList = getUnitList(state);
   return {
     mapType,
-    locale,
     districts,
     state,
+    getLocaleText,
     // unitList,
   };
 };
@@ -157,7 +157,8 @@ MapContainer.propTypes = {
   unitList: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.object, PropTypes.array])),
   locale: PropTypes.string,
   districts: PropTypes.arrayOf(PropTypes.object),
-  fetchDistrictsData: PropTypes.func,
+  fetchDistrictsData: PropTypes.func.isRequired,
+  getLocaleText: PropTypes.func.isRequired,
 };
 
 MapContainer.defaultProps = {
@@ -165,5 +166,4 @@ MapContainer.defaultProps = {
   unitList: [],
   locale: 'fi',
   districts: {},
-  fetchDistrictsData: null,
 };

--- a/src/views/Map/MapContainer.js
+++ b/src/views/Map/MapContainer.js
@@ -6,7 +6,7 @@ import { getMapType } from '../../redux/selectors/map';
 import getDistricts from '../../redux/selectors/district';
 import { fetchDistrictsData } from '../../redux/actions/district';
 import MapView from './components/MapView';
-import { getLocale, translate } from '../../redux/selectors/locale';
+import { getLocale, getLocaleString } from '../../redux/selectors/locale';
 import CreateMap from './utils/createMap';
 import { mapOptions } from './constants/mapConstants';
 import fetchStops from './utils/fetchStops';
@@ -28,7 +28,6 @@ class MapContainer extends React.Component {
     };
     this.fetchMapDistricts(mockPosition);
   }
-
 
   initiateMap = () => {
     const initialMap = CreateMap('servicemap');
@@ -107,7 +106,7 @@ class MapContainer extends React.Component {
 
   render() {
     const {
-      mapType, unitList, state, districts,
+      mapType, unitList, locale, districts,
     } = this.props;
     const { initialMap, transitStops } = this.state;
     if (initialMap) {
@@ -121,7 +120,7 @@ class MapContainer extends React.Component {
           fetchTransitStops={this.fetchTransitStops}
           clearTransitStops={this.clearTransitStops}
           transitStops={transitStops}
-          t={id => translate(state, id)}
+          getLocaleString={object => getLocaleString(locale, object)}
           // TODO: think about better styling location for map
           style={{ width: '100%', height: '100%', position: 'relative' }}
         />
@@ -157,7 +156,6 @@ MapContainer.propTypes = {
   mapType: PropTypes.oneOfType([PropTypes.objectOf(PropTypes.any), PropTypes.string]),
   unitList: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.object, PropTypes.array])),
   locale: PropTypes.string,
-  state: PropTypes.objectOf(PropTypes.any),
   districts: PropTypes.arrayOf(PropTypes.object),
   fetchDistrictsData: PropTypes.func,
 };
@@ -166,7 +164,6 @@ MapContainer.defaultProps = {
   mapType: '',
   unitList: [],
   locale: 'fi',
-  state: {},
   districts: {},
   fetchDistrictsData: null,
 };

--- a/src/views/Map/components/MapView.js
+++ b/src/views/Map/components/MapView.js
@@ -41,12 +41,12 @@ class MapView extends React.Component {
       mapBase,
       unitList,
       mapOptions,
-      districtList,
+      // districtList,
       style,
       fetchTransitStops,
       clearTransitStops,
       transitStops,
-      t,
+      getLocaleString,
     } = this.props;
     const {
       Map, TileLayer, ZoomControl, Marker, Popup, Polygon, highlightedDistrict,
@@ -102,7 +102,7 @@ class MapView extends React.Component {
               icon={drawIcon(highlightedDistrict.unit, mapBase.options.name)}
             >
               <Popup autoPan={false}>
-                <p>{highlightedDistrict.unit.name.fi}</p>
+                <p>{getLocaleString(highlightedDistrict.unit.name)}</p>
               </Popup>
             </Marker>
           ) : null}
@@ -119,7 +119,7 @@ class MapView extends React.Component {
               position={[stop.lat, stop.lon]}
             >
               <Popup autoPan={false}>
-                <TransitStopInfo t={t} stop={stop} />
+                <TransitStopInfo stop={stop} />
               </Popup>
             </Marker>
           ))}
@@ -137,12 +137,12 @@ MapView.propTypes = {
   style: PropTypes.objectOf(PropTypes.any),
   mapBase: PropTypes.objectOf(PropTypes.any),
   unitList: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.object, PropTypes.array])),
-  districtList: PropTypes.arrayOf(PropTypes.object),
+  // districtList: PropTypes.arrayOf(PropTypes.object),
   mapOptions: PropTypes.objectOf(PropTypes.any),
   fetchTransitStops: PropTypes.func,
   clearTransitStops: PropTypes.func,
   transitStops: PropTypes.arrayOf(PropTypes.object),
-  t: PropTypes.func,
+  getLocaleString: PropTypes.func.isRequired,
 };
 
 MapView.defaultProps = {
@@ -150,9 +150,8 @@ MapView.defaultProps = {
   mapBase: {},
   mapOptions: {},
   unitList: [],
-  districtList: [],
+  // districtList: [],
   fetchTransitStops: null,
   clearTransitStops: null,
   transitStops: [],
-  t: null,
 };

--- a/src/views/Map/components/MapView.js
+++ b/src/views/Map/components/MapView.js
@@ -46,7 +46,7 @@ class MapView extends React.Component {
       fetchTransitStops,
       clearTransitStops,
       transitStops,
-      getLocaleString,
+      getLocaleText,
     } = this.props;
     const {
       Map, TileLayer, ZoomControl, Marker, Popup, Polygon, highlightedDistrict,
@@ -102,7 +102,7 @@ class MapView extends React.Component {
               icon={drawIcon(highlightedDistrict.unit, mapBase.options.name)}
             >
               <Popup autoPan={false}>
-                <p>{getLocaleString(highlightedDistrict.unit.name)}</p>
+                <p>{getLocaleText(highlightedDistrict.unit.name)}</p>
               </Popup>
             </Marker>
           ) : null}
@@ -142,7 +142,7 @@ MapView.propTypes = {
   fetchTransitStops: PropTypes.func,
   clearTransitStops: PropTypes.func,
   transitStops: PropTypes.arrayOf(PropTypes.object),
-  getLocaleString: PropTypes.func.isRequired,
+  getLocaleText: PropTypes.func.isRequired,
 };
 
 MapView.defaultProps = {

--- a/src/views/Map/components/TransitStopInfo.js
+++ b/src/views/Map/components/TransitStopInfo.js
@@ -4,10 +4,11 @@ import PropTypes from 'prop-types';
 import DirectionsBus from '@material-ui/icons/DirectionsBus';
 import DirectionsRailway from '@material-ui/icons/DirectionsRailway';
 import DirectionsSubway from '@material-ui/icons/DirectionsSubway';
+import { FormattedMessage } from 'react-intl';
 
 // TODO: better styling + styling location
 const TransitStopInfo = (props) => {
-  const { stop, t } = props;
+  const { stop } = props;
   return (
     <div style={{ width: '230px' }}>
       <p style={{
@@ -75,7 +76,7 @@ const TransitStopInfo = (props) => {
               marginTop: '0px', marginBottom: '2px', width: '55%', overflow: 'hidden', whiteSpace: 'nowrap', textOverflow: 'ellipsis', lineHeight: '20px', height: '20px',
             }}
             >
-              {arrival.pickupType === 'NONE' ? t('map.transit.endStation') : arrival.headsign}
+              {arrival.pickupType === 'NONE' ? <FormattedMessage id="map.transit.endStation" /> : arrival.headsign}
             </p>
           </div>
         );
@@ -88,10 +89,8 @@ export default TransitStopInfo;
 
 TransitStopInfo.propTypes = {
   stop: PropTypes.objectOf(PropTypes.any),
-  t: PropTypes.func,
 };
 
 TransitStopInfo.defaultProps = {
   stop: {},
-  t: null,
 };


### PR DESCRIPTION
Add selector to return string based on locale
* The selector takes object of strings and returns the correct one
* Used when API returns e.g name object with values for each language
* If no value matching current locale is found, returns the first one
