### PR TITLE
Replace extra "+" symbols from serch queries

### DIFF
--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -27,7 +27,7 @@ class SearchBar extends React.Component {
     this.searchRef = React.createRef();
 
     this.state = {
-      search: initialValue || previousSearch || '',
+      search: previousSearch || initialValue || '',
       searchQuery: '',
       isActive: false,
       focusedSuggestion: null,

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -57,7 +57,9 @@ export const stringifySearchParams = (searchParams) => {
     searchParamsObject.append(key, value);
   });
 
-  return searchParamsObject.toString();
+  const string = searchParamsObject.toString().replace(/[+]/g, ' ');
+
+  return string;
 };
 
 // Keyboard handler


### PR DESCRIPTION
Fix the issue caused by search queries with multiple words. Previously it would search again when changing to next result list page.
Also prioritise previousSearch over initialValue in search bar 