### PR TITLE
Make acessibility statement more visible

### DIFF
--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -402,7 +402,7 @@ export default {
   'settings.aria.opened': 'Settings have been opened',
   'settings.aria.saved': 'Settings have been saved',
 
-  'info.title': 'About the service',
+  'info.title': 'About the service and accessibility statement',
   'info.statement': 'Accessibility statement',
 
   'alert.close': 'Close the notification',

--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -402,7 +402,7 @@ export default {
   'settings.aria.opened': 'Asetukset avattu',
   'settings.aria.saved': 'Asetukset on tallennettu',
 
-  'info.title': 'Tietoa palvelusta',
+  'info.title': 'Tietoa palvelusta ja saavutettavuusseloste',
   'info.statement': 'Saavutettavuusseloste',
 
   'alert.close': 'Sulje ilmoitus',

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -402,7 +402,7 @@ export default {
   'settings.aria.opened': 'Inställningarna har öppnats',
   'settings.aria.saved': 'Inställningarna har sparats',
 
-  'info.title': 'Om tjänsten',
+  'info.title': 'Om tjänsten och tillgänglighetsredogörelsen',
   'info.statement': 'Tillgänglighetsredogörelsen',
 
   'alert.close': 'Stäng meddelande',

--- a/src/views/InfoView/InfoView.js
+++ b/src/views/InfoView/InfoView.js
@@ -26,6 +26,10 @@ const InfoView = ({
   );
   const renderFinnishInfo = () => (
     <div className={classes.textContainer}>
+      <Typography component="h3" variant="body2">Palvelukartan saavutettavuus</Typography>
+      <ButtonBase className={classes.linkButton} role="link" onClick={() => handleClick()}>
+        <Typography color="inherit" variant="body2"><FormattedMessage id="info.statement" /></Typography>
+      </ButtonBase>
       <Typography component="h3" variant="body2"><FormattedMessage id="app.title" /></Typography>
       <Typography className={classes.text} variant="body2">
         Palvelukartalta löydät Espoon, Helsingin, Kauniaisten, Vantaan julkiset toimipisteet ja niiden palvelut.
@@ -163,10 +167,6 @@ const InfoView = ({
         then the background map will automatically change into a high-contrast background map. You can change
         the background map in the settings.
       </Typography> */}
-      <Typography component="h3" variant="body2">Palvelukartan saavutettavuus</Typography>
-      <ButtonBase className={classes.linkButton} role="link" onClick={() => handleClick()}>
-        <Typography color="inherit" variant="body2"><FormattedMessage id="info.statement" /></Typography>
-      </ButtonBase>
       <Typography component="h3" variant="body2">Palaute</Typography>
       <Typography className={classes.text} variant="body2">
         Kiitämme kaikesta palautteesta, jotta voimme kehittää Palvelukarttaa yhä paremmaksi.
@@ -315,6 +315,10 @@ const InfoView = ({
 
   const renderEnglishInfo = () => (
     <div className={classes.textContainer}>
+      <Typography component="h3" variant="body2">Accessibility of the Service Map</Typography>
+      <ButtonBase className={classes.linkButton} role="link" onClick={() => handleClick()}>
+        <Typography color="inherit" variant="body2"><FormattedMessage id="info.statement" /></Typography>
+      </ButtonBase>
       <Typography component="h3" variant="body2"><FormattedMessage id="app.title" /></Typography>
       <Typography className={classes.text} variant="body2">
         On the Service Map, you can find the public services units of the cities of Espoo, Helsinki, Kauniainen and
@@ -437,10 +441,6 @@ const InfoView = ({
         then the background map will automatically change into a high-contrast background map. You can change
         the background map in the settings.
       </Typography>
-      <Typography component="h3" variant="body2">Accessibility of the Service Map</Typography>
-      <ButtonBase className={classes.linkButton} role="link" onClick={() => handleClick()}>
-        <Typography color="inherit" variant="body2"><FormattedMessage id="info.statement" /></Typography>
-      </ButtonBase>
       <Typography component="h3" variant="body2">Feedback</Typography>
       <Typography className={classes.text} variant="body2">
         We thank you for all feedback, in order for us to be able to make the Service Map even better.
@@ -607,6 +607,10 @@ const InfoView = ({
 
   const renderSwedishInfo = () => (
     <div className={classes.textContainer}>
+      <Typography component="h3" variant="body2">Servicekartans tillgänglighet</Typography>
+      <ButtonBase className={classes.linkButton} role="link" onClick={() => handleClick()}>
+        <Typography color="inherit" variant="body2"><FormattedMessage id="info.statement" /></Typography>
+      </ButtonBase>
       <Typography component="h3" variant="body2"><FormattedMessage id="app.title" /></Typography>
       <Typography className={classes.text} variant="body2">
         På Servicekartan hittar du offentliga verksamhetsställen och service i Esbo, Grankulla, Helsingfors och
@@ -723,10 +727,6 @@ const InfoView = ({
         then the background map will automatically change into a high-contrast background map. You can change
         the background map in the settings.
       </Typography> */}
-      <Typography component="h3" variant="body2">Servicekartans tillgänglighet</Typography>
-      <ButtonBase className={classes.linkButton} role="link" onClick={() => handleClick()}>
-        <Typography color="inherit" variant="body2"><FormattedMessage id="info.statement" /></Typography>
-      </ButtonBase>
       <Typography component="h3" variant="body2">Respons</Typography>
       <Typography className={classes.text} variant="body2">
         Vi tackar för all respons som hjälper oss att göra Servicekartan ännu bättre.


### PR DESCRIPTION
Update title on front page and move link location to top of info view. Possibly temporary solution.