### PR TITLE
Prevent distance from being rendered as 0

### DIFF
--- a/src/components/ListItems/UnitItem/UnitItem.js
+++ b/src/components/ListItems/UnitItem/UnitItem.js
@@ -87,7 +87,7 @@ class UnitItem extends React.Component {
 
     // Distance
     let distance = calculateDistance(unit, latLng);
-    if (distance) {
+    if (typeof distance === 'number') {
       if (distance >= 1000) {
         distance /= 1000; // Convert from m to km
         distance = distance.toFixed(1); // Show only one decimal


### PR DESCRIPTION
Fixed problem where distance=0 was rendered as `0` and not `0m` For example /fi/address/helsinki/Arkadiankatu/25 gives data where distance to some units is zero.