### PR TITLE
Add aria label text for map element

### DIFF
--- a/src/i18n/translations/en.js
+++ b/src/i18n/translations/en.js
@@ -111,6 +111,7 @@ export default {
 
   // Map
   'map': 'Map',
+  'map.ariaLabel': 'Map. Currently map information is only accessible visually.', // TODO: verify
   'map.transit.endStation': 'Terminus',
   'map.address.searching': 'Retreiving address...',
   'map.address.info': 'Address information',

--- a/src/i18n/translations/fi.js
+++ b/src/i18n/translations/fi.js
@@ -110,6 +110,7 @@ export default {
 
   // Map
   'map': 'Kartta',
+  'map.ariaLabel': 'Karttanäkymä. Kartan tietoja voi tarkastella tällä hetkellä vain näönvaraisesti.',
   'map.transit.endStation': 'Päätepysäkki',
   'map.address.searching': 'Haetaan osoitetta...',
   'map.address.info': 'Osoitteen tiedot',

--- a/src/i18n/translations/sv.js
+++ b/src/i18n/translations/sv.js
@@ -109,6 +109,7 @@ export default {
 
   // Map
   'map': 'Map', // TODO: Translate
+  'map.ariaLabel': 'Karttanäkymä. Kartan tietoja voi tarkastella tällä hetkellä vain näönvaraisesti.', // TODO: translate
   'map.transit.endStation': 'Ändhållplats',
   'map.address.searching': 'Söker adress...',
   'map.address.info': 'Osoitteen tiedot', // TODO: Translate

--- a/src/layouts/DefaultLayout.js
+++ b/src/layouts/DefaultLayout.js
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
 import { unstable_useMediaQuery as useMediaQuery } from '@material-ui/core/useMediaQuery';
 import Sidebar from '../views/Sidebar';
 import MapView from '../views/MapView';
@@ -72,7 +72,7 @@ const createContentStyles = (
 
 const DefaultLayout = (props) => {
   const {
-    i18n, location, settingsToggled, toggleSettings,
+    i18n, intl, location, settingsToggled, toggleSettings,
   } = props;
   const isMobile = useMediaQuery(`(max-width:${mobileBreakpoint}px)`);
   const isSmallScreen = useMediaQuery(`(max-width:${smallScreenBreakpoint}px)`);
@@ -97,8 +97,10 @@ const DefaultLayout = (props) => {
             <Sidebar />
           )}
         </main>
-        <div aria-hidden style={styles.map}>
-          <MapView isMobile={!!isMobile} />
+        <div aria-label={intl.formatMessage({ id: 'map.ariaLabel' })} tabIndex="-1" style={styles.map}>
+          <div aria-hidden="true" style={styles.map}>
+            <MapView isMobile={!!isMobile} />
+          </div>
         </div>
       </div>
 
@@ -116,6 +118,7 @@ const DefaultLayout = (props) => {
 // Typechecking
 DefaultLayout.propTypes = {
   i18n: PropTypes.instanceOf(I18n),
+  intl: intlShape.isRequired,
   location: PropTypes.objectOf(PropTypes.any).isRequired,
   settingsToggled: PropTypes.bool.isRequired,
   toggleSettings: PropTypes.func.isRequired,
@@ -125,4 +128,4 @@ DefaultLayout.defaultProps = {
   i18n: null,
 };
 
-export default DefaultLayout;
+export default injectIntl(DefaultLayout);

--- a/src/layouts/EmbedLayout.js
+++ b/src/layouts/EmbedLayout.js
@@ -3,6 +3,7 @@ import React from 'react';
 import {
   Switch, Route,
 } from 'react-router-dom';
+import { injectIntl, intlShape } from 'react-intl';
 import MapView from '../views/MapView';
 import PageHandler from '../views/components/PageHandler';
 import UnitFetcher from '../components/DataFetchers/UnitFetcher';
@@ -45,7 +46,7 @@ const createContentStyles = (
   return styles;
 };
 
-const EmbedLayout = () => {
+const EmbedLayout = ({ intl }) => {
   const styles = createContentStyles();
 
   return (
@@ -73,12 +74,18 @@ const EmbedLayout = () => {
             />
           </Switch>
         </div>
-        <div aria-hidden style={styles.map}>
-          <MapView />
+        <div aria-label={intl.formatMessage({ id: 'map.ariaLabel' })} tabIndex="-1" style={styles.map}>
+          <div aria-hidden="true" style={styles.map}>
+            <MapView />
+          </div>
         </div>
       </div>
     </>
   );
 };
 
-export default EmbedLayout;
+EmbedLayout.propTypes = {
+  intl: intlShape.isRequired,
+};
+
+export default injectIntl(EmbedLayout);


### PR DESCRIPTION
Adding aria-label to map wrapper to inform user that map exists. This way map settings in settings page are not as confusing for screen reader users.