### PR TITLE
Mobile accessibility

### DIFF
--- a/src/components/DrawerMenu/DrawerMenu.js
+++ b/src/components/DrawerMenu/DrawerMenu.js
@@ -55,9 +55,7 @@ const DrawerMenu = (props) => {
       // active: settingsOpen,
       icon: getIcon('accessibility'),
       clickEvent: () => {
-        if (settingsOpen !== 'all') {
-          toggleSettings('all');
-        }
+        toggleSettings('mobile');
         toggleDrawerMenu();
       },
     },

--- a/src/components/DrawerMenu/DrawerMenu.js
+++ b/src/components/DrawerMenu/DrawerMenu.js
@@ -105,6 +105,7 @@ const DrawerMenu = (props) => {
           tabIndex={isOpen ? 0 : -1}
           role="link"
           aria-hidden={!isOpen}
+          aria-label={`${item.name} ${item.disabled ? item.subText : ''}`}
           onClick={item.clickEvent}
           className={`${classes.drawerButton} ${item.active ? classes.drawerButtonActive : ''}`}
           focusVisibleClassName={classes.itemFocus}
@@ -112,7 +113,7 @@ const DrawerMenu = (props) => {
           <div className={`${classes.drawerIcon} ${item.active ? classes.drawerIconActive : ''} ${item.disabled ? classes.disabled : ''}`}>
             {item.icon}
           </div>
-          <span className={classes.buttonLabel}>
+          <span aria-hidden className={classes.buttonLabel}>
             <Typography className={`${classes.drawerButtonText} ${item.disabled ? classes.disabled : ''}`} variant="body1">{item.name}</Typography>
             {item.disabled && <Typography className={classes.drawerButtonText} variant="caption">{item.subText}</Typography>}
           </span>

--- a/src/components/PaperButton/PaperButton.js
+++ b/src/components/PaperButton/PaperButton.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FormattedMessage, intlShape } from 'react-intl';
 import { Button, Typography } from '@material-ui/core';
 import Container from '../Container';
 
 const PaperButton = ({
-  classes, disabled, text, onClick, icon, link, subtitle,
+  classes, intl, disabled, messageID, onClick, icon, link, subtitleID,
 }) => {
   const clonedIcon = icon ? React.cloneElement(icon, { className: classes.icon }) : null;
   const role = link ? 'link' : 'button';
@@ -18,19 +19,20 @@ const PaperButton = ({
         onClick={onClick}
         role={role}
         disabled={disabled}
+        aria-label={`${intl.formatMessage({ id: messageID })} ${subtitleID ? intl.formatMessage({ id: subtitleID }) : ''}`}
       >
         <div className={`${classes.iconContainer} ${disabled ? classes.iconDisabled : ''}`}>
           {clonedIcon}
         </div>
         <div>
-          <Typography variant="body2" className={classes.text}>
-            {text}
+          <Typography aria-hidden variant="body2" className={classes.text}>
+            <FormattedMessage id={messageID} />
           </Typography>
           {
-            subtitle
+            subtitleID
             && (
-              <Typography variant="caption" className={classes.text}>
-                {subtitle}
+              <Typography aria-hidden variant="caption" className={classes.text}>
+                <FormattedMessage id={subtitleID} />
               </Typography>
             )
           }
@@ -46,8 +48,9 @@ PaperButton.propTypes = {
   icon: PropTypes.node,
   link: PropTypes.bool,
   onClick: PropTypes.func,
-  text: PropTypes.oneOfType([PropTypes.node, PropTypes.string]).isRequired,
-  subtitle: PropTypes.node,
+  messageID: PropTypes.string.isRequired,
+  subtitleID: PropTypes.string,
+  intl: intlShape.isRequired,
 };
 
 PaperButton.defaultProps = {
@@ -55,7 +58,7 @@ PaperButton.defaultProps = {
   icon: null,
   link: false,
   onClick: null,
-  subtitle: null,
+  subtitleID: null,
 };
 
 

--- a/src/components/PaperButton/index.js
+++ b/src/components/PaperButton/index.js
@@ -1,5 +1,6 @@
 import { withStyles } from '@material-ui/core';
+import { injectIntl } from 'react-intl';
 import PaperButton from './PaperButton';
 import styles from './styles';
 
-export default withStyles(styles)(PaperButton);
+export default injectIntl(withStyles(styles)(PaperButton));

--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -186,7 +186,7 @@ class SearchBar extends React.Component {
     const containerStyles = `${isActive ? classes.containerSticky : classes.containerInactive} ${classes.container}`;
 
     return (
-      <form onSubmit={this.onSubmit} className={containerStyles} autoComplete="off">
+      <form action="" onSubmit={this.onSubmit} className={containerStyles} autoComplete="off">
         {
           (!hideBackButton || (isActive && isMobile))
           && (
@@ -201,10 +201,10 @@ class SearchBar extends React.Component {
         <InputBase
           inputProps={{
             role: 'combobox',
-            type: 'text',
             'aria-haspopup': !!showSuggestions,
             'aria-label': intl.formatMessage({ id: 'search.searchField' }),
           }}
+          type="search"
           inputRef={(ref) => { this.searchRef = ref; }}
           className={classes.input}
           value={inputValue || ''}

--- a/src/components/ServiceMapButton/ServiceMapButton.js
+++ b/src/components/ServiceMapButton/ServiceMapButton.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { ButtonBase, Typography } from '@material-ui/core';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, intlShape } from 'react-intl';
 
 // ServiceMapButton
 const SMButton = ({
   children,
   classes,
+  intl,
   className,
   small,
   color,
@@ -24,9 +25,17 @@ const SMButton = ({
   const buttonClasses = `${classes.button} ${small ? classes.smallButton : ''} ${margin ? classes.margin : classes.marginRight} ${className} ${colorStyle}`;
   const textClasses = classes.typography;
 
+  let buttonTitle = null;
+
+  if (srText) {
+    buttonTitle = srText;
+  } else if (messageID) {
+    buttonTitle = intl.formatMessage({ id: messageID });
+  }
+
   return (
     <ButtonBase
-      aria-label={srText}
+      aria-label={buttonTitle}
       className={buttonClasses}
       icon={buttonIcon}
       onClick={onClick}
@@ -43,7 +52,7 @@ const SMButton = ({
       {
         messageID
         && (
-          <Typography color="inherit" component="p" variant="caption" className={textClasses}>
+          <Typography aria-hidden color="inherit" component="p" variant="caption" className={textClasses}>
             <FormattedMessage id={messageID} />
           </Typography>
         )
@@ -70,6 +79,7 @@ SMButton.propTypes = {
   children: PropTypes.node,
   role: PropTypes.string,
   disabled: PropTypes.bool,
+  intl: intlShape.isRequired,
 };
 
 SMButton.defaultProps = {

--- a/src/components/ServiceMapButton/index.js
+++ b/src/components/ServiceMapButton/index.js
@@ -1,5 +1,6 @@
 import { withStyles } from '@material-ui/core';
+import { injectIntl } from 'react-intl';
 import SMButton from './ServiceMapButton';
 import styles from './styles';
 
-export default withStyles(styles)(SMButton);
+export default injectIntl(withStyles(styles)(SMButton));

--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -77,6 +77,11 @@ class Settings extends React.Component {
       currentSettings: newCurrent,
       previousSettings: newCurrent,
     });
+
+    setTimeout(() => {
+      const settings = document.getElementsByClassName('SettingsTitle')[0];
+      settings.firstChild.focus();
+    }, 1);
   }
 
   componentWillUnmount() {
@@ -179,8 +184,10 @@ class Settings extends React.Component {
     const { settings } = this.props;
     setTimeout(() => {
       let elem;
-      if (settings.toggled === 'all') {
+      if (settings.toggled === 'search') {
         elem = document.getElementById('SettingsLink');
+      } else if (settings.toggled === 'mobile') {
+        elem = document.getElementById('MenuButton');
       } else {
         elem = document.getElementById(`SettingsButton${settings.toggled}`);
       }

--- a/src/components/SettingsInfo/SettingsInfo.js
+++ b/src/components/SettingsInfo/SettingsInfo.js
@@ -70,7 +70,7 @@ const SettingsInfo = ({
           aria-labelledby="SettingsInfo-srTitle"
           role="link"
           onClick={() => {
-            toggleSettings('all');
+            toggleSettings('search');
             setTimeout(() => {
               const settings = document.getElementsByClassName('SettingsTitle')[0];
               if (settings) {

--- a/src/components/TopBar/TopBar.js
+++ b/src/components/TopBar/TopBar.js
@@ -111,6 +111,7 @@ class TopBar extends React.Component {
     const { drawerOpen } = this.state;
     return (
       <Button
+        id="MenuButton"
         aria-label={intl.formatMessage({ id: drawerOpen ? 'general.menu.close' : 'general.menu.open' })}
         aria-pressed={drawerOpen}
         className={drawerOpen ? classes.toolbarButtonPressed : classes.toolbarButton}

--- a/src/components/TopBar/TopBar.js
+++ b/src/components/TopBar/TopBar.js
@@ -4,7 +4,7 @@ import {
   Button, Typography, AppBar, Toolbar, ButtonBase, NoSsr,
 } from '@material-ui/core';
 import { Map, Menu, Close } from '@material-ui/icons';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, intlShape } from 'react-intl';
 import I18n from '../../i18n';
 import HomeLogo from '../Logos/HomeLogo';
 import { DesktopComponent, MobileComponent } from '../../layouts/WrapperComponents/WrapperComponents';
@@ -107,10 +107,12 @@ class TopBar extends React.Component {
   }
 
   renderMenuButton = () => {
-    const { classes } = this.props;
+    const { classes, intl } = this.props;
     const { drawerOpen } = this.state;
     return (
       <Button
+        aria-label={intl.formatMessage({ id: drawerOpen ? 'general.menu.close' : 'general.menu.open' })}
+        aria-pressed={drawerOpen}
         className={drawerOpen ? classes.toolbarButtonPressed : classes.toolbarButton}
         classes={{ label: classes.buttonLabel }}
         onClick={() => this.toggleDrawerMenu()}
@@ -330,6 +332,7 @@ TopBar.propTypes = {
   changeTheme: PropTypes.func.isRequired,
   setMapType: PropTypes.func.isRequired,
   theme: PropTypes.string.isRequired,
+  intl: intlShape.isRequired,
 };
 
 TopBar.defaultProps = {

--- a/src/components/TopBar/index.js
+++ b/src/components/TopBar/index.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { withStyles } from '@material-ui/core';
+import { injectIntl } from 'react-intl';
 import { getLocaleString } from '../../redux/selectors/locale';
 import styles from './styles';
 import TopBar from './TopBar';
@@ -26,7 +27,7 @@ const mapStateToProps = (state) => {
   };
 };
 
-export default withRouter(withStyles(styles)(connect(
+export default injectIntl(withRouter(withStyles(styles)(connect(
   mapStateToProps,
   { changeTheme, setMapType },
-)(TopBar)));
+)(TopBar))));

--- a/src/i18n/translations/en.js
+++ b/src/i18n/translations/en.js
@@ -317,7 +317,8 @@ export default {
   'settings.mapSettings.long': 'Map setttings',
   'settings.accessibilitySettings': 'Accessibility settings',
   'settings.accessibilitySettings.long': 'Accessibility settings',
-  'settings.all.long': 'Settings',
+  'settings.mobile.long': 'Settings',
+  'settings.search.long': 'Settings',
   'settings.amount': `{count, plural,
     one {# selection}
     other {# selections}

--- a/src/i18n/translations/en.js
+++ b/src/i18n/translations/en.js
@@ -78,6 +78,8 @@ export default {
   'general.frontPage': 'Front page',
   'general.contrast': 'Contrast',
   'general.menu': 'Menu',
+  'general.menu.open': 'Open menu',
+  'general.menu.close': 'Close menu',
   'general.back': 'Back',
   'general.back.address': 'Back to address view',
   'general.back.home': 'Back to home view',

--- a/src/i18n/translations/fi.js
+++ b/src/i18n/translations/fi.js
@@ -317,7 +317,8 @@ export default {
   'settings.mapSettings.long': 'Kartta-asetukset',
   'settings.accessibilitySettings': 'Esteettömyysasetukset',
   'settings.accessibilitySettings.long': 'Esteettömyysasetukset',
-  'settings.all.long': 'Asetukset',
+  'settings.mobile.long': 'Asetukset',
+  'settings.search.long': 'Asetukset',
   'settings.amount': `{count, plural,
     one {# valinta}
     other {# valintaa}

--- a/src/i18n/translations/fi.js
+++ b/src/i18n/translations/fi.js
@@ -78,6 +78,8 @@ export default {
   'general.frontPage': 'Etusivu',
   'general.contrast': 'Kontrasti',
   'general.menu': 'Valikko',
+  'general.menu.open': 'Avaa valikko',
+  'general.menu.close': 'Sulje valikko',
   'general.back': 'Palaa',
   'general.back.address': 'Palaa osoitenäkymään',
   'general.back.home': 'Palaa aloitusnäkymään',

--- a/src/i18n/translations/sv.js
+++ b/src/i18n/translations/sv.js
@@ -78,6 +78,8 @@ export default {
   'general.frontPage': 'Första sidan',
   'general.contrast': 'Kontrast',
   'general.menu': 'Meny',
+  'general.menu.open': 'Öppna menyn', // TODO: vereify
+  'general.menu.close': 'Stäng menyn', // TODO: vereify
   'general.back': 'Tillbaka',
   'general.back.address': 'Gå tillbaka till adressvyn',
   'general.back.home': 'Gå tillbaka till startvyn',

--- a/src/i18n/translations/sv.js
+++ b/src/i18n/translations/sv.js
@@ -317,7 +317,8 @@ export default {
   'settings.mapSettings.long': 'Kartinställningar',
   'settings.accessibilitySettings': 'Tillgänglighetsinställningar',
   'settings.accessibilitySettings.long': 'Tillgänglighetsinställningar',
-  'settings.all.long': 'Inställningar',
+  'settings.mobile.long': 'Inställningar',
+  'settings.search.long': 'Inställningar',
   'settings.amount': `{count, plural,
     one {# val} 
     other {# val}

--- a/src/index.css
+++ b/src/index.css
@@ -18,6 +18,10 @@ code {
 }
 
 
+input[type="search"]::-webkit-search-cancel-button{ 
+  -webkit-appearance:none;
+} 
+
 .sr-only {
   position: absolute;
   width: 1px;

--- a/src/views/HomeView/HomeView.js
+++ b/src/views/HomeView/HomeView.js
@@ -43,7 +43,7 @@ class HomeView extends React.Component {
               messageID="home.buttons.settings"
               icon={getIcon('accessibility')}
               link
-              onClick={() => toggleSettings('all')}
+              onClick={() => toggleSettings('mobile')}
             />
           </MobileComponent>
           <PaperButton

--- a/src/views/HomeView/HomeView.js
+++ b/src/views/HomeView/HomeView.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
 import { Map } from '@material-ui/icons';
 import SearchBar from '../../components/SearchBar';
 import { MobileComponent } from '../../layouts/WrapperComponents/WrapperComponents';
@@ -24,43 +23,43 @@ class HomeView extends React.Component {
       <div className={classes.background}>
         <div className={classes.buttonContainer}>
           <PaperButton
-            text={<FormattedMessage id="home.buttons.closeByServices" />}
+            messageID="home.buttons.closeByServices"
             icon={getIcon('location')}
             link
             disabled={noUserLocation}
             onClick={() => {
               navigator.push('address', getAddressNavigatorParams(userLocation.addressData));
             }}
-            subtitle={subtitleID && <FormattedMessage id={subtitleID} />}
+            subtitleID={subtitleID && subtitleID}
           />
           <PaperButton
-            text={<FormattedMessage id="home.buttons.services" />}
+            messageID="home.buttons.services"
             icon={getIcon('serviceList')}
             link
             onClick={() => navigator.push('serviceTree')}
           />
           <MobileComponent>
             <PaperButton
-              text={<FormattedMessage id="home.buttons.settings" />}
+              messageID="home.buttons.settings"
               icon={getIcon('accessibility')}
               link
               onClick={() => toggleSettings('all')}
             />
           </MobileComponent>
           <PaperButton
-            text={<FormattedMessage id="home.send.feedback" />}
+            messageID="home.send.feedback"
             icon={getIcon('feedback')}
             link
             onClick={() => navigator.push('feedback')}
           />
           <PaperButton
-            text={<FormattedMessage id="info.title" />}
+            messageID="info.title"
             icon={getIcon('help')}
             link
             onClick={() => navigator.push('info')}
           />
           <PaperButton
-            text={<FormattedMessage id="home.old.link" />}
+            messageID="home.old.link"
             icon={<Map />}
             link
             onClick={() => {

--- a/src/views/UnitView/UnitView.js
+++ b/src/views/UnitView/UnitView.js
@@ -208,6 +208,7 @@ const UnitView = (props) => {
     <MobileComponent>
       <div className={classes.mobileButtonArea}>
         <SMButton
+          aria-hidden
           messageID="general.showOnMap"
           icon={<Map />}
           onClick={(e) => {


### PR DESCRIPTION
- Added correct aria-labeling to drawer menu button
- Modifed button components so that the text inside the button is aria-hidden, and the button itself has the text as aria-label (iOS mobile VoiceOver would only read the text inside the button ignoring the button and its state completely)
- Fixed issue with  focus disappearing from page on entering settings page
- Added aria-hidden to "show on map" -button on unit page
- Added "search" -type to search field, so that virtual keyboard has correct layout