### PR TITLE
Trust proxies so HTTP host parameters from proxies are respected

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -39,6 +39,9 @@ setupTests();
 const app = express();
 const supportedLanguages = config.supportedLanguages;
 
+// This is required for proxy setups to work in production
+app.set('trust proxy', true);
+
 // Add static folder
 app.use(express.static(path.resolve(__dirname, 'src')));
 


### PR DESCRIPTION
This setting is required for production deployments.