### PR TITLE
Navigation impovements

### DIFF
--- a/src/components/TitleBar/TitleBar.js
+++ b/src/components/TitleBar/TitleBar.js
@@ -43,12 +43,13 @@ const styles = theme => ({
 });
 
 const TitleBar = ({
-  classes, title, titleComponent, icon,
+  classes, title, titleComponent, icon, backButtonEvent,
 }) => (
   <>
     <MobileComponent>
       <div className={classes.mobileContainer}>
         <BackButton
+          onClick={backButtonEvent}
           className={classes.iconButton}
           variant="icon"
         />
@@ -91,10 +92,12 @@ TitleBar.propTypes = {
   title: PropTypes.string.isRequired,
   titleComponent: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']),
   icon: PropTypes.objectOf(PropTypes.any),
+  backButtonEvent: PropTypes.func,
 };
 
 TitleBar.defaultProps = {
   titleComponent: 'h3',
   icon: null,
+  backButtonEvent: null,
 };
 export default withStyles(styles)(TitleBar);

--- a/src/views/AddressView/AddressView.js
+++ b/src/views/AddressView/AddressView.js
@@ -194,13 +194,38 @@ class AddressView extends React.Component {
     }
   }
 
+  renderTitleContent = (title) => {
+    const {
+      intl, breadcrumb, match, navigator,
+    } = this.props;
+    const { error } = this.state;
+
+    let backButtonEvent = null;
+    /* If breadcrumb history has only pages within this address,
+    push straight to home instead of normal back functionality */
+    if (!breadcrumb.filter(page => page.pathname.indexOf(match.url) === -1).length) {
+      backButtonEvent = () => {
+        if (navigator) {
+          navigator.push('home');
+        }
+      };
+    }
+
+    return (
+      <>
+        <DesktopComponent>
+          <SearchBar backButtonEvent={backButtonEvent} placeholder={intl.formatMessage({ id: 'search' })} />
+        </DesktopComponent>
+        <TitleBar backButtonEvent={backButtonEvent} icon={<AddressIcon />} title={error || title} />
+      </>
+    );
+  }
+
   render() {
     const {
       match, intl, getLocaleText, map, classes, mobile,
     } = this.props;
-    const {
-      addressData, districts, units, error,
-    } = this.state;
+    const { addressData, districts, units } = this.state;
 
     if (units) {
       units.forEach((unit) => {
@@ -219,19 +244,10 @@ class AddressView extends React.Component {
       </HeadModifier>
     );
 
-    const TopBar = (
-      <div>
-        <DesktopComponent>
-          <SearchBar placeholder={intl.formatMessage({ id: 'search' })} />
-        </DesktopComponent>
-        <TitleBar icon={<AddressIcon />} title={error || title} />
-      </div>
-    );
-
     return (
       <div>
         {head}
-        {TopBar}
+        {this.renderTitleContent(title)}
         {districts && Object.entries(districts).map(districtList => (
           districtList[1].length > 0 && (
             <TitledList title={intl.formatMessage({ id: `address.list.${districtList[0]}` })} titleComponent="h4" key={districtList[0]}>
@@ -303,6 +319,7 @@ AddressView.propTypes = {
   mobile: PropTypes.bool.isRequired,
   addressState: PropTypes.objectOf(PropTypes.any),
   classes: PropTypes.objectOf(PropTypes.any).isRequired,
+  breadcrumb: PropTypes.objectOf(PropTypes.any).isRequired,
 };
 
 AddressView.defaultProps = {

--- a/src/views/AddressView/index.js
+++ b/src/views/AddressView/index.js
@@ -12,7 +12,7 @@ const mapStateToProps = (state) => {
   const map = state.mapRef.leafletElement;
   const getLocaleText = textObject => getLocaleString(state, textObject);
   const highlightedDistrict = state.districts.highlitedDistrict;
-  const { navigator } = state;
+  const { navigator, breadcrumb } = state;
   const addressState = state.address;
   const { mobile } = state.user;
   return {
@@ -20,6 +20,7 @@ const mapStateToProps = (state) => {
     getLocaleText,
     highlightedDistrict,
     navigator,
+    breadcrumb,
     addressState,
     mobile,
   };

--- a/src/views/EventDetailView/EventDetailView.js
+++ b/src/views/EventDetailView/EventDetailView.js
@@ -75,6 +75,18 @@ class EventDetailView extends React.Component {
     return time;
   }
 
+  renderTitleContent = () => {
+    const { event, intl, getLocaleText } = this.props;
+    return (
+      <>
+        <DesktopComponent>
+          <SearchBar placeholder={intl.formatMessage({ id: 'search' })} />
+        </DesktopComponent>
+        <TitleBar title={getLocaleText(event.name)} icon={<Event />} />
+      </>
+    );
+  }
+
   render() {
     const {
       event, intl, getLocaleText, selectedUnit,
@@ -89,11 +101,7 @@ class EventDetailView extends React.Component {
       const time = this.formatDate(event);
       return (
         <>
-          <DesktopComponent>
-            <SearchBar placeholder={intl.formatMessage({ id: 'search' })} />
-          </DesktopComponent>
-          <TitleBar title={getLocaleText(event.name)} icon={<Event />} />
-
+          {this.renderTitleContent()}
           {event.images && (
           <img
             style={{

--- a/src/views/UnitView/UnitFullListView.js
+++ b/src/views/UnitView/UnitFullListView.js
@@ -82,22 +82,38 @@ class UnitFullListView extends React.Component {
     }
   }
 
+  renderTopBar = () => {
+    const {
+      getLocaleText, intl, unit, breadcrumb, navigator,
+    } = this.props;
+    const { icon } = this.state;
+
+    let backButtonEvent = null;
+
+    if (!breadcrumb.length) {
+      backButtonEvent = () => {
+        if (navigator) {
+          navigator.push('unit', { id: unit.id });
+        }
+      };
+    }
+
+    return (
+      <>
+        <DesktopComponent>
+          <SearchBar backButtonEvent={backButtonEvent} placeholder={intl.formatMessage({ id: 'search' })} />
+        </DesktopComponent>
+        <TitleBar backButtonEvent={backButtonEvent} icon={icon} title={getLocaleText(unit.name)} />
+      </>
+    );
+  }
+
   render() {
     const {
       getLocaleText, unit, intl, classes,
     } = this.props;
-    const { icon, titleId } = this.state;
+    const { titleId } = this.state;
 
-    const topBar = (
-      unit && (
-        <>
-          <DesktopComponent>
-            <SearchBar placeholder={intl.formatMessage({ id: 'search' })} />
-          </DesktopComponent>
-          <TitleBar icon={icon} title={getLocaleText(unit.name)} />
-        </>
-      )
-    );
     const head = titleId && (
       <HeadModifier>
         <title>
@@ -111,7 +127,7 @@ class UnitFullListView extends React.Component {
       <>
         {head}
         <div className={classes.fullListContent}>
-          {topBar}
+          {this.renderTopBar()}
           {this.getContent()}
         </div>
       </>
@@ -123,10 +139,13 @@ const mapStateToProps = (state) => {
   const getLocaleText = textObject => getLocaleString(state, textObject);
   const eventsData = state.event.data;
   const unit = state.selectedUnit.data;
+  const { breadcrumb, navigator } = state;
   return {
     getLocaleText,
     eventsData,
     unit,
+    breadcrumb,
+    navigator,
   };
 };
 
@@ -138,11 +157,14 @@ UnitFullListView.propTypes = {
   fetchUnitEvents: PropTypes.func.isRequired,
   location: PropTypes.objectOf(PropTypes.any).isRequired,
   classes: PropTypes.objectOf(PropTypes.any).isRequired,
+  breadcrumb: PropTypes.arrayOf(PropTypes.any).isRequired,
+  navigator: PropTypes.objectOf(PropTypes.any),
 };
 
 UnitFullListView.defaultProps = {
   unit: null,
   eventsData: { events: null, unit: null },
+  navigator: null,
 };
 
 export default withStyles(styles)(withRouter(injectIntl(connect(

--- a/src/views/UnitView/UnitView.js
+++ b/src/views/UnitView/UnitView.js
@@ -89,31 +89,48 @@ class UnitView extends React.Component {
     }
   }
 
+  renderTitleContent = (correctUnit) => {
+    const {
+      getLocaleText, intl, unit, breadcrumb, navigator, match,
+    } = this.props;
+    const { didMount } = this.state;
+    const title = unit && unit.name ? getLocaleText(unit.name) : '';
+    const icon = didMount && unit ? <UnitIcon unit={unit} /> : null;
+
+    let backButtonEvent = null;
+    /* If breadcrumb history has only pages within this unit,
+    push straight to home instead of normal back functionality */
+    if (!breadcrumb.filter(page => page.pathname.indexOf(match.url) === -1).length) {
+      backButtonEvent = () => {
+        if (navigator) {
+          navigator.push('home');
+        }
+      };
+    }
+    return (
+      <div>
+        <DesktopComponent>
+          <SearchBar backButtonEvent={backButtonEvent} placeholder={intl.formatMessage({ id: 'search' })} />
+        </DesktopComponent>
+        <TitleBar backButtonEvent={backButtonEvent} icon={icon} title={correctUnit ? title : ''} />
+      </div>
+    );
+  }
+
   render() {
     const {
       classes, getLocaleText, intl, unit, eventsData, navigator, match,
     } = this.props;
-    const { didMount, reservations } = this.state;
+    const { reservations } = this.state;
 
     const correctUnit = unit && unit.id === parseInt(match.params.unit, 10);
-
-    const title = unit && unit.name ? getLocaleText(unit.name) : '';
-    const icon = didMount && unit ? <UnitIcon unit={unit} /> : null;
-
-    const TopBar = (
-      <div>
-        <DesktopComponent>
-          <SearchBar placeholder={intl.formatMessage({ id: 'search' })} />
-        </DesktopComponent>
-        <TitleBar icon={icon} title={correctUnit ? title : ''} />
-      </div>
-    );
+    const titleContent = this.renderTitleContent(correctUnit);
 
     if (unit && (!correctUnit || !unit.complete)) {
       return (
         <div className={classes.root}>
           <div className="Content">
-            {TopBar}
+            {titleContent}
             <p>
               <FormattedMessage id="general.loading" />
             </p>
@@ -126,7 +143,7 @@ class UnitView extends React.Component {
       return (
         <div className={classes.root}>
           <div className="Content">
-            {TopBar}
+            {titleContent}
 
             {/* Unit image */}
             {unit.picture_url
@@ -195,7 +212,7 @@ class UnitView extends React.Component {
     return (
       <div className={classes.root}>
         <div className="Content">
-          {TopBar}
+          {titleContent}
           <Typography color="primary" variant="body1">
             <FormattedMessage id="unit.details.notFound" />
           </Typography>
@@ -212,7 +229,7 @@ const mapStateToProps = (state) => {
   const eventFetching = state.event.isFetching;
   const getLocaleText = textObject => getLocaleString(state, textObject);
   const map = state.mapRef.leafletElement;
-  const { navigator } = state;
+  const { navigator, breadcrumb } = state;
   return {
     unit,
     eventsData,
@@ -220,6 +237,7 @@ const mapStateToProps = (state) => {
     getLocaleText,
     map,
     navigator,
+    breadcrumb,
   };
 };
 
@@ -241,6 +259,7 @@ UnitView.propTypes = {
   getLocaleText: PropTypes.func.isRequired,
   intl: intlShape.isRequired,
   navigator: PropTypes.objectOf(PropTypes.any),
+  breadcrumb: PropTypes.arrayOf(PropTypes.any).isRequired,
 };
 
 UnitView.defaultProps = {


### PR DESCRIPTION
* Add new renderTitleContent function to create top content (title and/or searchbar) too pages. (Could be its own component too)
* Add new back button events to titleBar/searchBar back button:
Subpages now always take back to parent page even if not in history (for example unit's map view will take to unit's page)
