### PR TITLE
Fix issue where polyfill builtins weren't loaded properly

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,9 @@
 {
   "presets": [
     [
-      "react-app"
+      "react-app", {
+        "useBuiltIns": "entry"
+      }
     ]
   ]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,12 +11,12 @@ const js = {
   
   test: /\.(js|mjs|jsx|ts|tsx)$/,
   exclude: /node_modules/,
-  loader: require.resolve('babel-loader'),
+  loader: 'babel-loader',
   options: {
     customize: require.resolve(
       'babel-preset-react-app/webpack-overrides'
     ),
-    
+
     plugins: [
       [
         require.resolve('babel-plugin-named-asset-import'),


### PR DESCRIPTION
Fix for internet explorer issue where polyfills were not loaded correctly.
Should fix issues for pages like 
- `/sv/address/esbo/gårdsbrinken/1`
- `/sv/embed/address/esbo/gårdsbrinken/1` 
- `/sv/address/esbo/karvasbackavägen/6`
