### PR TITLE
District area drawing fix

### DIFF
--- a/src/views/AddressView/AddressView.js
+++ b/src/views/AddressView/AddressView.js
@@ -113,7 +113,7 @@ const AddressView = (props) => {
     if (!mobile && highlightedDistrict && highlightedDistrict.id === district.id) {
       setHighlightedDistrict(null);
     } else {
-      setHighlightedDistrict([district]);
+      setHighlightedDistrict(district);
     }
 
     const { coordinates } = district.boundary;
@@ -296,7 +296,7 @@ AddressView.propTypes = {
   setAddressData: PropTypes.func.isRequired,
   setAddressLocation: PropTypes.func.isRequired,
   setAddressUnits: PropTypes.func.isRequired,
-  highlightedDistrict: PropTypes.arrayOf(PropTypes.any),
+  highlightedDistrict: PropTypes.objectOf(PropTypes.any),
   classes: PropTypes.objectOf(PropTypes.any).isRequired,
   embed: PropTypes.bool,
 };

--- a/src/views/AddressView/utils/fetchDistricts.js
+++ b/src/views/AddressView/utils/fetchDistricts.js
@@ -55,18 +55,6 @@ const fetchDistricts = async (lnglat) => {
     });
   }
 
-  // Change district coordinates from lnglat to latlng before returning data
-  const data = districtData.results;
-  const districtList = data;
-  for (let i = 0; i < data.length; i += 1) {
-    const L = require('leaflet');
-    const geoJSONBounds = [];
-    data[i].boundary.coordinates[0][0].forEach((coordinate) => {
-      const geoJSONCoord = L.GeoJSON.coordsToLatLng(coordinate);
-      geoJSONBounds.push([geoJSONCoord.lat, geoJSONCoord.lng]);
-    });
-    districtList[i].boundary.coordinates[0][0] = geoJSONBounds;
-  }
 
   // Organize district to lists depending on district type
   const geographical = [];
@@ -74,7 +62,7 @@ const fetchDistricts = async (lnglat) => {
   const health = [];
   const education = [];
 
-  districtList.forEach((district) => {
+  districtData.results.forEach((district) => {
     switch (district.type) {
       case 'neighborhood': case 'postcode_area':
         geographical.push(district);

--- a/src/views/AddressView/utils/fetchDistricts.js
+++ b/src/views/AddressView/utils/fetchDistricts.js
@@ -1,4 +1,4 @@
-import { districtFetch, unitsFetch } from '../../../utils/fetch';
+import { districtFetch } from '../../../utils/fetch';
 
 /* eslint-disable global-require */
 const fetchDistricts = async (lnglat) => {
@@ -25,6 +25,7 @@ const fetchDistricts = async (lnglat) => {
     page_size: 80,
     type: `${districts.join(',')}`,
     geometry: true,
+    unit_include: 'name,location',
   };
   const districtData = await districtFetch(options);
 
@@ -35,25 +36,6 @@ const fetchDistricts = async (lnglat) => {
       idList.push(district.service_point_id);
     }
   });
-
-  // Fetch the unit data with the received id's
-  if (idList.length > 0) {
-    const unitOptions = {
-      id: idList.join(','),
-      only: 'name,location',
-      page_size: 50,
-    };
-    const unitData = await unitsFetch(unitOptions);
-
-    districtData.results.forEach((district) => {
-      unitData.results.forEach((unit) => {
-        if (unit.id === parseInt(district.service_point_id, 10)) {
-        // Combine the unit data to the correct district
-          district.unit = unit; // eslint-disable-line no-param-reassign
-        }
-      });
-    });
-  }
 
 
   // Organize district to lists depending on district type

--- a/src/views/DivisionView/DivisionView.js
+++ b/src/views/DivisionView/DivisionView.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import fetchDivisionDistrict from './fetchDivisionDistrict';
 import { focusDistrict } from '../MapView/utils/mapActions';
@@ -39,16 +39,16 @@ const DivisionView = ({
       fetchUnits(options);
       fetchDivisionDistrict(options.division)
         .then((data) => {
-          setHighlightedDistrict(data);
+          setHighlightedDistrict(data[0]);
         });
     }
   }, []);
 
   useEffect(() => {
-    if (!highlightedDistrict || !highlightedDistrict.length) {
+    if (!highlightedDistrict) {
       return;
     }
-    const coordinates = highlightedDistrict.map(district => (district.boundary.coordinates));
+    const { coordinates } = highlightedDistrict.boundary;
     if (map && coordinates) {
       focusDistrict(map, coordinates);
     }
@@ -63,7 +63,7 @@ export default DivisionView;
 // Typechecking
 DivisionView.propTypes = {
   fetchUnits: PropTypes.func.isRequired,
-  highlightedDistrict: PropTypes.arrayOf(PropTypes.any),
+  highlightedDistrict: PropTypes.objectOf(PropTypes.any),
   location: PropTypes.objectOf(PropTypes.any).isRequired,
   map: PropTypes.objectOf(PropTypes.any),
   match: PropTypes.objectOf(PropTypes.any).isRequired,

--- a/src/views/DivisionView/fetchDivisionDistrict.js
+++ b/src/views/DivisionView/fetchDivisionDistrict.js
@@ -1,5 +1,4 @@
 import { districtFetch } from '../../utils/fetch';
-import swapCoordinates from '../MapView/utils/swapCoordinates';
 
 // Fetch district data for specific devision using ocdID
 const fetchDivisionDistrict = async (ocdID) => {
@@ -14,9 +13,7 @@ const fetchDivisionDistrict = async (ocdID) => {
   const districts = results || null;
 
   const data = districts.reduce((result, item) => {
-    const newItem = item;
-    newItem.boundary.coordinates[0] = swapCoordinates(newItem.boundary.coordinates[0]);
-    result.push(newItem);
+    result.push(item);
     return result;
   }, []);
 

--- a/src/views/MapView/MapView.js
+++ b/src/views/MapView/MapView.js
@@ -349,7 +349,7 @@ MapView.propTypes = {
   currentPage: PropTypes.string.isRequired,
   getAddressNavigatorParams: PropTypes.func.isRequired,
   getLocaleText: PropTypes.func.isRequired,
-  highlightedDistrict: PropTypes.arrayOf(PropTypes.any),
+  highlightedDistrict: PropTypes.objectOf(PropTypes.any),
   highlightedUnit: PropTypes.objectOf(PropTypes.any),
   intl: intlShape.isRequired,
   isMobile: PropTypes.bool,

--- a/src/views/MapView/components/Districts.js
+++ b/src/views/MapView/components/Districts.js
@@ -43,7 +43,7 @@ const Districts = ({
               {/* Popup for the district unit name */}
               <Popup
                 className="popup"
-                offset={[-1, -29]}
+                offset={[-0.5, -20]}
                 closeButton={false}
                 autoPan={false}
                 position={[

--- a/src/views/MapView/components/Districts.js
+++ b/src/views/MapView/components/Districts.js
@@ -18,24 +18,24 @@ const Districts = ({
   navigator,
 }) => {
   const renderDistrictMarkers = () => {
-    if (highlightedDistrict && highlightedDistrict.length) {
-      return highlightedDistrict.map(district => (
-        <React.Fragment key={district.id}>
-          {district && district.unit && district.unit.location ? (
+    if (highlightedDistrict) {
+      return (
+        <React.Fragment key={highlightedDistrict.id}>
+          {highlightedDistrict && highlightedDistrict.unit && highlightedDistrict.unit.location ? (
             <>
               <Marker
                 position={[
-                  district.unit.location.coordinates[1],
-                  district.unit.location.coordinates[0],
+                  highlightedDistrict.unit.location.coordinates[1],
+                  highlightedDistrict.unit.location.coordinates[0],
                 ]}
-                icon={drawMarkerIcon(district.unit, settings)}
+                icon={drawMarkerIcon(highlightedDistrict.unit, settings)}
                 keyboard={false}
                 onClick={() => {
                   if (navigator) {
                     if (mobile) {
-                      navigator.replace('unit', { id: district.unit.id });
+                      navigator.replace('unit', { id: highlightedDistrict.unit.id });
                     } else {
-                      navigator.push('unit', { id: district.unit.id });
+                      navigator.push('unit', { id: highlightedDistrict.unit.id });
                     }
                   }
                 }}
@@ -47,15 +47,15 @@ const Districts = ({
                 closeButton={false}
                 autoPan={false}
                 position={[
-                  district.unit.location.coordinates[1],
-                  district.unit.location.coordinates[0],
+                  highlightedDistrict.unit.location.coordinates[1],
+                  highlightedDistrict.unit.location.coordinates[0],
                 ]}
               >
                 <Typography
                   noWrap
                   className={classes.popup}
                 >
-                  {getLocaleText(district.unit.name)}
+                  {getLocaleText(highlightedDistrict.unit.name)}
                 </Typography>
               </Popup>
             </>
@@ -63,17 +63,17 @@ const Districts = ({
             : null
           }
         </React.Fragment>
-      ));
+      );
     }
     return null;
   };
 
   const renderDistricts = () => {
-    if (!highlightedDistrict || !highlightedDistrict.length) {
+    if (!highlightedDistrict) {
       return null;
     }
 
-    const areas = highlightedDistrict[0].boundary.coordinates.map(
+    const areas = highlightedDistrict.boundary.coordinates.map(
       coords => swapCoordinates(coords),
     );
 
@@ -106,7 +106,7 @@ Districts.propTypes = {
   Polygon: PropTypes.objectOf(PropTypes.any).isRequired,
   Marker: PropTypes.objectOf(PropTypes.any).isRequired,
   Popup: PropTypes.objectOf(PropTypes.any).isRequired,
-  highlightedDistrict: PropTypes.arrayOf(PropTypes.any),
+  highlightedDistrict: PropTypes.objectOf(PropTypes.any),
   getLocaleText: PropTypes.func.isRequired,
   settings: PropTypes.objectOf(PropTypes.any).isRequired,
   mapOptions: PropTypes.objectOf(PropTypes.any).isRequired,

--- a/src/views/MapView/components/Districts.js
+++ b/src/views/MapView/components/Districts.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { withStyles, Typography } from '@material-ui/core';
 import { drawMarkerIcon } from '../utils/drawIcon';
 import styles from '../styles';
+import swapCoordinates from '../utils/swapCoordinates';
 
 const Districts = ({
   Polygon,
@@ -72,14 +73,15 @@ const Districts = ({
       return null;
     }
 
-    const districtPositions = highlightedDistrict
-      .map(district => (district.boundary.coordinates[0]));
+    const areas = highlightedDistrict[0].boundary.coordinates.map(
+      coords => swapCoordinates(coords),
+    );
 
     return (
       <Polygon
         positions={[
           [mapOptions.polygonBounds],
-          [districtPositions],
+          [areas],
         ]}
         color="#ff8400"
         fillColor="#000"

--- a/src/views/MapView/utils/mapActions.js
+++ b/src/views/MapView/utils/mapActions.js
@@ -1,3 +1,5 @@
+import swapCoordinates from './swapCoordinates';
+
 /* eslint-disable global-require, no-underscore-dangle */
 
 const fitUnitsToMap = (units, map) => {
@@ -34,7 +36,8 @@ const focusUnit = (map, coordinates) => {
 };
 
 const focusDistrict = (map, coordinates) => {
-  map.fitBounds(coordinates);
+  const bounds = coordinates.map(area => swapCoordinates(area));
+  map.fitBounds(bounds);
 };
 
 const fitBbox = (map, bbox) => {

--- a/src/views/UnitView/UnitView.js
+++ b/src/views/UnitView/UnitView.js
@@ -56,7 +56,7 @@ const UnitView = (props) => {
     if (unit && map) {
       const { geometry, location } = unit;
       if (geometry && geometry.type === 'MultiLineString') {
-        focusDistrict(map, geometry.coordinates);
+        focusDistrict(map, [geometry.coordinates]);
       } else if (location) {
         focusUnit(map, location.coordinates);
       }


### PR DESCRIPTION
* Fixed issue where districts with multiple area bounds would only draw first area
* Removed district coordinate swapping from fetch functions and instead do swapping when drawing/focusing to map
* Changed highlighted district type from array to object (since there can only be one highlighted district) 
* Add missing units from districts. (For example Kalasatama health station district now shows Kalasatama health station)
* Move area unit popup closer to unit icon