### PR TITLE
Add show on map button to mobile unit view

### DIFF
--- a/config/paths.js
+++ b/config/paths.js
@@ -13,12 +13,8 @@ const paths = {
     regex: /\/[a-zA-Z]{2}\/search/
   },
   unit: {
-    generate: id => `/unit/${id || ''}`,
+    generate: data => `/unit/${data.id || ''}${data.query || ''}`,
     regex: /\/[a-zA-Z]{2}\/unit\/([0-9]+)/
-  },
-  unitMap: {
-    generate: id => `/unit/${id || ''}?map=true`,
-    regex: /\/[a-zA-Z]{2}\/unit\/([0-9]+)\?map=true/
   },
   unitEvents: {
     generate: id => `/unit/${id || ''}/events`,

--- a/config/paths.js
+++ b/config/paths.js
@@ -16,6 +16,10 @@ const paths = {
     generate: id => `/unit/${id || ''}`,
     regex: /\/[a-zA-Z]{2}\/unit\/([0-9]+)/
   },
+  unitMap: {
+    generate: id => `/unit/${id || ''}?map=true`,
+    regex: /\/[a-zA-Z]{2}\/unit\/([0-9]+)\?map=true/
+  },
   unitEvents: {
     generate: id => `/unit/${id || ''}/events`,
     regex: /\/[a-zA-Z]{2}\/unit\/([0-9]+)\/events/

--- a/src/components/ListItems/UnitItem/UnitItem.js
+++ b/src/components/ListItems/UnitItem/UnitItem.js
@@ -68,7 +68,7 @@ class UnitItem extends React.Component {
             onClick();
           } else if (navigator) {
             changeSelectedUnit(unit);
-            navigator.push('unit', id);
+            navigator.push('unit', { id });
           }
         }}
       />

--- a/src/components/MobileBottomNavigation/MobileBottomNavigation.js
+++ b/src/components/MobileBottomNavigation/MobileBottomNavigation.js
@@ -21,23 +21,6 @@ const styles = {
 };
 
 class MobileBottomNavigation extends React.Component {
-  state = {
-    value: 0,
-  };
-
-  // Figure out initial selected value
-  componentDidMount() {
-    const { actions, location } = this.props;
-    const path = location.pathname;
-
-    actions.forEach((action, index) => {
-      // If pathname contains action.path
-      if (comparePath(action.path, path)) {
-        this.setState({ value: index });
-      }
-    });
-  }
-
   handleChange = (event, value) => {
     const { actions } = this.props;
     const action = actions[value] && actions[value].onClick;
@@ -46,8 +29,6 @@ class MobileBottomNavigation extends React.Component {
     if (action) {
       action(event);
     }
-
-    this.setState({ value });
   };
 
   render() {
@@ -55,7 +36,12 @@ class MobileBottomNavigation extends React.Component {
       actions, classes, style, location,
     } = this.props;
     const path = location.pathname;
-    const { value } = this.state;
+
+    let value = 0;
+    if (comparePath('map', path)) {
+      value = 1;
+    }
+
     let show = false;
     // If current location equals action path show mobile navigation
     actions.forEach((action) => {

--- a/src/i18n/translations/en.js
+++ b/src/i18n/translations/en.js
@@ -31,6 +31,7 @@ export default {
   'general.home': 'Home',
   'general.noData': 'No data available',
   'general.loading': 'Loading',
+  'general.showOnMap': 'Show on map',
   'general.pageTitles.home': 'Home view',
   'general.pageTitles.search': 'Search view',
   'general.pageTitles.unit': 'Unit view',

--- a/src/i18n/translations/fi.js
+++ b/src/i18n/translations/fi.js
@@ -31,6 +31,7 @@ export default {
   'general.home': 'Koti',
   'general.noData': 'Tietoa ei saatavilla',
   'general.loading': 'Ladataan',
+  'general.showOnMap': 'Näytä kartalla',
   'general.pageTitles.home': 'Aloitusnäkymä',
   'general.pageTitles.search': 'Hakutulosnäkymä',
   'general.pageTitles.unit': 'Toimipistenäkymä',

--- a/src/i18n/translations/sv.js
+++ b/src/i18n/translations/sv.js
@@ -31,6 +31,7 @@ export default {
   'general.home': 'Home', // TODO: Translate
   'general.noData': 'No data available', // TODO: Translate
   'general.loading': 'Loading', // TODO: Translate
+  'general.showOnMap': 'Show on map', // TODO: Translate
   'general.pageTitles.home': 'Home view', // TODO: Translate
   'general.pageTitles.search': 'Search view', // TODO: Translate
   'general.pageTitles.unit': 'Unit view', // TODO: Translate

--- a/src/layouts/DefaultLayout.js
+++ b/src/layouts/DefaultLayout.js
@@ -21,7 +21,7 @@ const mobileBreakpoint = config.mobile_ui_breakpoint;
 const smallScreenBreakpoint = config.small_screen_breakpoint;
 
 const createContentStyles = (
-  isMobile, isSmallScreen, landscape, mobileMapOnly, keyboardVisible,
+  isMobile, isSmallScreen, landscape, mobileMapOnly, fullMobileMap, keyboardVisible,
 ) => {
   let width = 450;
   if (isMobile) {
@@ -46,6 +46,7 @@ const createContentStyles = (
       width,
       margin: 0,
       overflow: 'auto',
+      visibility: mobileMapOnly ? 'hidden' : null,
       paddingBottom: isMobile && !mobileMapOnly ? bottomBarHeight : 0,
     },
     map: {
@@ -67,19 +68,18 @@ const createContentStyles = (
     },
   };
 
-  // Mobile map view styles
-  if (mobileMapOnly) {
-    styles.sidebar.visibility = 'hidden';
-  } else if (isMobile) {
+  if (isMobile) {
     styles.sidebar.flex = '1 1 auto';
+    if (fullMobileMap && !landscape) {
+      styles.map.paddingBottom = 0;
+      styles.map.paddingTop = 56; // Titlebar height
+    }
+    // Landscape orientation styles
+    if (landscape) {
+      styles.map.paddingBottom = '10vw';
+      styles.mobileNav.height = '10vw';
+    }
   }
-
-  // Landscape orientation styles
-  if (landscape && isMobile) {
-    styles.map.paddingBottom = '10vw';
-    styles.mobileNav.height = '10vw';
-  }
-
 
   return styles;
 };
@@ -92,7 +92,8 @@ const DefaultLayout = (props) => {
   const lng = params && params.lng;
   const isMobile = useMediaQuery(`(max-width:${mobileBreakpoint}px)`);
   const isSmallScreen = useMediaQuery(`(max-width:${smallScreenBreakpoint}px)`);
-  const mobileMapOnly = isMobile && location.pathname.indexOf('/map') > -1; // If mobile map view
+  const fullMobileMap = new URLSearchParams(location.search).get('map'); // If mobile map without bottom navigation & searchbar
+  const mobileMapOnly = isMobile && (location.pathname.indexOf('/map') > -1 || fullMobileMap); // If mobile map view
   const landscape = useMediaQuery('(min-device-aspect-ratio: 1/1)');
   const portrait = useMediaQuery('(max-device-aspect-ratio: 1/1)');
   // This checks if the keyboard is up.
@@ -100,7 +101,7 @@ const DefaultLayout = (props) => {
   const keyboardVisible = (landscape ? useMediaQuery('(max-height:200px)') : useMediaQuery('(max-height:500px)'));
 
   const styles = createContentStyles(
-    isMobile, isSmallScreen, landscape, mobileMapOnly, keyboardVisible,
+    isMobile, isSmallScreen, landscape, mobileMapOnly, fullMobileMap, keyboardVisible,
   );
 
   return (

--- a/src/views/EventDetailView/EventDetailView.js
+++ b/src/views/EventDetailView/EventDetailView.js
@@ -102,7 +102,7 @@ class EventDetailView extends React.Component {
                 e.preventDefault();
                 if (navigator) {
                   // Event database precedes unit id with tprek:
-                  navigator.push('unit', unit.id.split(':').pop());
+                  navigator.push('unit', { id: unit.id.split(':').pop() });
                 }
               }}
             />

--- a/src/views/Map/MapContainer.js
+++ b/src/views/Map/MapContainer.js
@@ -15,6 +15,7 @@ import { mapOptions } from './constants/mapConstants';
 import { fetchStops } from './utils/transitFetch';
 
 import SearchBar from '../../components/SearchBar';
+import TitleBar from '../../components/TitleBar/TitleBar';
 
 class MapContainer extends React.Component {
   constructor(props) {
@@ -108,6 +109,22 @@ class MapContainer extends React.Component {
     } = this.props;
     const { initialMap, transitStops } = this.state;
 
+    const topBar = (
+      <div style={{
+        zIndex: 99999999, position: 'fixed', top: 0, width: '100%',
+      }}
+      >
+        {isMobile && currentPage === 'map' && (
+          // If on root map page (/map) display search bar.
+          <SearchBar placeholder={intl.formatMessage({ id: 'search' })} />
+        )}
+        {isMobile && currentPage === 'unit' && highlightedUnit && (
+          // If on unit's map page (/unit?map=true) display title bar
+          <TitleBar title={getLocaleText(highlightedUnit.name)} />
+        )}
+      </div>
+    );
+
     let mapUnits = [];
 
     if (currentPage === 'search') {
@@ -125,16 +142,7 @@ class MapContainer extends React.Component {
     if (initialMap) {
       return (
         <>
-          {isMobile && (
-          <div style={{
-            zIndex: 999999999999, position: 'fixed', top: 0, width: '100%',
-          }}
-          >
-            <SearchBar
-              placeholder={intl.formatMessage({ id: 'search' })}
-            />
-          </div>
-          )}
+          {topBar}
           <MapView
             key={mapType ? mapType.crs.code : initialMap.crs.code}
             mapType={mapType || initialMap}

--- a/src/views/Map/components/MapView.js
+++ b/src/views/Map/components/MapView.js
@@ -168,7 +168,7 @@ class MapView extends React.Component {
                   icon={drawMarkerIcon(unit, mapType.options.name)}
                   onClick={() => {
                     if (navigator) {
-                      navigator.push('unit', unit.id);
+                      navigator.push('unit', { id: unit.id });
                     }
                   }}
                   keyboard={false}

--- a/src/views/Map/utils/mapActions.js
+++ b/src/views/Map/utils/mapActions.js
@@ -25,6 +25,7 @@ const focusUnit = (map, unit) => {
       [unit.location.coordinates[1], unit.location.coordinates[0]],
       map._layersMaxZoom - 1,
     );
+    map._onResize();
   }
 };
 

--- a/src/views/MobileMapView/MobileMapView.js
+++ b/src/views/MobileMapView/MobileMapView.js
@@ -3,15 +3,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { injectIntl, intlShape } from 'react-intl';
 import { connect } from 'react-redux';
+import { setCurrentPage } from '../../redux/actions/user';
 import SearchBar from '../../components/SearchBar';
 import HomeView from '../HomeView';
 import { DesktopComponent, MobileComponent } from '../../layouts/WrapperComponents/WrapperComponents';
 
-const MobileMapView = ({ intl, map }) => {
+const MobileMapView = ({ intl, map, setCurrentPage }) => {
   if (map && typeof window !== 'undefined') {
     // Reftesh map when changing mobile page initialize correct size
     map._onResize();
   }
+
+  setCurrentPage('map');
 
   return (
     <>
@@ -35,6 +38,7 @@ const mapStateToProps = state => ({
 MobileMapView.propTypes = {
   intl: intlShape.isRequired,
   map: PropTypes.objectOf(PropTypes.any),
+  setCurrentPage: PropTypes.func.isRequired,
 };
 
 MobileMapView.defaultProps = {
@@ -44,5 +48,5 @@ MobileMapView.defaultProps = {
 
 export default injectIntl(connect(
   mapStateToProps,
-  null,
+  { setCurrentPage },
 )(MobileMapView));

--- a/src/views/SearchView/SearchView.js
+++ b/src/views/SearchView/SearchView.js
@@ -112,7 +112,7 @@ class SearchView extends React.Component {
       // eslint-disable-next-line camelcase
       switch (object_type) {
         case 'unit':
-          path = generatePath('unit', lng, id);
+          path = generatePath('unit', lng, { id });
           break;
         case 'service':
           path = generatePath('service', lng, id);

--- a/src/views/UnitView/UnitView.js
+++ b/src/views/UnitView/UnitView.js
@@ -9,7 +9,7 @@ import { fetchUnitEvents } from '../../redux/actions/event';
 import { fetchSelectedUnit, changeSelectedUnit } from '../../redux/actions/selectedUnit';
 import { getSelectedUnit } from '../../redux/selectors/selectedUnit';
 import { getLocaleString } from '../../redux/selectors/locale';
-import { DesktopComponent } from '../../layouts/WrapperComponents/WrapperComponents';
+import { DesktopComponent, MobileComponent } from '../../layouts/WrapperComponents/WrapperComponents';
 import { drawIcon } from '../Map/utils/drawIcon';
 
 import SearchBar from '../../components/SearchBar';
@@ -25,6 +25,7 @@ import ElectronicServices from './components/ElectronicServices';
 import Description from './components/Description';
 import Services from './components/Services';
 import Events from './components/Events';
+import ServiceMapButton from '../../components/ServiceMapButton';
 
 class UnitView extends React.Component {
   constructor(props) {
@@ -74,7 +75,7 @@ class UnitView extends React.Component {
 
   render() {
     const {
-      classes, getLocaleText, intl, unit, eventsData,
+      classes, getLocaleText, intl, unit, eventsData, navigator,
     } = this.props;
     const { icon } = this.state;
 
@@ -107,11 +108,34 @@ class UnitView extends React.Component {
         <div className={classes.root}>
           <div className="Content">
             {TopBar}
-            {
-                unit.picture_url
-                && <img className={classes.image} alt={`${intl.formatMessage({ id: 'unit.picture' })}${getLocaleText(unit.name)}`} src={unit.picture_url} />
+
+            {/* Unit image */}
+            {unit.picture_url
+              && (
+              <img
+                className={classes.image}
+                alt={`${intl.formatMessage({ id: 'unit.picture' })}${getLocaleText(unit.name)}`}
+                src={unit.picture_url}
+              />
+              )
             }
-            {/* View Ccomponents */}
+
+            {/* Show on map button for mobile */}
+            <MobileComponent>
+              <ServiceMapButton
+                onClick={(e) => {
+                  e.preventDefault();
+                  this.setState({ centered: false });
+                  if (navigator) {
+                    navigator.push('unitMap', unit.id);
+                  }
+                }}
+              >
+                <FormattedMessage id="general.showOnMap" />
+              </ServiceMapButton>
+            </MobileComponent>
+
+            {/* View Components */}
             <Highlights unit={unit} getLocaleText={getLocaleText} />
             <ContactInfo unit={unit} />
             <ElectronicServices unit={unit} />
@@ -156,12 +180,14 @@ const mapStateToProps = (state) => {
   const eventFetching = state.event.isFetching;
   const getLocaleText = textObject => getLocaleString(state, textObject);
   const map = state.mapRef.leafletElement;
+  const { navigator } = state;
   return {
     unit,
     eventsData,
     eventFetching,
     getLocaleText,
     map,
+    navigator,
   };
 };
 
@@ -182,6 +208,7 @@ UnitView.propTypes = {
   classes: PropTypes.objectOf(PropTypes.any).isRequired,
   getLocaleText: PropTypes.func.isRequired,
   intl: intlShape.isRequired,
+  navigator: PropTypes.objectOf(PropTypes.any),
 };
 
 UnitView.defaultProps = {
@@ -189,4 +216,5 @@ UnitView.defaultProps = {
   eventsData: { events: null, unit: null },
   match: {},
   map: null,
+  navigator: null,
 };

--- a/src/views/UnitView/UnitView.js
+++ b/src/views/UnitView/UnitView.js
@@ -127,7 +127,7 @@ class UnitView extends React.Component {
                   e.preventDefault();
                   this.setState({ centered: false });
                   if (navigator) {
-                    navigator.push('unitMap', unit.id);
+                    navigator.push('unit', { id: unit.id, query: '?map=true' });
                   }
                 }}
               >


### PR DESCRIPTION
* Add show on map button to mobile unit view
* Add top bar to map (is either search bar or title bar depending on page)
* Modify mobile bottom navigation so that the correct page is highlighted when coming back to homepage using back-button.
* Add new variable fullMobileMap to defaultLayout styling. If fullMobileMap is true, use styling for map view without bottom navigation and search-bar