### PR TITLE
Feature/new top bar

### DIFF
--- a/browserTests/browserTest.js
+++ b/browserTests/browserTest.js
@@ -19,7 +19,7 @@ const getLocation = ClientFunction(() => document.location.href);
 const testFinnish = async (t) => {
   const languageButtons = ReactSelector('Button');
   const title = Selector('.app-title').textContent;
-  const text = await languageButtons.nth(0).innerText.then(s => s.toLocaleLowerCase());
+  const text = await languageButtons.nth(1).innerText.then(s => s.toLocaleLowerCase());
 
   await t
     .expect(getLocation()).contains(`http://${server.address}:${server.port}/en`)
@@ -27,20 +27,20 @@ const testFinnish = async (t) => {
     .expect(text).contains('suomi')
     
     
-    .click(languageButtons.nth(0))
+    .click(languageButtons.nth(1))
     .navigateTo(`http://${server.address}:${server.port}/fi`);
 };
 
 test('Language does change', async (t) => {
-  const languageButtons = ReactSelector('Button');
+  const languageButtons = ReactSelector('ButtonBase');
   const title = Selector('.app-title').textContent;
-  const text = await languageButtons.nth(0).innerText.then(s => s.toLocaleLowerCase());
+  const text = await languageButtons.nth(2).innerText.then(s => s.toLocaleLowerCase());
 
   await t
     .expect(getLocation()).contains(`http://${server.address}:${server.port}/fi`)
     .expect(title).eql('Palvelukartta')
-    .expect(text).contains('english')    
-    .click(languageButtons.nth(0))
+    .expect(text).contains('in english')    
+    .click(languageButtons.nth(2))
     .navigateTo(`http://${server.address}:${server.port}/en`);
 
   testFinnish(t);

--- a/config/default.js
+++ b/config/default.js
@@ -23,7 +23,8 @@ export default {
   "mobileUiBreakpoint": 699,
   "productionPrefix": process.env.PRODUCTION_PREFIX,
   "smallScreenBreakpoint": 899,
-  "topBarHeight": 64,
+  "topBarHeight": 98,
+  "topBarHeightMobile": 88,
   // locales
   "defaultLocale": 'fi',
   "streetAddressLanguages": ["fi", "sv"],

--- a/src/components/Logos/HomeLogo/index.js
+++ b/src/components/Logos/HomeLogo/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core';
 import logoLight from '../../../assets/images/service-map-logo-nega-fi_TEST.svg';
 import logoDark from '../../../assets/images/service-map-logo-fi_TEST.svg';
-import logoMobile from '../../../assets/images/service-map-logo-nega-mobile.svg';
+// import logoMobile from '../../../assets/images/service-map-logo-nega-mobile.svg';
 import styles from './styles';
 
 const HomeLogo = (props) => {
@@ -13,7 +13,7 @@ const HomeLogo = (props) => {
   if (mobile) {
     return (
       <div role="img" {...rest}>
-        <img src={logoMobile} alt="" className={classes.iconMobile} />
+        <img src={logoDark} alt="" className={classes.iconMobile} />
       </div>
     );
   }

--- a/src/components/Logos/HomeLogo/styles.js
+++ b/src/components/Logos/HomeLogo/styles.js
@@ -8,6 +8,6 @@ export default () => ({
     height: 45,
   },
   iconMobile: {
-    height: 45,
+    height: 40,
   },
 });

--- a/src/components/TabLists/TabLists.js
+++ b/src/components/TabLists/TabLists.js
@@ -209,6 +209,8 @@ class TabLists extends React.Component {
     if (!this.tabsRef) {
       return;
     }
+    const { mobile } = this.state;
+    const appBarHeight = mobile ? config.topBarHeightMobile : config.topBarHeight;
 
     // Reset scroll to avoid scrolled sticky  elements having inconsistent offsetTop
     const elem = document.getElementsByClassName(this.sidebarClass)[0];
@@ -242,7 +244,7 @@ class TabLists extends React.Component {
       // Set new styles and scrollDistance value to state
       this.setState({
         styles: {
-          top: stickyElementPadding,
+          top: Math.max(appBarHeight, stickyElementPadding),
         },
         tabStyles: {
           minHeight: customTabHeight,

--- a/src/components/TopBar/TopBar.js
+++ b/src/components/TopBar/TopBar.js
@@ -104,9 +104,9 @@ class TopBar extends React.Component {
                   <FormattedMessage id="general.frontPage" />
                 </Typography>
               </ButtonBase>
-              <Typography color="inherit">|</Typography>
+              <Typography aria-hidden color="inherit">|</Typography>
               {this.renderLanguages()}
-              <Typography color="inherit">|</Typography>
+              <Typography aria-hidden color="inherit">|</Typography>
               {/* Contrast button implementation
                 <ButtonBase role="link" onClick={() => console.log('change contrast')}>
                   <Typography color="inherit">Kontrasti</Typography>

--- a/src/components/TopBar/TopBar.js
+++ b/src/components/TopBar/TopBar.js
@@ -18,7 +18,7 @@ class TopBar extends React.Component {
     const mapPage = location.pathname.indexOf('/map') > -1;
     return (
       <Button
-        className={classes.toolbarButton}
+        className={mapPage ? classes.toolbarButtonPressed : classes.toolbarButton}
         classes={{ label: classes.buttonLabel }}
         onClick={(e) => {
           e.preventDefault();

--- a/src/components/TopBar/TopBar.js
+++ b/src/components/TopBar/TopBar.js
@@ -1,157 +1,70 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  Button, Typography, AppBar, Toolbar,
+  Button, Typography, AppBar, Toolbar, ButtonBase,
 } from '@material-ui/core';
-import { Map, AccessibilityNew } from '@material-ui/icons';
+import { Map, Menu } from '@material-ui/icons';
 import { FormattedMessage } from 'react-intl';
 import I18n from '../../i18n';
-import { generatePath } from '../../utils/path';
 import HomeLogo from '../Logos/HomeLogo';
 import { DesktopComponent, MobileComponent } from '../../layouts/WrapperComponents/WrapperComponents';
 
 
 class TopBar extends React.Component {
-  renderSettingsButton = () => {
-    const { settingsOpen, toggleSettings, classes } = this.props;
-    const combinedClassName = `${classes.button}${settingsOpen ? ` ${classes.buttonSettings}` : ''}`;
+  renderMapButton = () => {
+    const {
+      classes, navigator, location, settingsOpen, toggleSettings,
+    } = this.props;
+    const mapPage = location.pathname.indexOf('/map') > -1;
     return (
       <Button
-        id="SettingsButton"
-        aria-pressed={settingsOpen}
-        className={combinedClassName}
+        className={classes.toolbarButton}
         classes={{ label: classes.buttonLabel }}
-        color="inherit"
         onClick={(e) => {
           e.preventDefault();
-          toggleSettings();
-
-          setTimeout(() => {
-            const button = document.getElementById('SettingsButton');
-            const settings = document.getElementsByClassName('SettingsContent')[0];
-            if (settings) {
-              // Focus on settings title
-              settings.firstChild.focus();
-            } else {
-              button.focus();
-            }
-          }, 1);
+          if (settingsOpen) {
+            toggleSettings();
+            navigator.push('map');
+          } else if (mapPage) {
+            navigator.goBack('home');
+          } else {
+            navigator.push('map');
+          }
         }}
       >
-        <AccessibilityNew className={classes.buttonSettingsIcon} />
+        <Map />
         <Typography color="inherit" variant="body2">
-          <FormattedMessage id="settings" />
+          <FormattedMessage id="map" />
         </Typography>
       </Button>
     );
   }
 
-  renderDesktopBar = () => {
-    const { classes, match, topNav } = this.props;
-    const { params } = match;
-    const lng = params && params.lng;
-
+  renderMenuButton = () => {
+    const { classes } = this.props;
     return (
-      <AppBar className={classes.desktopNav}>
-        <Toolbar className={classes.toolbar}>
-          <div style={topNav} className={classes.topNavLeft}>
-            <div className={classes.logoContainer}>
-              {/* Jump link to main content for screenreaders
-                  Must be first interactable element on page */}
-              <a id="site-title" href="#view-title" className="sr-only">
-                <Typography variant="srOnly">
-                  <FormattedMessage id="general.skipToContent" />
-                </Typography>
-              </a>
-
-              {/* Home logo link to home view */}
-              <a href={generatePath('home', lng)} className={`focus-dark-background ${classes.logoHomeLink}`}>
-                <HomeLogo aria-hidden="true" className={classes.logo} />
-                <Typography className="sr-only app-title" color="inherit" component="h1" variant="body1">
-                  <FormattedMessage id="app.title" />
-                </Typography>
-              </a>
-            </div>
-            {this.renderLanguages()}
-            {this.renderSettingsButton()}
-
-          </div>
-          <div className={classes.topNavRight}>
-            <a href="https://forms.gle/roe9XNrZGQWBhMBJ7" rel="noopener noreferrer" target="_blank" className={classes.feedbackLink}>
-              <p className={classes.feedbackText}>
-                <FormattedMessage id="general.give.feedback" />
-              </p>
-            </a>
-          </div>
-        </Toolbar>
-      </AppBar>
+      <Button
+        className={classes.toolbarButton}
+        classes={{ label: classes.buttonLabel }}
+      >
+        <Menu />
+        <Typography color="inherit" variant="body2">
+          <FormattedMessage id="general.menu" />
+        </Typography>
+      </Button>
     );
-  };
-
-  renderMobileBar = () => {
-    const {
-      classes, location, navigator, settingsOpen, toggleSettings,
-    } = this.props;
-    const mapPage = location.pathname.indexOf('/map') > -1;
-    const mapButtonClass = `${classes.button} ${mapPage && !settingsOpen ? classes.buttonMap : ''}`;
-
-    if (location.pathname.length < 5 || location.pathname.indexOf('/map') > -1) {
-      return (
-        <AppBar className={classes.mobileNav}>
-          <Toolbar className={classes.toolbar}>
-
-            <div className={classes.topNavLeftMobile}>
-              {/* TODO: remove this inline style once we get the correct icon */}
-              <div className={classes.homeLogoContainer}>
-                <HomeLogo mobile aria-hidden="true" className={classes.logo} />
-              </div>
-              {this.renderLanguages()}
-            </div>
-
-            <div className={classes.topNavRightMobile}>
-              {this.renderSettingsButton()}
-              {/* Map button */}
-              <Button
-                className={mapButtonClass}
-                classes={{ label: classes.buttonLabel }}
-                color="inherit"
-                onClick={(e) => {
-                  e.preventDefault();
-                  if (settingsOpen) {
-                    toggleSettings();
-                    navigator.push('map');
-                  } else if (mapPage) {
-                    navigator.push('home');
-                  } else {
-                    navigator.push('map');
-                  }
-                }}
-              >
-                <Map />
-                <Typography color="inherit" variant="body2">
-                  <FormattedMessage id="map" />
-                </Typography>
-              </Button>
-            </div>
-
-          </Toolbar>
-        </AppBar>
-      );
-    } return (null);
-  };
+  }
 
   renderLanguages = () => {
     const { classes, i18n, location } = this.props;
     return (
-      <div className={classes.languages}>
+      <>
         {i18n.availableLocales
-          .filter(locale => locale !== i18n.locale)
           .map(locale => (
-            <Button
+            <ButtonBase
               role="link"
+              className={locale !== i18n.locale ? classes.greyText : ''}
               key={locale}
-              color="inherit"
-              variant="text"
               onClick={() => {
                 const newLocation = location;
                 const newPath = location.pathname.replace(/^\/[a-zA-Z]{2}\//, `/${locale}/`);
@@ -159,26 +72,79 @@ class TopBar extends React.Component {
                 window.location = `${newLocation.pathname}${newLocation.search}`;
               }}
             >
-              <Typography color="inherit" variant="body2" className={classes.noTextTransform}>
+              <Typography color="inherit">
                 {i18n.localeText(locale)}
               </Typography>
-            </Button>
+            </ButtonBase>
           ))}
-      </div>
+      </>
     );
   }
+
+  navigateHome = () => {
+    const { currentPage, navigator } = this.props;
+    if (currentPage !== 'home') {
+      navigator.push('home');
+    } else {
+      document.getElementById('view-title').focus();
+    }
+  }
+
+  renderTopBar = (type) => {
+    const { classes } = this.props;
+
+    return (
+      <>
+        <AppBar>
+          {/* Toolbar black area */}
+          <Toolbar className={classes.toolbarBlack}>
+            <div className={classes.toolbarBlackContainer}>
+              <ButtonBase role="link" onClick={() => this.navigateHome()}>
+                <Typography color="inherit">
+                  <FormattedMessage id="general.frontPage" />
+                </Typography>
+              </ButtonBase>
+              <Typography color="inherit">|</Typography>
+              {this.renderLanguages()}
+              <Typography color="inherit">|</Typography>
+              {/* Contrast button implementation
+                <ButtonBase role="link" onClick={() => console.log('change contrast')}>
+                  <Typography color="inherit">Kontrasti</Typography>
+                </ButtonBase> */}
+            </div>
+          </Toolbar>
+
+          {/* Toolbar white area */}
+          <Toolbar className={type === 'mobile' ? classes.toolbarWhiteMobile : classes.toolbarWhite}>
+            <div className={classes.homeLogoContainer}>
+              <HomeLogo mobile={type === 'mobile'} dark aria-hidden="true" className={classes.logo} />
+            </div>
+            <MobileComponent>
+              <div className={classes.mobileButtonContainer}>
+                {this.renderMapButton()}
+                {/* {this.renderMenuButton()} */}
+              </div>
+            </MobileComponent>
+          </Toolbar>
+        </AppBar>
+        {/* This empty toolbar fixes the issue where App bar hides the top page content */}
+        <Toolbar className={type === 'mobile' ? classes.alignerMobile : classes.aligner} />
+      </>
+    );
+  }
+
 
   render() {
     return (
       <>
         <MobileComponent>
           <>
-            {this.renderMobileBar()}
+            {this.renderTopBar('mobile')}
           </>
         </MobileComponent>
         <DesktopComponent>
           <>
-            {this.renderDesktopBar()}
+            {this.renderTopBar('desktop')}
           </>
         </DesktopComponent>
       </>
@@ -190,11 +156,10 @@ TopBar.propTypes = {
   i18n: PropTypes.instanceOf(I18n),
   classes: PropTypes.objectOf(PropTypes.any).isRequired,
   location: PropTypes.objectOf(PropTypes.any).isRequired,
-  match: PropTypes.objectOf(PropTypes.any).isRequired,
   navigator: PropTypes.objectOf(PropTypes.any),
-  topNav: PropTypes.objectOf(PropTypes.any).isRequired,
   settingsOpen: PropTypes.bool,
   toggleSettings: PropTypes.func.isRequired,
+  currentPage: PropTypes.string.isRequired,
 };
 
 TopBar.defaultProps = {

--- a/src/components/TopBar/index.js
+++ b/src/components/TopBar/index.js
@@ -7,9 +7,10 @@ import TopBar from './TopBar';
 
 // Listen to redux state
 const mapStateToProps = (state) => {
-  const { navigator } = state;
+  const { navigator, user } = state;
   return {
     navigator,
+    currentPage: user.page,
   };
 };
 

--- a/src/components/TopBar/styles.js
+++ b/src/components/TopBar/styles.js
@@ -1,91 +1,70 @@
 import config from '../../../config';
 
-const { topBarHeight } = config;
+const { topBarHeight, topBarHeightMobile } = config;
 
 const styles = () => ({
-  button: {
-    textTransform: 'none',
-    paddingRight: 16,
-    paddingLeft: 16,
-  },
   buttonLabel: {
     display: 'flex',
     flexDirection: 'column',
   },
-  buttonSettings: {
-    backgroundColor: '#4e67d2',
-  },
-  buttonSettingsIcon: {
-    marginRight: 8,
-  },
-  buttonMap: {
-    backgroundColor: '#4e67d2',
-  },
-  desktopNav: {
-    position: 'relative',
-    height: topBarHeight,
-  },
-  feedbackLink: {
-    display: 'inline-block',
-  },
-  feedbackText: {
-    margin: 0,
-    color: 'white',
-    textDecorationColor: 'white',
-  },
+  // feedbackLink: {
+  //   display: 'inline-block',
+  // },
+  // feedbackText: {
+  //   margin: 0,
+  //   color: 'white',
+  //   textDecorationColor: 'white',
+  // },
   homeLogoContainer: {
     paddingTop: 8,
     alignSelf: 'center',
   },
-  languages: {
-    flex: '0 0 auto',
-    display: 'flex',
-  },
   logo: {
-    marginLeft: 8,
+    marginLeft: 4,
+    marginRight: 16,
   },
-  logoContainer: {
-    flex: '1 0 auto',
-    display: 'flex',
-  },
-  logoHomeLink: {
-    alignSelf: 'center',
-  },
-  noTextTransform: {
-    textTransform: 'none',
-  },
-  mobileNav: {
-    position: 'sticky',
-    height: topBarHeight,
-    top: 0,
-    zIndex: 999999999,
-    backgroundColor: '#2242C7',
-  },
-  toolbar: {
+  toolbarBlack: {
+    minHeight: 28,
+    height: 28,
+    backgroundColor: '#141823',
     padding: 0,
-    display: 'flex',
+    paddingLeft: 8,
+  },
+  toolbarBlackContainer: {
     justifyContent: 'space-around',
-  },
-  topNavLeft: {
     display: 'flex',
-    height: topBarHeight,
-    justifyContent: 'space-between',
+    width: 450,
+    color: '#fff',
   },
-  topNavLeftMobile: {
-    display: 'flex',
-    height: topBarHeight,
-    justifyContent: 'flex-start',
-    width: '60%',
-    marginLeft: 8,
+  greyText: {
+    color: '#CCCBCB',
   },
-  topNavRight: {
-    flex: '1 1 auto',
+  toolbarWhite: {
+    height: 70,
+    backgroundColor: '#fff',
   },
-  topNavRightMobile: {
-    display: 'flex',
+  toolbarWhiteMobile: {
+    minHeight: 60,
+    height: 60,
+    backgroundColor: '#fff',
+  },
+  buttonPressed: {
+    backgroundColor: '#e6e6e6',
+  },
+  toolbarButton: {
+    textTransform: 'none',
+    color: '#000',
+    marginLeft: 4,
+    marginRight: 4,
+  },
+  mobileButtonContainer: {
+    marginLeft: 'auto',
+  },
+  aligner: {
     height: topBarHeight,
-    justifyContent: 'flex-end',
-    width: '40%',
+  },
+  alignerMobile: {
+    height: topBarHeightMobile,
   },
 });
 

--- a/src/components/TopBar/styles.js
+++ b/src/components/TopBar/styles.js
@@ -47,9 +47,18 @@ const styles = () => ({
     minHeight: 60,
     height: 60,
     backgroundColor: '#fff',
+    paddingRight: 0,
   },
-  buttonPressed: {
-    backgroundColor: '#e6e6e6',
+  toolbarButtonPressed: {
+    textTransform: 'none',
+    backgroundColor: '#353638',
+    color: '#fff',
+    marginLeft: 4,
+    marginRight: 4,
+    borderRadius: 0,
+    '&:hover': {
+      backgroundColor: '#353638',
+    },
   },
   toolbarButton: {
     textTransform: 'none',

--- a/src/components/TopBar/styles.js
+++ b/src/components/TopBar/styles.js
@@ -65,6 +65,7 @@ const styles = () => ({
     color: '#000',
     marginLeft: 4,
     marginRight: 4,
+    borderRadius: 0,
   },
   mobileButtonContainer: {
     marginLeft: 'auto',

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -9,10 +9,10 @@ import messagesEn from './translations/en';
 
 // Translation messages for React Intl
 export const messages = {
-  fi: { text: 'Suomi', messages: messagesFi },
-  en: { text: 'English', messages: messagesEn },
+  fi: { text: 'Suomeksi', messages: messagesFi },
+  en: { text: 'In English', messages: messagesEn },
   // TODO: Add swedish language back once translations are done
-  // sv: { text: 'Svenska', messages: messagesSv },
+  // sv: { text: 'På svenska', messages: messagesSv },
 };
 
 // Mutable class keys

--- a/src/i18n/translations/en.js
+++ b/src/i18n/translations/en.js
@@ -55,6 +55,8 @@ export default {
   'sorting.match.desc': 'Relevance',
 
   // General
+  'general.frontPage': 'Front page',
+  'general.menu': 'Menu',
   'general.back': 'Back',
   'general.back.address': 'Back to address view',
   'general.back.home': 'Back to home view',

--- a/src/i18n/translations/fi.js
+++ b/src/i18n/translations/fi.js
@@ -54,6 +54,8 @@ export default {
   'sorting.match.desc': 'Osuvin ensin',
 
   // General
+  'general.frontPage': 'Etusivu',
+  'general.menu': 'Valikko',
   'general.back': 'Palaa',
   'general.back.address': 'Palaa osoitenäkymään',
   'general.back.home': 'Palaa aloitusnäkymään',

--- a/src/i18n/translations/sv.js
+++ b/src/i18n/translations/sv.js
@@ -54,6 +54,8 @@ export default {
   'sorting.match.desc': 'Osuvin ensin', // TODO: Translate
 
   // General
+  'general.frontPage': 'Etusivu', // TODO: Translate
+  'general.menu': 'Valikko', // TODO: Translate
   'general.back': 'Tillbaka',
   'general.back.address': 'Back to address view', // TODO: Translate
   'general.back.home': 'Back to home view', // TODO: Translate

--- a/src/layouts/DefaultLayout.js
+++ b/src/layouts/DefaultLayout.js
@@ -23,7 +23,7 @@ const createContentStyles = (
   } else if (isSmallScreen) {
     width = '50%';
   }
-  const topBarHeight = `${config.topBarHeight}px`;
+  const topBarHeight = isMobile ? `${config.topBarHeightMobile}px` : `${config.topBarHeight}px`;
 
   const styles = {
     activeRoot: {
@@ -53,9 +53,6 @@ const createContentStyles = (
       margin: 0,
       overflow: !isMobile ? 'auto' : '',
       visibility: mobileMapOnly && !settingsOpen ? 'hidden' : null,
-    },
-    topNav: {
-      minWidth: width,
     },
   };
 
@@ -88,7 +85,15 @@ const DefaultLayout = (props) => {
 
   return (
     <>
-      <TopBar settingsOpen={settingsToggled} toggleSettings={() => toggleSettings(!settingsToggled)} topNav={styles.topNav} i18n={i18n} />
+      <h1 id="app-title" tabIndex="-1" className="sr-only app-title" component="h1">
+        <FormattedMessage id="app.title" />
+      </h1>
+      {/* Jump link to main content for screenreaders
+        Must be first interactable element on page */}
+      <a href="#view-title" className="sr-only">
+        <FormattedMessage id="general.skipToContent" />
+      </a>
+      <TopBar settingsOpen={settingsToggled} toggleSettings={type => (!type || type === settingsToggled ? toggleSettings(false) : toggleSettings(type))} i18n={i18n} />
       <div style={styles.activeRoot}>
         <main className="SidebarWrapper" style={styles.sidebar}>
           {settingsToggled ? (
@@ -106,7 +111,7 @@ const DefaultLayout = (props) => {
 
       <footer role="contentinfo" className="sr-only">
         <DesktopComponent>
-          <a href="#site-title">
+          <a href="#app-title">
             <FormattedMessage id="general.backToStart" />
           </a>
         </DesktopComponent>

--- a/src/views/components/ViewTitle/ViewTitle.js
+++ b/src/views/components/ViewTitle/ViewTitle.js
@@ -21,9 +21,9 @@ class ViewTitle extends React.Component {
     } else {
       actionSetInitialLoad();
       // Focus to site title on first load
-      const siteTitle = document.getElementById('site-title');
-      if (siteTitle) {
-        siteTitle.focus();
+      const appTitle = document.getElementById('app-title');
+      if (appTitle) {
+        appTitle.focus();
       }
     }
   }


### PR DESCRIPTION
* New design for top bar (desktop & mobile)
* Modified document structure. New order for the start of the page is: h1(sr-only) -> jump link to main (sr-only) -> Top bar 
* Front page link will no longer reload the page. It pushes to home page and focuses to view title
* Modified the tabList top calculations, so that the sticky elements won't go under the top bar 

Note: Some elements have been commented out, since their functionality has not been implemented yet. The black tool bar looks slightly unfinished because of this.