### PR TITLE
Fix/zoom only when search- or service-data changes

### DIFF
--- a/src/redux/actions/services.js
+++ b/src/redux/actions/services.js
@@ -40,7 +40,7 @@ export const fetchServiceUnits = serviceId => async (dispatch) => {
   const options = {
     service: serviceId,
     page_size: 50,
-    only: 'name,accessibility_shortcoming_count',
+    only: 'name,accessibility_shortcoming_count,location',
   };
 
   // Fetch data

--- a/src/views/SearchView/SearchView.js
+++ b/src/views/SearchView/SearchView.js
@@ -44,9 +44,8 @@ class SearchView extends React.Component {
     const searchParam = this.getSearchParam();
     if (this.shouldFetch()) {
       fetchUnits(searchParam);
+      this.focusMap(units, map);
     }
-
-    this.focusMap(units, map);
   }
 
   shouldComponentUpdate(nextProps) {

--- a/src/views/ServiceView/ServiceView.js
+++ b/src/views/ServiceView/ServiceView.js
@@ -26,7 +26,7 @@ class ServiceView extends React.Component {
 
   componentDidMount() {
     const {
-      current, match, fetchService,
+      match, fetchService,
     } = this.props;
     const { params } = match;
 
@@ -35,24 +35,31 @@ class ServiceView extends React.Component {
     });
 
     // Fetch service if current is not same as url param's
-    if (!current || `${current.id}` !== params.service) {
+    if (this.shouldFetch()) {
       fetchService(params.service);
     }
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(nextProps) {
     const {
-      current, unitData, match, map,
+      unitData,
     } = this.props;
-    const { params } = match;
     // Focus map if service is set and units exist
-    if (current && `${current.id}` === params.service && unitData && unitData.length > 0) {
+    if (unitData.length > 0 && unitData !== nextProps.unitData) {
       // Focus map on unit
-      this.focusMap(unitData, map);
+      this.focusMap(unitData);
     }
   }
 
-  focusMap = (unit, map) => {
+  // Check if view will fetch data because search params has changed
+  shouldFetch = () => {
+    const { current, isLoading, match } = this.props;
+    const { params } = match;
+    return !isLoading && (!current || `${current.id}` !== params.service);
+  }
+
+  focusMap = (unit) => {
+    const { map } = this.props;
     const { mapMoved } = this.state;
     if (unit && map && map._layersMaxZoom && !mapMoved) {
       this.setState({ mapMoved: true });


### PR DESCRIPTION
Zoom to berries only when new search or service data is fetched.