### PR TITLE
LocalStorageUtility add try-catch to when setting localStorage

### DIFF
--- a/src/utils/localStorage.js
+++ b/src/utils/localStorage.js
@@ -4,11 +4,21 @@ const APP_KEY = 'SM';
 
 
 class LocalStorageUtility {
-  storage;
+  storage = null;
 
   static setStorage() {
-    if (isClient() && !this.storage) {
-      this.storage = window.localStorage;
+    if (!isClient()) {
+      return;
+    }
+
+    try {
+      if (!this.storage) {
+        this.storage = window.localStorage;
+      }
+    } catch (e) {
+      // Error while setting storage
+      // Can be caused by blocked cookies
+      this.storage = null;
     }
   }
 


### PR DESCRIPTION
Prevents crash when user has blocked cookies on browser.