### PR TITLE
Do not bundle node_modules dependencies in the server webpack bundle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22195,6 +22195,12 @@
         "tapable": "^1.0.0"
       }
     },
+    "webpack-node-externals": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz",
+      "integrity": "sha512-ajerHZ+BJKeCLviLUUmnyd5B4RavLF76uv3cs6KNuO8W+HuQaEs0y0L7o40NQxdPy5w0pcv8Ew7yPUAQG0UdCg==",
+      "dev": true
+    },
     "webpack-sources": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "eslint-plugin-react": "^7.12.4",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^24.5.0",
-    "jest-canvas-mock": "^2.1.2"
+    "jest-canvas-mock": "^2.1.2",
+    "webpack-node-externals": "^1.7.2"
   },
   "jest": {
     "moduleNameMapper": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const webpack = require('webpack'); //to access built-in plugins
 const path = require('path');
+const nodeExternals = require('webpack-node-externals');
 const dotenv = require('dotenv');
 dotenv.config();
 
@@ -87,6 +88,10 @@ const serverConfig = {
   entry: {
     'index.js': path.resolve(__dirname, 'server/server.js'),
   },
+  externals: [nodeExternals({
+    // excluding material ui from the build breaks the page styles
+    whitelist: [/^@material-ui.*/]
+  })],
   module: {
     rules: [
       {


### PR DESCRIPTION
Fixes a memory leak in the Sentry client.

Eases debugging with stack traces.

Still bundles material ui, because otherwise the page styles break.