### PR TITLE
Fix focus loss on settings confirmation click

### DIFF
--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -636,14 +636,20 @@ class Settings extends React.Component {
             small
             role="button"
             messageID="general.save"
-            onClick={() => this.saveSettings()}
+            onClick={() => {
+              this.saveSettings();
+              this.dialogRef.current.querySelector('h2').focus();
+            }}
             color="primary"
           />
           <SMButton
             small
             role="button"
             messageID="general.cancel"
-            onClick={() => this.resetCurrentSelections()}
+            onClick={() => {
+              this.resetCurrentSelections();
+              this.dialogRef.current.querySelector('h2').focus();
+            }}
           />
         </Container>
       </Container>
@@ -719,6 +725,7 @@ class Settings extends React.Component {
             />
             <SMButton
               small
+              role="button"
               onClick={() => this.toggleSettingsContainer()}
               messageID="general.close"
               srText={intl.formatMessage({ id: 'general.closeSettings' })}

--- a/src/components/TitleBar/styles.js
+++ b/src/components/TitleBar/styles.js
@@ -18,6 +18,9 @@ export default theme => ({
     textTransform: 'none',
     textAlign: 'left',
     marginLeft: 10,
+    '&:focus': {
+      outlineStyle: 'none',
+    },
   },
   iconButton: {
     display: 'flex',


### PR DESCRIPTION
Previously clicking save or cancel on settings page notification box would make screen readers stuck. (Focus is nowhere). Now it focuses back to settings title.