### PR TITLE
Prevent map clustering from changing when list ordering is changed

### DIFF
--- a/src/redux/selectors/results.js
+++ b/src/redux/selectors/results.js
@@ -11,13 +11,14 @@ const cities = state => [
   ...state.settings.kauniainen ? ['kauniainen'] : [],
 ];
 
-export const getProcessedData = (state, options = {}) => createSelector(
-  [units, isFetching, cities],
-  (data, isFetching, cities) => {
-    // Prevent processing data if fetch is in process
-    if (isFetching) {
-      return [];
-    }
+/**
+ * Returns given data after filtering it
+ * @param {*} data - search data to be filtered
+ * @param {*} options - options for filtering - municipality: to override city setting filtering
+ */
+const getFilteredData = (data, options = {}) => createSelector(
+  [cities],
+  (cities) => {
     let filteredData = data
       .filter(filterEmptyServices(cities));
     if (options.municipality) {
@@ -25,10 +26,45 @@ export const getProcessedData = (state, options = {}) => createSelector(
     } else {
       filteredData = filteredData.filter(filterCities(cities));
     }
+    return filteredData;
+  },
+);
 
+/**
+ * Gets processed data for rendering search results
+ * @param {*} state - redux state object
+ * @param {*} options - options for filtering
+ */
+export const getProcessedData = (state, options = {}) => createSelector(
+  [units, isFetching],
+  (data, isFetching) => {
+    // Prevent processing data if fetch is in process
+    if (isFetching) {
+      return [];
+    }
+
+    const filteredData = getFilteredData(data, options)(state);
     const orderedData = getOrderedData(filteredData)(state);
+
     return orderedData;
   },
 )(state);
 
-export default getProcessedData;
+/**
+ * Get processed data for map rendering
+ * @param {*} state - redux state object
+ * @param {*} options - options for filtering
+ */
+export const getProcessedMapData = (state, options = {}) => createSelector(
+  [units, isFetching],
+  (data, isFetching) => {
+    // Prevent processing data if fetch is in process
+    if (isFetching) {
+      return [];
+    }
+
+    const filteredData = getFilteredData(data, options)(state);
+
+    return filteredData;
+  },
+)(state);

--- a/src/views/MapView/index.js
+++ b/src/views/MapView/index.js
@@ -9,7 +9,7 @@ import { setAddressLocation } from '../../redux/actions/address';
 import { findUserLocation } from '../../redux/actions/user';
 import MapView from './MapView';
 import { getServiceUnits } from '../../redux/selectors/service';
-import { getProcessedData } from '../../redux/selectors/results';
+import { getProcessedMapData } from '../../redux/selectors/results';
 import { markerClusterConnector, renderMarkerConnector } from './utils/unitMarkers';
 import { getAddressNavigatorParamsConnector } from '../../utils/address';
 import { generatePath } from '../../utils/path';
@@ -24,7 +24,7 @@ const mapStateToProps = (state, props) => {
   const {
     address, navigator, settings, user,
   } = state;
-  const unitList = getProcessedData(state);
+  const unitList = getProcessedMapData(state);
   const unitsLoading = state.service.isFetching;
   const serviceUnits = getServiceUnits(state);
   // const serviceUnits = state.service.data;


### PR DESCRIPTION
Prevent map clustering changes when unit ordering is changed by user. Previously map markers were re-rendered every time user changed the order priority for unit listing. This caused list data to change and affected the map clustering by changing cluster positions.

This solution introduces new getProcessedMapData selector which completely ignores ordering the data.