### PR TITLE
Feature/bbox parameter option

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -19,6 +19,7 @@ import { changeLocaleAction } from './redux/actions/user';
 import DefaultLayout from './layouts';
 import EmbedLayout from './layouts/EmbedLayout';
 import Navigator from './components/Navigator';
+import DataFetcher from './components/DataFetchers/DataFetcher';
 
 class App extends React.Component {
   constructor(props) {
@@ -57,6 +58,7 @@ class App extends React.Component {
             <Route render={() => <DefaultLayout i18n={i18n} />} />
           </Switch>
           <Navigator />
+          <DataFetcher />
         </div>
       </IntlProvider>
     );

--- a/src/components/DataFetchers/DataFetcher.js
+++ b/src/components/DataFetchers/DataFetcher.js
@@ -1,0 +1,79 @@
+import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { withRouter } from 'react-router-dom';
+import { connect } from 'react-redux';
+import { fetchUnits } from '../../redux/actions/unit';
+import { fitBbox } from '../../views/MapView/utils/mapActions';
+import { reverseBBoxCoordinates, searchParamData } from './helpers';
+
+const DataFetcher = ({
+  currentPage,
+  fetchUnits,
+  location,
+  map,
+}) => {
+  /**
+   * Handle bbox fetching
+   */
+  const handleBBoxFetch = () => {
+    if (!map) {
+      return false;
+    }
+
+    const options = searchParamData(location);
+    if (options.q || options.service_node || options.service) {
+      return false;
+    }
+    if (!options.bbox || !options.bbox_srid || !options.level) {
+      return false;
+    }
+
+    fetchUnits(options);
+    fitBbox(map, reverseBBoxCoordinates(options.bbox));
+    return true;
+  };
+
+  // Component mount action
+  useEffect(() => {
+    if (!map) {
+      return;
+    }
+    switch (currentPage) {
+      case 'search':
+      case 'home':
+        handleBBoxFetch();
+        break;
+      default:
+    }
+  }, [currentPage, map]);
+
+  return null;
+};
+
+// Listen to redux state
+const mapStateToProps = (state) => {
+  const { mapRef, user } = state;
+  const map = mapRef.leafletElement;
+
+  return {
+    currentPage: user.page,
+    map,
+  };
+};
+
+export default withRouter(connect(
+  mapStateToProps,
+  {
+    fetchUnits,
+  },
+)(DataFetcher));
+
+// Typechecking
+DataFetcher.propTypes = {
+  fetchUnits: PropTypes.func.isRequired,
+  map: PropTypes.objectOf(PropTypes.any),
+};
+
+DataFetcher.defaultProps = {
+  map: null,
+};

--- a/src/components/DataFetchers/DataFetcher.js
+++ b/src/components/DataFetchers/DataFetcher.js
@@ -4,7 +4,8 @@ import { withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { fetchUnits } from '../../redux/actions/unit';
 import { fitBbox } from '../../views/MapView/utils/mapActions';
-import { reverseBBoxCoordinates, searchParamData } from './helpers';
+import { searchParamFetchOptions } from './helpers';
+import { getSearchParam } from '../../utils';
 
 const DataFetcher = ({
   currentPage,
@@ -20,16 +21,20 @@ const DataFetcher = ({
       return false;
     }
 
-    const options = searchParamData(location);
-    if (options.q || options.service_node || options.service) {
-      return false;
+    const bbox = getSearchParam(location, 'bbox');
+    if (bbox) {
+      fitBbox(map, bbox.split(','));
     }
-    if (!options.bbox || !options.bbox_srid || !options.level) {
+
+    const options = searchParamFetchOptions(location, null, true);
+    if (
+      !options.bbox || !options.bbox_srid || !options.level
+      || options.q || options.service_node || options.service
+    ) {
       return false;
     }
 
     fetchUnits(options);
-    fitBbox(map, reverseBBoxCoordinates(options.bbox));
     return true;
   };
 

--- a/src/components/DataFetchers/helpers.js
+++ b/src/components/DataFetchers/helpers.js
@@ -1,0 +1,89 @@
+/* eslint-disable camelcase */
+import { parseSearchParams } from '../../utils';
+
+export const searchParamData = (location, redirectNode, includeService = false) => {
+  const searchParams = parseSearchParams(location.search);
+
+  const {
+    q,
+    category,
+    city,
+    municipality,
+    service,
+    service_node,
+    bbox,
+    level,
+  } = searchParams;
+
+  const options = {};
+  if (q) {
+    options.q = q;
+  } else {
+    // Handle bbox and level
+    if (bbox) {
+      const nLevel = level || 'customer_service'; // Taken from old servicemap
+      if (nLevel === 'none') {
+        return null;
+      }
+      options.level = nLevel;
+      // Swapping latLngs
+      const bboxParts = bbox.split(',');
+      options.bbox = [bboxParts[1], bboxParts[0], bboxParts[3], bboxParts[2]].join(',');
+      options.bbox_srid = 4326;
+      return options;
+    }
+    // Parse service
+    if (includeService && service) {
+      options.service = service;
+    }
+
+    // Parse service_node
+    if (service_node) {
+      options.service_node = service_node;
+    }
+    if (!includeService && redirectNode) {
+      options.service_node = redirectNode;
+    }
+
+    if (category) {
+      const data = category.split(',');
+
+      // Parse services
+      const services = data.reduce((result, item) => {
+        if (item.indexOf('service:') === 0) {
+          result.push(item.split(':')[1]);
+        }
+        return result;
+      }, []);
+
+      if (services.length) {
+        options.service = services.join(',');
+      }
+
+      // Parse serviceNodes
+      const serviceNodes = data.reduce((result, item) => {
+        if (item.indexOf('service_node:') === 0) {
+          result.push(item.split(':')[1]);
+        }
+        return result;
+      }, []);
+
+      if (serviceNodes.length) {
+        options.service_node = serviceNodes.join(',');
+      }
+    }
+  }
+
+  // Parse municipality
+  if (municipality || city) {
+    options.municipality = municipality || city;
+  }
+
+
+  return options;
+};
+
+export const reverseBBoxCoordinates = (bbox) => {
+  const bboxParts = bbox.split(',');
+  return [bboxParts[1], bboxParts[0], bboxParts[3], bboxParts[2]];
+};

--- a/src/components/DataFetchers/helpers.js
+++ b/src/components/DataFetchers/helpers.js
@@ -1,7 +1,13 @@
 /* eslint-disable camelcase */
 import { parseSearchParams } from '../../utils';
 
-export const searchParamData = (location, redirectNode, includeService = false) => {
+
+export const reverseBBoxCoordinates = (bbox) => {
+  const bboxParts = bbox.split(',');
+  return [bboxParts[1], bboxParts[0], bboxParts[3], bboxParts[2]];
+};
+
+export const searchParamFetchOptions = (location, redirectNode, includeService = false) => {
   const searchParams = parseSearchParams(location.search);
 
   const {
@@ -16,22 +22,10 @@ export const searchParamData = (location, redirectNode, includeService = false) 
   } = searchParams;
 
   const options = {};
+
   if (q) {
     options.q = q;
   } else {
-    // Handle bbox and level
-    if (bbox) {
-      const nLevel = level || 'customer_service'; // Taken from old servicemap
-      if (nLevel === 'none') {
-        return null;
-      }
-      options.level = nLevel;
-      // Swapping latLngs
-      const bboxParts = bbox.split(',');
-      options.bbox = [bboxParts[1], bboxParts[0], bboxParts[3], bboxParts[2]].join(',');
-      options.bbox_srid = 4326;
-      return options;
-    }
     // Parse service
     if (includeService && service) {
       options.service = service;
@@ -72,6 +66,22 @@ export const searchParamData = (location, redirectNode, includeService = false) 
         options.service_node = serviceNodes.join(',');
       }
     }
+
+    if (options.service || options.service_node) {
+      return options;
+    }
+
+    // Handle bbox and level
+    if (bbox) {
+      const nLevel = level || 'customer_service'; // Taken from old servicemap
+      if (nLevel === 'none') {
+        return null;
+      }
+      options.level = nLevel;
+      // Swapping latLngs
+      options.bbox = reverseBBoxCoordinates(bbox).join(',');
+      options.bbox_srid = 4326;
+    }
   }
 
   // Parse municipality
@@ -79,11 +89,5 @@ export const searchParamData = (location, redirectNode, includeService = false) 
     options.municipality = municipality || city;
   }
 
-
   return options;
-};
-
-export const reverseBBoxCoordinates = (bbox) => {
-  const bboxParts = bbox.split(',');
-  return [bboxParts[1], bboxParts[0], bboxParts[3], bboxParts[2]];
 };

--- a/src/redux/actions/unit.js
+++ b/src/redux/actions/unit.js
@@ -11,7 +11,6 @@ const {
 export const fetchUnits = (
   // searchQuery = null,
   options = null,
-  searchType = null,
   abortController = null,
 ) => async (dispatch, getState)
 => {

--- a/src/redux/actions/unit.js
+++ b/src/redux/actions/unit.js
@@ -14,6 +14,11 @@ export const fetchUnits = (
   abortController = null,
 ) => async (dispatch, getState)
 => {
+  const { units, user } = getState();
+  const { locale } = user;
+  if (units.isFetching) {
+    throw Error('Unable to fetch units because previous fetch is still active');
+  }
   const stringifySearchQuery = (data) => {
     try {
       const search = Object.keys(data).map(key => (`${key}:${data[key]}`));
@@ -24,8 +29,6 @@ export const fetchUnits = (
   };
   const searchQuery = options.q ? options.q : stringifySearchQuery(options);
   const onStart = () => dispatch(isFetching(searchQuery));
-  const { user } = getState();
-  const { locale } = user;
 
   const onSuccess = (results) => {
     if (options.q) {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -155,5 +155,11 @@ export const isSmallContentArea = () => {
   );
 };
 
+export const getSearchParam = (location, key) => {
+  const searchParams = parseSearchParams(location.search);
+  const param = searchParams[key];
+  return param;
+};
+
 
 export default isClient;

--- a/src/views/MapView/MapView.js
+++ b/src/views/MapView/MapView.js
@@ -65,7 +65,7 @@ const MapView = (props) => {
     let mapUnits = [];
     let unitGeometry = null;
 
-    if (currentPage === 'search' || currentPage === 'division') {
+    if (currentPage === 'home' || currentPage === 'search' || currentPage === 'division') {
       mapUnits = unitList;
     } else if (currentPage === 'address') {
       mapUnits = addressUnits;

--- a/src/views/MapView/utils/mapActions.js
+++ b/src/views/MapView/utils/mapActions.js
@@ -37,7 +37,19 @@ const focusDistrict = (map, coordinates) => {
   map.fitBounds(coordinates);
 };
 
+const fitBbox = (map, bbox) => {
+  if (!map || !bbox || bbox.length !== 4) {
+    return;
+  }
+  const L = require('leaflet');
+  const sw = L.latLng(bbox.slice(0, 2));
+  const ne = L.latLng(bbox.slice(2, 4));
+  const bounds = L.latLngBounds(sw, ne);
+  map.fitBounds(bounds);
+};
+
 export {
+  fitBbox,
   fitUnitsToMap,
   focusUnit,
   focusDistrict,

--- a/src/views/SearchView/SearchView.js
+++ b/src/views/SearchView/SearchView.js
@@ -11,7 +11,7 @@ import styles from './styles';
 import Loading from '../../components/Loading/Loading';
 import SearchBar from '../../components/SearchBar';
 import { fitUnitsToMap } from '../MapView/utils/mapActions';
-import { parseSearchParams } from '../../utils';
+import { parseSearchParams, getSearchParam } from '../../utils';
 import TabLists from '../../components/TabLists';
 
 import Container from '../../components/Container';
@@ -102,8 +102,8 @@ class SearchView extends React.Component {
           options.service_node = `${(options.service_node ? `${options.service_node},` : '')}${data.service_node}`;
 
           // Set serviceRedirect to wasHandled
-          this.setState({ serviceRedirect: { service: options.service_node, wasHandled: true } });
           fetchUnits(options);
+          this.setState({ serviceRedirect: { service: options.service_node, wasHandled: true } });
         }
       });
       return true;
@@ -141,6 +141,10 @@ class SearchView extends React.Component {
     if (q) {
       options.q = q;
     } else {
+      // Parse municipality
+      if (municipality || city) {
+        options.municipality = municipality || city;
+      }
       // Parse service
       if (includeService && service) {
         options.service = service;
@@ -183,11 +187,6 @@ class SearchView extends React.Component {
       }
     }
 
-    // Parse municipality
-    if (municipality || city) {
-      options.municipality = municipality || city;
-    }
-
 
     return options;
   }
@@ -213,6 +212,10 @@ class SearchView extends React.Component {
   }
 
   focusMap = (units, map) => {
+    const { location } = this.props;
+    if (getSearchParam(location, 'bbox')) {
+      return;
+    }
     if (map && map._layersMaxZoom) {
       fitUnitsToMap(units, map);
     }


### PR DESCRIPTION
Handle bbox parameters for unit fetching and map focusing. Add independent DataFetcher component for easier fetch handling.

Meant to solve problems with old embeds and links. For example 
- `/embed/unit?service=25656&bbox=60.10423,24.57757,60.24830,25.12205&city=helsinki`
- `/embed?level=all&bbox=60.184077,24.978499,60.186077,24.980499`
- `/embed?lang=fi&bbox=60.25251,25.21889,60.28112,25.32483&level=all`

Should also handle fetching etc without embed in url.

Should test properly that everything works. There was some problems with old bbox functionality for example old bbox used another coordinate projection to get data from larger area. But this data didn't fall under given bbox parameter so I think it's still fine to exclude that extra data in this new solution.

Also old version had issues where bbox focusing was overridden by focus to unit functionality. This means that in new version `embed/unit?service=25656&bbox=60.10423,24.57757,60.24830,25.12205&city=helsinki` shows the actual bbox area given rather than trying to focus by fitting units to screen.