### PR TITLE
Feature/address utility

### DIFF
--- a/src/components/ListItems/AddressItem/AddressItem.js
+++ b/src/components/ListItems/AddressItem/AddressItem.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { uppercaseFirst } from '../../../utils';
 import SimpleListItem from '../SimpleListItem';
 import { AddressIcon } from '../../SMIcon';
+import { getAddressText } from '../../../utils/address';
 
 const AddressItem = (props) => {
   const {
@@ -10,7 +11,7 @@ const AddressItem = (props) => {
   } = props;
 
   const number = `${address.number ? address.number : ''}${address.letter ? address.letter : ''}`;
-  const text = `${getLocaleText(address.street.name)} ${number}, ${uppercaseFirst(address.street.municipality)}`;
+  const text = getAddressText(address, getLocaleText);
 
   return (
     <SimpleListItem

--- a/src/components/ListItems/AddressItem/AddressItem.js
+++ b/src/components/ListItems/AddressItem/AddressItem.js
@@ -3,14 +3,13 @@ import PropTypes from 'prop-types';
 import { uppercaseFirst } from '../../../utils';
 import SimpleListItem from '../SimpleListItem';
 import { AddressIcon } from '../../SMIcon';
-import { getAddressText } from '../../../utils/address';
+import { getAddressText, getAddressNavigatorParams } from '../../../utils/address';
 
 const AddressItem = (props) => {
   const {
     getLocaleText, navigator, address, classes, selected, className,
   } = props;
 
-  const number = `${address.number ? address.number : ''}${address.letter ? address.letter : ''}`;
   const text = getAddressText(address, getLocaleText);
 
   return (
@@ -23,11 +22,7 @@ const AddressItem = (props) => {
       handleItemClick={(e) => {
         e.preventDefault();
         if (navigator) {
-          navigator.push('address', {
-            municipality: address.street.municipality,
-            street: getLocaleText(address.street.name),
-            number: `${number}`,
-          });
+          navigator.push('address', getAddressNavigatorParams(address, getLocaleText));
         }
       }}
       role="link"

--- a/src/components/TopBar/TopBar.js
+++ b/src/components/TopBar/TopBar.js
@@ -10,6 +10,7 @@ import HomeLogo from '../Logos/HomeLogo';
 import { DesktopComponent, MobileComponent } from '../../layouts/WrapperComponents/WrapperComponents';
 import { getIcon } from '../SMIcon';
 import DrawerMenu from '../DrawerMenu';
+import { getAddressNavigatorParams } from '../../utils/address';
 
 class TopBar extends React.Component {
   state={ drawerOpen: false }
@@ -199,11 +200,7 @@ class TopBar extends React.Component {
         break;
 
       case 'address':
-        navigator.push('address', {
-          municipality: data.street.municipality,
-          street: getLocaleText(data.street.name),
-          number: data.number,
-        });
+        navigator.push('address', getAddressNavigatorParams(data, getLocaleText));
         break;
 
       case 'services':

--- a/src/utils/address.js
+++ b/src/utils/address.js
@@ -1,4 +1,35 @@
+/* eslint-disable prefer-destructuring */
 import { uppercaseFirst } from '.';
+
+export const addressMatchParamsToFetchOptions = (match) => {
+  if (!match) {
+    return null;
+  }
+  const data = {
+    municipality: `${match.params.municipality}`,
+    street: `${match.params.street}`,
+    language: match.params.lng === 'sv' ? 'sv' : 'fi',
+  };
+
+  const { number } = match.params;
+  const numberParam = number;
+
+  if (numberParam.indexOf('-') > -1) {
+    const parts = number.split('-');
+    data.number = parts[0];
+    if (parts.length === 2) {
+      if (parts[1] !== '' && !Number.isNaN(Number(parts[1]))) {
+        data.number_end = parts[1];
+      } else {
+        data.letter = parts[1];
+      }
+    }
+  } else {
+    data.number = numberParam;
+  }
+
+  return data;
+};
 
 export const getAddressNavigatorParams = (address, getLocaleText) => {
   if (!address || !address.number || !address.street.name || !address.street.municipality) {

--- a/src/utils/address.js
+++ b/src/utils/address.js
@@ -1,0 +1,15 @@
+import { uppercaseFirst } from '.';
+
+export const getAddressText = (address, getLocaleText) => {
+  if (!address || !address.number || !address.street.name || !address.street.municipality) {
+    return '';
+  }
+  if (typeof getLocaleText !== 'function') {
+    throw Error('getAddressText requires getLocaleText function');
+  }
+  const nStart = address.number;
+  const nEnd = address.number_end ? `-${address.number_end}` : '';
+  const letter = address.letter ? address.letter : '';
+  const fullNumber = `${nStart}${nEnd}${letter}`;
+  return `${getLocaleText(address.street.name)} ${fullNumber}, ${uppercaseFirst(address.street.municipality)}`;
+};

--- a/src/utils/address.js
+++ b/src/utils/address.js
@@ -1,5 +1,30 @@
 import { uppercaseFirst } from '.';
 
+export const getAddressNavigatorParams = (address, getLocaleText) => {
+  if (!address || !address.number || !address.street.name || !address.street.municipality) {
+    return null;
+  }
+  if (typeof getLocaleText !== 'function') {
+    throw Error('getAddressText requires getLocaleText function');
+  }
+
+  const nStart = address.number;
+  const nEnd = address.number_end ? `-${address.number_end}` : '';
+  const letter = address.letter ? `-${address.letter}` : '';
+  const fullNumber = `${nStart}${nEnd}${letter}`;
+  const data = {
+    municipality: address.street.municipality,
+    street: getLocaleText(address.street.name),
+    number: fullNumber,
+  };
+
+  if (address.number_end) {
+    data.number_end = address.number_end;
+  }
+
+  return data;
+};
+
 export const getAddressText = (address, getLocaleText) => {
   if (!address || !address.number || !address.street.name || !address.street.municipality) {
     return '';

--- a/src/views/AddressView/AddressView.js
+++ b/src/views/AddressView/AddressView.js
@@ -18,7 +18,7 @@ import fetchAddressData from './utils/fetchAddressData';
 import SMButton from '../../components/ServiceMapButton';
 import DistritctItem from './components/DistrictItem';
 import TabLists from '../../components/TabLists';
-import { getAddressText } from '../../utils/address';
+import { getAddressText, getAddressNavigatorParams } from '../../utils/address';
 
 
 const AddressView = (props) => {
@@ -91,9 +91,7 @@ const AddressView = (props) => {
 
           if (params.street.toLowerCase() !== getLocaleText(address.street.name).toLowerCase()) {
             navigator.replace('address', {
-              municipality: address.street.municipality,
-              street: getLocaleText(address.street.name),
-              number: `${address.number}${address.letter || ''}`,
+              ...getAddressNavigatorParams(address, getLocaleText),
               embed,
             });
             return;

--- a/src/views/AddressView/AddressView.js
+++ b/src/views/AddressView/AddressView.js
@@ -18,6 +18,7 @@ import fetchAddressData from './utils/fetchAddressData';
 import SMButton from '../../components/ServiceMapButton';
 import DistritctItem from './components/DistrictItem';
 import TabLists from '../../components/TabLists';
+import { getAddressText } from '../../utils/address';
 
 
 const AddressView = (props) => {
@@ -222,7 +223,7 @@ const AddressView = (props) => {
   }
 
   // Render component
-  const title = addressData ? `${getLocaleText(addressData.street.name)} ${addressData.number}, ${match.params.municipality}` : '';
+  const title = getAddressText(addressData, getLocaleText);
   const tabs = [
     {
       ariaLabel: intl.formatMessage({ id: 'address.nearby' }),

--- a/src/views/AddressView/AddressView.js
+++ b/src/views/AddressView/AddressView.js
@@ -18,7 +18,7 @@ import fetchAddressData from './utils/fetchAddressData';
 import SMButton from '../../components/ServiceMapButton';
 import DistritctItem from './components/DistrictItem';
 import TabLists from '../../components/TabLists';
-import { getAddressText, getAddressNavigatorParams } from '../../utils/address';
+import { getAddressText, getAddressNavigatorParams, addressMatchParamsToFetchOptions } from '../../utils/address';
 
 
 const AddressView = (props) => {
@@ -74,12 +74,7 @@ const AddressView = (props) => {
       setUnits(null);
     }
 
-    const options = match ? {
-      municipality: `${match.params.municipality}`,
-      street: `${match.params.street}`,
-      number: `${match.params.number}`,
-      language: match.params.lng === 'sv' ? 'sv' : 'fi',
-    } : {};
+    const options = match ? addressMatchParamsToFetchOptions(match) : {};
 
     fetchAddressData(options)
       .then((data) => {
@@ -95,10 +90,6 @@ const AddressView = (props) => {
               embed,
             });
             return;
-          }
-          // If address data has letters as well, combine them with address number
-          if (address.letter) {
-            address.number += address.letter;
           }
           setAddressLocation({ addressCoordinates: address.location.coordinates });
           setAddressData(address);

--- a/src/views/AddressView/utils/fetchAddressData.js
+++ b/src/views/AddressView/utils/fetchAddressData.js
@@ -28,13 +28,15 @@ const fetchAddressData = async (options) => {
     const data = response.results;
 
     if (data.length > 0) {
-      if (options.letter) {
-        data.forEach((result) => {
-          if (result.letter === options.letter) {
-            address = result;
-          }
-        });
-      } else {
+      data.forEach((result) => {
+        if (
+          result.letter === options.letter
+          || (!result.letter && !options.letter)
+        ) {
+          address = result;
+        }
+      });
+      if (!address) {
         // eslint-disable-next-line prefer-destructuring
         address = data[0];
       }

--- a/src/views/AddressView/utils/fetchAddressData.js
+++ b/src/views/AddressView/utils/fetchAddressData.js
@@ -3,30 +3,53 @@ import { addressFetch } from '../../../utils/fetch';
 
 const fetchAddressData = async (options) => {
   const data = {};
-  if (options.municipality && options.street && options.number) {
-    data.street = options.street;
-    data.municipality = options.municipality;
-    data.number = options.number;
-  } else {
+  if (!options.municipality || !options.street || !options.number) {
     return null;
+  }
+
+  data.street = options.street;
+  data.municipality = options.municipality;
+  data.number = options.number;
+  if (options.number_end) {
+    data.number_end = options.number_end;
   }
   if (options.language) {
     data.language = options.language;
   }
 
+  // Try to get address from response
+  // Handle multiple results by comparing letter 'a' 'b' etc.
+  const getAddressFromResponse = (response, options = {}) => {
+    if (!response && !response.results) {
+      return null;
+    }
+
+    let address = null;
+    const data = response.results;
+
+    if (data.length > 0) {
+      if (options.letter) {
+        data.forEach((result) => {
+          if (result.letter === options.letter) {
+            address = result;
+          }
+        });
+      } else {
+        // eslint-disable-next-line prefer-destructuring
+        address = data[0];
+      }
+    }
+
+    return address;
+  };
+
   const onSuccess = async (response) => {
     let address = null;
-    if (response.results.length === 1) {
-      // eslint-disable-next-line prefer-destructuring
-      address = response.results[0];
+    if (response.results.length > 0) {
+      address = getAddressFromResponse(response, options);
     } else {
       data.language = data.language === 'fi' ? 'sv' : 'fi';
-      address = await addressFetch(data, null, (response) => {
-        if (response.results.length === 1) {
-          return response.results[0];
-        }
-        return null;
-      });
+      address = await addressFetch(data, null, response => getAddressFromResponse(response, options));
     }
     return address;
   };

--- a/src/views/AddressView/utils/fetchAddressData.js
+++ b/src/views/AddressView/utils/fetchAddressData.js
@@ -29,9 +29,17 @@ const fetchAddressData = async (options) => {
 
     if (data.length > 0) {
       data.forEach((result) => {
-        if (
-          result.letter === options.letter
-          || (!result.letter && !options.letter)
+        if (options.number_end || options.letter) {
+          if (
+            result.letter === options.letter
+            || result.number_end === options.number_end
+          ) {
+            address = result;
+          }
+          return;
+        }
+        if ((!result.letter && !options.letter)
+          || (!result.number_end && !options.number_end)
         ) {
           address = result;
         }

--- a/src/views/HomeView/HomeView.js
+++ b/src/views/HomeView/HomeView.js
@@ -6,6 +6,7 @@ import SearchBar from '../../components/SearchBar';
 import { MobileComponent } from '../../layouts/WrapperComponents/WrapperComponents';
 import PaperButton from '../../components/PaperButton';
 import { getIcon } from '../../components/SMIcon';
+import { getAddressNavigatorParams } from '../../utils/address';
 
 class HomeView extends React.Component {
   renderNavigationOptions = () => {
@@ -29,11 +30,7 @@ class HomeView extends React.Component {
             link
             disabled={noUserLocation}
             onClick={() => {
-              navigator.push('address', {
-                municipality: userLocation.addressData.street.municipality,
-                street: getLocaleText(userLocation.addressData.street.name),
-                number: userLocation.addressData.number,
-              });
+              navigator.push('address', getAddressNavigatorParams(userLocation.addressData, getLocaleText));
             }}
             subtitle={subtitleID && <FormattedMessage id={subtitleID} />}
           />

--- a/src/views/MapView/MapView.js
+++ b/src/views/MapView/MapView.js
@@ -21,6 +21,7 @@ import AddressMarker from './components/AddressMarker';
 import { parseSearchParams } from '../../utils';
 import isClient from '../../utils';
 import swapCoordinates from './utils/swapCoordinates';
+import { getAddressNavigatorParams } from '../../utils/address';
 
 
 const MapView = (props) => {
@@ -174,11 +175,7 @@ const MapView = (props) => {
   const navigateToAddress = (latLng) => {
     fetchAddress(latLng)
       .then((data) => {
-        navigator.push('address', {
-          municipality: data.street.municipality,
-          street: getLocaleText(data.street.name),
-          number: data.number,
-        });
+        navigator.push('address', getAddressNavigatorParams(data, getLocaleText));
       });
   };
 

--- a/src/views/MapView/components/AddressPopup.js
+++ b/src/views/MapView/components/AddressPopup.js
@@ -4,6 +4,7 @@ import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 import styles from '../styles';
 import fetchAddress from '../utils/fetchAddress';
+import { getAddressNavigatorParams } from '../../../utils/address';
 
 const AddressPopup = ({
   Popup, classes, mapClickPoint, getLocaleText, map, navigator,
@@ -29,11 +30,7 @@ const AddressPopup = ({
             onClick={() => {
               if (navigator) {
                 map.leafletElement.closePopup();
-                navigator.push('address', {
-                  municipality: address.street.municipality,
-                  street: getLocaleText(address.street.name),
-                  number: address.number,
-                });
+                navigator.push('address', getAddressNavigatorParams(address, getLocaleText));
               }
             }}
           >

--- a/src/views/SearchView/SearchView.js
+++ b/src/views/SearchView/SearchView.js
@@ -19,6 +19,7 @@ import { generatePath } from '../../utils/path';
 import { DesktopComponent } from '../../layouts/WrapperComponents/WrapperComponents';
 import ExpandedSuggestions from '../../components/ExpandedSuggestions';
 import SettingsInfo from '../../components/SettingsInfo';
+import { getAddressNavigatorParams } from '../../utils/address';
 
 class SearchView extends React.Component {
   constructor(props) {
@@ -247,18 +248,16 @@ class SearchView extends React.Component {
     // and only 1 result found redirect directly to specific result page
     if (!isFetching && !this.shouldFetch() && units && units.length === 1) {
       const {
-        id, object_type, letter, number, street,
+        id, object_type,
       } = units[0];
       let path = null;
       // Parse language params
       const { params } = match;
       const lng = params && params.lng;
-      const { name, municipality } = street || {};
-      const streetName = name ? getLocaleText(name) : null;
 
       switch (object_type) {
         case 'address':
-          path = generatePath('address', lng, { number: `${number}${letter || ''}`, municipality, street: streetName });
+          path = generatePath('address', lng, getAddressNavigatorParams(units[0], getLocaleText));
           break;
         case 'unit':
           path = generatePath('unit', lng, { id });


### PR DESCRIPTION
New address utility functions to centralize aspects of address data handling to one place.
- `getAddressText` - To transform address data object to readable string
- `getAddressNavigatorParam` - To transform address data object to navigator object for redirecting and pushing to new view
- `addressMatchParamsToFetchOptions` - To transform address path parameters to usable fetch options used by `fetchAddressData`

Fixes
- Fixed problem where address title was not shown even when address data was successfully fetched. 
- Fixed `fetchAddressData` to handle multiple results for addresses with building letters