### PR TITLE
Change PaperButton to adjust to container width

### DIFF
--- a/src/components/PaperButton/styles.js
+++ b/src/components/PaperButton/styles.js
@@ -2,8 +2,7 @@ export default theme => ({
   container: {
     flex: '0 0 auto',
     padding: 0,
-    width: '88%',
-    maxWidth: 356,
+    width: '100%',
     border: `${theme.palette.detail.alpha} solid 0.5px`,
     '&:hover': {
       backgroundColor: theme.palette.primary.main,


### PR DESCRIPTION
Fix issue with home view paper buttons not staying in line with searchbar.