### PR TITLE
Fix/address view separate markers

### DIFF
--- a/src/components/TabLists/TabLists.js
+++ b/src/components/TabLists/TabLists.js
@@ -8,7 +8,6 @@ import { intlShape } from 'react-intl';
 import isClient, { parseSearchParams, stringifySearchParams, AddEventListener } from '../../utils';
 import ResultList from '../Lists/ResultList';
 import PaginationComponent from './PaginationComponent';
-import { DesktopComponent, MobileComponent } from '../../layouts/WrapperComponents/WrapperComponents';
 import ResultOrderer from './ResultOrderer';
 import config from '../../../config';
 
@@ -326,6 +325,7 @@ class TabLists extends React.Component {
                       }}
                       className={classes.tab}
                       label={label}
+                      onClick={item.onClick || null}
                     />
                   );
                 }
@@ -339,6 +339,7 @@ class TabLists extends React.Component {
                       selected: classes.selected,
                     }}
                     label={`${item.title}`}
+                    onClick={item.onClick || null}
                   />
                 );
               })

--- a/src/views/AddressView/AddressView.js
+++ b/src/views/AddressView/AddressView.js
@@ -156,8 +156,8 @@ const AddressView = (props) => {
         return (
           Object.entries(districts).map(districtList => (
             districtList[1].length > 0 && (
-              <div className={classes.districtListcontainer}>
-                <TitledList title={intl.formatMessage({ id: `address.list.${districtList[0]}` })} titleComponent="h4" key={districtList[0]}>
+              <div key={districtList[0]} className={classes.districtListcontainer}>
+                <TitledList title={intl.formatMessage({ id: `address.list.${districtList[0]}` })} titleComponent="h4">
                   {districtList[1].map((district) => {
                     const title = district.name
                       ? getLocaleText(district.name) : getLocaleText(district.unit.name);

--- a/src/views/AddressView/AddressView.js
+++ b/src/views/AddressView/AddressView.js
@@ -210,6 +210,11 @@ const AddressView = (props) => {
       itemsPerPage: 10,
       title: intl.formatMessage({ id: 'address.nearby' }),
       noOrderer: true, // Remove this when we want result orderer for address unit list
+      onClick: () => {
+        if (highlightedDistrict) {
+          setHighlightedDistrict(null);
+        }
+      },
     },
     {
       ariaLabel: intl.formatMessage({ id: 'address.districts' }),

--- a/src/views/MapView/MapView.js
+++ b/src/views/MapView/MapView.js
@@ -207,13 +207,18 @@ const MapView = (props) => {
             url={mapObject.options.url}
             attribution='&copy; <a href=&quot;http://osm.org/copyright&quot;>OpenStreetMap</a> contributors'
           />
-          <UnitMarkers
-            data={getMapUnits()}
-            Marker={Marker}
-            Polyline={Polyline}
-            Tooltip={Tooltip}
-            embeded={embeded}
-          />
+          {
+            !highlightedDistrict
+            && (
+              <UnitMarkers
+                data={getMapUnits()}
+                Marker={Marker}
+                Polyline={Polyline}
+                Tooltip={Tooltip}
+                embeded={embeded}
+              />
+            )
+          }
           <Districts
             Polygon={Polygon}
             Marker={Marker}


### PR DESCRIPTION
- Don't show unit markers if highlighted districts are shown
- Hide highlighted districts on Nearby tab click
- Fix error caused by missing key in address view