### PR TITLE
Fix/search settings accessibility

### DIFF
--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -177,10 +177,17 @@ class Settings extends React.Component {
   // eslint-disable-next-line class-methods-use-this
   focusToBaseElement() {
     const { settings } = this.props;
-    const elem = document.getElementById(`SettingsButton${settings.toggled}`);
-    if (elem) {
-      setTimeout(() => { elem.focus(); }, 1);
-    }
+    setTimeout(() => {
+      let elem;
+      if (settings.toggled === 'all') {
+        elem = document.getElementById('SettingsLink');
+      } else {
+        elem = document.getElementById(`SettingsButton${settings.toggled}`);
+      }
+      if (elem) {
+        elem.focus();
+      }
+    }, 1);
   }
 
   /**
@@ -656,7 +663,7 @@ class Settings extends React.Component {
   }
 
   render() {
-    const { classes, settings } = this.props;
+    const { classes, settings, intl } = this.props;
     const { alert, saved } = this.state;
     const settingsPage = settings.toggled;
     const settingsHaveChanged = this.settingsHaveChanged();
@@ -714,6 +721,7 @@ class Settings extends React.Component {
               small
               onClick={() => this.toggleSettingsContainer()}
               messageID="general.close"
+              srText={intl.formatMessage({ id: 'general.closeSettings' })}
             />
           </Container>
 

--- a/src/components/Settings/styles.js
+++ b/src/components/Settings/styles.js
@@ -87,6 +87,12 @@ export default theme => ({
   },
   container: {
     backgroundColor: '#fff',
+    position: 'absolute',
+    top: 0,
+    zIndex: theme.zIndex.infront,
+    height: '100%',
+    width: '100%',
+    overflow: 'auto',
   },
   hidden: {
     display: 'none',
@@ -140,7 +146,7 @@ export default theme => ({
     margin: 0,
   },
   stickyMobile: {
-    top: topBarHeight,
+    top: 0,
   },
   disabled: {
     backgroundColor: 'rgba(0, 0, 0, 0.12)',

--- a/src/components/SettingsInfo/SettingsInfo.js
+++ b/src/components/SettingsInfo/SettingsInfo.js
@@ -66,9 +66,19 @@ const SettingsInfo = ({
       <Divider aria-hidden="true" />
       <Container className={classes.container}>
         <ButtonBase
+          id="SettingsLink"
           aria-labelledby="SettingsInfo-srTitle"
           role="link"
-          onClick={() => toggleSettings('all')}
+          onClick={() => {
+            toggleSettings('all');
+            setTimeout(() => {
+              const settings = document.getElementsByClassName('SettingsTitle')[0];
+              if (settings) {
+                // Focus on settings title
+                settings.firstChild.focus();
+              }
+            }, 1);
+          }}
           className={classes.settingsLink}
         >
           <Typography

--- a/src/layouts/DefaultLayout.js
+++ b/src/layouts/DefaultLayout.js
@@ -56,9 +56,14 @@ const createContentStyles = (
       bottom: 0,
       width,
       margin: 0,
-      overflow: !isMobile ? 'auto' : '',
+      // eslint-disable-next-line no-nested-ternary
+      overflow: settingsOpen ? 'hidden'
+        : isMobile ? '' : 'auto',
       visibility: mobileMapOnly && !settingsOpen ? 'hidden' : null,
       flex: '0 1 auto',
+    },
+    sidebarContent: {
+      height: '100%',
     },
   };
 
@@ -113,15 +118,16 @@ const DefaultLayout = (props) => {
 
       <div id="activeRoot" style={styles.activeRoot}>
         <main role={settingsToggled && 'dialog'} className="SidebarWrapper" style={styles.sidebar}>
-          {settingsToggled ? (
+          {settingsToggled && (
             <Settings
               key={settingsToggled}
               toggleSettings={() => setSettingsPage()}
               isMobile={!!isMobile}
             />
-          ) : (
-            <Sidebar />
           )}
+          <div style={styles.sidebarContent} aria-hidden={!!settingsToggled}>
+            <Sidebar />
+          </div>
         </main>
         <div
           aria-label={intl.formatMessage({ id: 'map.ariaLabel' })}


### PR DESCRIPTION
* Opening settings page from search view settings link will now put focus correctly on top of settings dialog. Closing settings will put focus back to the link.
* Settings page is now visually on top of sidebar instead of replacing sidebar content. 