### PR TITLE
Tweak unit event sort order

### DIFF
--- a/src/utils/fetch/constants.js
+++ b/src/utils/fetch/constants.js
@@ -69,7 +69,7 @@ export const APIHandlers = {
     options: {
       type: 'event',
       start: 'today',
-      sort: 'start_time',
+      sort: 'end_time',
       include: 'location',
     },
   },


### PR DESCRIPTION
Try to promote single-occurrence events over long periodical ones.