### PR TITLE
Fix/banner accessibility

### DIFF
--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -35,6 +35,7 @@ class Settings extends React.Component {
 
   constructor(props) {
     super(props);
+    this.dialogRef = React.createRef();
     this.state = {
       alert: false,
       currentSettings: {},
@@ -145,6 +146,18 @@ class Settings extends React.Component {
     this.setState({
       alert,
     });
+  }
+
+  focusToFirstElement = () => {
+    const dialog = this.dialogRef.current;
+    const buttons = dialog.querySelectorAll('button');
+    buttons[0].focus();
+  }
+
+  focusToLastElement = () => {
+    const dialog = this.dialogRef.current;
+    const buttons = dialog.querySelectorAll('button');
+    buttons[buttons.length - 1].focus();
   }
 
   /**
@@ -614,12 +627,14 @@ class Settings extends React.Component {
         <Container className={`${classes.confirmationButtonContainer} ${classes.right}`}>
           <SMButton
             small
+            role="button"
             messageID="general.save"
             onClick={() => this.saveSettings()}
             color="primary"
           />
           <SMButton
             small
+            role="button"
             messageID="general.cancel"
             onClick={() => this.resetCurrentSelections()}
           />
@@ -678,8 +693,11 @@ class Settings extends React.Component {
     }
 
     return (
-      <div id="SettingsContainer" className={`${classes.container}`}>
-        <TitleBar className="SettingsTitle" titleComponent="h2" title={<FormattedMessage id={`settings.${settingsPage}.long`} />} />
+      <div id="SettingsContainer" className={`${classes.container}`} ref={this.dialogRef}>
+        {/* Empty element that makes keyboard focus loop in dialog */}
+        <Typography variant="srOnly" aria-hidden tabIndex="0" onFocus={() => this.focusToLastElement()} />
+
+        <TitleBar id="SettingsTitle" className="SettingsTitle" titleComponent="h2" title={<FormattedMessage id={`settings.${settingsPage}.long`} />} />
         <>
           {showAlert && (
             this.renderSaveAlert()
@@ -693,6 +711,7 @@ class Settings extends React.Component {
           <Container className={`${classes.confirmationButtonContainer}`}>
             <SMButton
               small
+              role="button"
               disabled={!settingsHaveChanged}
               onClick={() => this.saveSettings()}
               messageID="general.save.changes"
@@ -714,6 +733,8 @@ class Settings extends React.Component {
             )}
           </Typography>
         </>
+        {/* Empty element that makes keyboard focus loop in dialog */}
+        <Typography variant="srOnly" aria-hidden tabIndex="0" onFocus={() => this.focusToFirstElement()} />
       </div>
     );
   }

--- a/src/components/TopBar/TopBar.js
+++ b/src/components/TopBar/TopBar.js
@@ -51,22 +51,26 @@ class TopBar extends React.Component {
             }, 1);
           }}
         >
-          <Typography variant="subtitle1" className={classes.settingsButtonText}>
+          <Typography component="p" variant="subtitle1" className={classes.settingsButtonText}>
             <FormattedMessage id={`settings.${category.type}`} />
           </Typography>
           {category.type === 'mapSettings'
             ? (
-              <span className={classes.iconTextContainer}>
-                {getIcon(category.settings, { className: classes.smallIcon })}
-                <Typography>
-                  <FormattedMessage id={`settings.map.${category.settings}`} />
-                </Typography>
-              </span>
+              <NoSsr>
+                <span className={classes.iconTextContainer}>
+                  {getIcon(category.settings, { className: classes.smallIcon })}
+                  <Typography>
+                    <FormattedMessage id={`settings.map.${category.settings}`} />
+                  </Typography>
+                </span>
+              </NoSsr>
             )
             : (
-              <Typography>
-                <FormattedMessage id="settings.amount" values={{ count: category.settings.filter(i => (i !== false && i !== null)).length }} />
-              </Typography>
+              <NoSsr>
+                <Typography>
+                  <FormattedMessage id="settings.amount" values={{ count: category.settings.filter(i => (i !== false && i !== null)).length }} />
+                </Typography>
+              </NoSsr>
             )}
         </Button>
       )));
@@ -271,20 +275,21 @@ class TopBar extends React.Component {
               {this.renderDrawerMenu(pageType)}
             </MobileComponent>
             <DesktopComponent>
-              <NoSsr>
-                {!smallScreen ? (
-                  <div className={classes.settingsButtonsContainer}>
-                    { this.renderSettingsButtons()}
+              {!smallScreen ? (
+                <div className={classes.settingsButtonsContainer}>
+                  <Typography component="h2" variant="srOnly">
+                    <FormattedMessage id="settings" />
+                  </Typography>
+                  {this.renderSettingsButtons()}
+                </div>
+              ) : (
+                <>
+                  <div className={classes.mobileButtonContainer}>
+                    {this.renderMenuButton()}
                   </div>
-                ) : (
-                  <>
-                    <div className={classes.mobileButtonContainer}>
-                      {this.renderMenuButton()}
-                    </div>
-                    {this.renderDrawerMenu(pageType)}
-                  </>
-                )}
-              </NoSsr>
+                  {this.renderDrawerMenu(pageType)}
+                </>
+              )}
             </DesktopComponent>
           </Toolbar>
         </AppBar>

--- a/src/components/TopBar/TopBar.js
+++ b/src/components/TopBar/TopBar.js
@@ -139,6 +139,7 @@ class TopBar extends React.Component {
             <ButtonBase
               role="link"
               key={locale}
+              lang={locale}
               onClick={() => {
                 const newLocation = location;
                 const newPath = location.pathname.replace(/^\/[a-zA-Z]{2}\//, `/${locale}/`);

--- a/src/layouts/DefaultLayout.js
+++ b/src/layouts/DefaultLayout.js
@@ -94,31 +94,48 @@ const DefaultLayout = (props) => {
 
   return (
     <>
-      <h1 id="app-title" tabIndex="-1" className="sr-only app-title" component="h1">
-        <FormattedMessage id="app.title" />
-      </h1>
-      {/* Jump link to main content for screenreaders
+      <div id="topArea" aria-hidden={!!settingsToggled}>
+        <h1 id="app-title" tabIndex="-1" className="sr-only app-title" component="h1">
+          <FormattedMessage id="app.title" />
+        </h1>
+        {/* Jump link to main content for screenreaders
         Must be first interactable element on page */}
-      <a href="#view-title" className="sr-only">
-        <FormattedMessage id="general.skipToContent" />
-      </a>
-      <TopBar settingsOpen={settingsToggled} toggleSettings={type => setSettingsPage(type)} smallScreen={isSmallScreen} i18n={i18n} />
-      <div style={styles.activeRoot}>
-        <main className="SidebarWrapper" style={styles.sidebar}>
+        <a href="#view-title" className="sr-only">
+          <FormattedMessage id="general.skipToContent" />
+        </a>
+        <TopBar
+          settingsOpen={settingsToggled}
+          toggleSettings={type => setSettingsPage(type)}
+          smallScreen={isSmallScreen}
+          i18n={i18n}
+        />
+      </div>
+
+      <div id="activeRoot" style={styles.activeRoot}>
+        <main role={settingsToggled && 'dialog'} className="SidebarWrapper" style={styles.sidebar}>
           {settingsToggled ? (
-            <Settings key={settingsToggled} toggleSettings={() => setSettingsPage()} isMobile={!!isMobile} />
+            <Settings
+              key={settingsToggled}
+              toggleSettings={() => setSettingsPage()}
+              isMobile={!!isMobile}
+            />
           ) : (
             <Sidebar />
           )}
         </main>
-        <div aria-label={intl.formatMessage({ id: 'map.ariaLabel' })} tabIndex="-1" style={styles.map}>
+        <div
+          aria-label={intl.formatMessage({ id: 'map.ariaLabel' })}
+          aria-hidden={!!settingsToggled}
+          tabIndex="-1"
+          style={styles.map}
+        >
           <div aria-hidden="true" style={styles.mapWrapper}>
             <MapView isMobile={!!isMobile} />
           </div>
         </div>
       </div>
 
-      <footer role="contentinfo" className="sr-only">
+      <footer role="contentinfo" aria-hidden={!!settingsToggled} className="sr-only">
         <DesktopComponent>
           <a href="#app-title">
             <FormattedMessage id="general.backToStart" />


### PR DESCRIPTION
* Settings page is now dialog that traps keyboard and screen reader users inside, so that it's only possible to leave the dialog by pressing one of the close buttons. Keyboard navigation loops through the dialog, sr navigation makes rest of the page aria-hidden.