### PR TITLE
Remove previous search if search is service nodes

### DIFF
--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -179,7 +179,10 @@ class SearchBar extends React.Component {
     // Style classes
     const backButtonStyles = `${classes.iconButton}`;
     const showSuggestions = isActive;
-    const inputValue = typeof search === 'string' ? search : previousSearchText;
+    let inputValue = typeof search === 'string' ? search : previousSearchText;
+    if (inputValue.includes('service_node')) {
+      inputValue = null;
+    }
     const containerStyles = `${isActive ? classes.containerSticky : classes.containerInactive} ${classes.container}`;
 
     return (


### PR DESCRIPTION
Previously, if previous search is service nodes search (search initiated from service tree), search bar would get odd previous search test.