### PR TITLE
Add marker event always if embed is active

### DIFF
--- a/src/views/MapView/utils/unitMarkers.js
+++ b/src/views/MapView/utils/unitMarkers.js
@@ -180,7 +180,7 @@ const renderUnitMarkers = (
           tooltipOptions(unit, unitListFiltered.length),
         );
 
-        if (unitListFiltered.length > 1) {
+        if (unitListFiltered.length > 1 || embeded) {
           markerElem.on('click', () => {
             if (embeded) {
               const { origin } = window.location;


### PR DESCRIPTION
Unit page embeds showed single unit marker which didn't get click event when embeded.