### PR TITLE
Swap snackbar close button stylings with settings close button

### DIFF
--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -14,7 +14,9 @@ import {
   Radio,
   FormLabel,
   FormControl,
+  IconButton,
 } from '@material-ui/core';
+import { Close } from '@material-ui/icons';
 import isClient, { AddEventListener } from '../../utils';
 import SettingsUtility from '../../utils/settings';
 import Container from '../Container';
@@ -518,17 +520,15 @@ class Settings extends React.Component {
     return (
       <Container aria-hidden="true" className={containerClasses} paper>
         <Typography color="inherit" className={typographyClasses}><FormattedMessage id="general.save.changes.done" /></Typography>
-        <Button
+        <IconButton
           aria-label={intl.formatMessage({ id: 'general.closeSettings' })}
           className={buttonClasses}
-          color="primary"
           onClick={() => {
             this.setAlert(false);
           }}
-          variant="text"
         >
-          <FormattedMessage id="general.close" />
-        </Button>
+          <Close />
+        </IconButton>
       </Container>
     );
   }

--- a/src/components/Settings/SettingsTitle.js
+++ b/src/components/Settings/SettingsTitle.js
@@ -3,9 +3,8 @@ import PropTypes from 'prop-types';
 import { FormattedMessage, intlShape } from 'react-intl';
 import {
   Typography,
-  IconButton,
+  Button,
 } from '@material-ui/core';
-import { Close } from '@material-ui/icons';
 import Container from '../Container';
 
 const SettingsTitle = ({
@@ -15,15 +14,17 @@ const SettingsTitle = ({
     {
       close
       && (
-        <IconButton
+        <Button
           aria-label={intl.formatMessage({ id: 'general.closeSettings' })}
-          className={classes.closeButton}
+          className={`${classes.flexBase}`}
+          color="primary"
           onClick={() => {
             close();
           }}
+          variant="text"
         >
-          <Close />
-        </IconButton>
+          <FormattedMessage id="general.close" />
+        </Button>
       )
     }
     <Typography className={classes.titleText} component="h3" variant="caption" align="left" {...typography}>


### PR DESCRIPTION
Swapped Close-button and close icon placements in Settings view to help differentiate which closes the actual settings view.