### PR TITLE
Download tool + memoized selector refactor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10121,8 +10121,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -10140,13 +10139,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -10159,18 +10156,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -10273,8 +10267,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -10284,7 +10277,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -10297,20 +10289,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -10327,7 +10316,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -10400,8 +10388,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -10411,7 +10398,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -10487,8 +10473,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -10518,7 +10503,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -10536,7 +10520,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -10575,13 +10558,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -19221,16 +19202,35 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-redux": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-6.0.1.tgz",
-      "integrity": "sha512-T52I52Kxhbqy/6TEfBv85rQSDz6+Y28V/pf52vDWs1YRXG19mcFOGfHnY2HsNFHyhP+ST34Aih98fvt6tqwVcQ==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.1.tgz",
+      "integrity": "sha512-T+VfD/bvgGTUA74iW9d2i5THrDQWbweXP0AVNI8tNd1Rk5ch1rnMiJkDD67ejw7YBKM4+REvcvqRuWJb7BLuEg==",
       "requires": {
-        "@babel/runtime": "^7.3.1",
+        "@babel/runtime": "^7.5.5",
         "hoist-non-react-statics": "^3.3.0",
-        "invariant": "^2.2.4",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.7.2",
-        "react-is": "^16.8.2"
+        "react-is": "^16.9.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+          "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+        }
       }
     },
     "react-router": {
@@ -19553,8 +19553,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -19572,13 +19571,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -19591,18 +19588,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -19705,8 +19699,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -19716,7 +19709,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -19729,20 +19721,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.2.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.1",
                 "yallist": "^3.0.0"
@@ -19759,7 +19748,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -19832,8 +19820,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -19843,7 +19830,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -19919,8 +19905,7 @@
             },
             "safe-buffer": {
               "version": "5.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -19950,7 +19935,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -19968,7 +19952,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -20007,13 +19990,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "react-jss": "^8.6.1",
     "react-leaflet": "^2.4.0",
     "react-leaflet-control": "^2.1.2",
-    "react-redux": "^6.0.0",
+    "react-redux": "^7.2.1",
     "react-router-dom": "^5.1.2",
     "react-scripts": "^2.1.8",
     "redux": "^4.0.1",

--- a/src/components/DropDownMenuButton/DropDownMenuButton.js
+++ b/src/components/DropDownMenuButton/DropDownMenuButton.js
@@ -60,7 +60,9 @@ class DropDownMenuButton extends React.Component {
   }
 
   render() {
-    const { buttonIcon, buttonText, classes, panelID } = this.props;
+    const {
+      buttonIcon, buttonText, classes, panelID,
+    } = this.props;
     const { open } = this.state;
     const arrowIcon = open
       ? <ArrowDropUp className={classes.iconRight} />
@@ -72,7 +74,7 @@ class DropDownMenuButton extends React.Component {
           buttonRef={(node) => {
             this.anchorEl = node;
           }}
-          aria-controls={panelID}
+          aria-controls={open ? panelID : undefined}
           aria-haspopup="true"
           aria-expanded={open}
           onClick={this.handleToggle}

--- a/src/components/DropDownMenuButton/styles.js
+++ b/src/components/DropDownMenuButton/styles.js
@@ -4,10 +4,14 @@ export default theme => ({
     alignItems: 'center',
     display: 'block',
     height: '100%',
+    width: 230,
+    marginRight: theme.spacing.unitDouble,
   },
   button: {
     height: '100%',
-    marginRight: theme.spacing.unit,
+    width: '100%',
+    paddingLeft: theme.spacing.unit,
+    paddingRight: theme.spacing.unitDouble,
     '& p': {
       marginRight: theme.spacing.unitDouble,
       textTransform: 'none',
@@ -31,24 +35,26 @@ export default theme => ({
     },
   },
   iconRight: {
-    marginLeft: theme.spacing.unitDouble,
+    marginLeft: 'auto',
     fontSize: 24,
   },
   menuItem: {
-    // display: 'flex',
+    justifyContent: 'start',
     flex: '1 0 auto',
     alignItems: 'center',
     cursor: 'pointer',
     ...theme.typography.body2,
     // Icon element
     '& span': {
+      display: 'flex',
+      justifyContent: 'center',
       width: 32,
       margin: theme.spacing.unit,
       marginRight: theme.spacing.unitDouble,
     },
     // Text element
     '& p': {
-      marginRight: theme.spacing.unitDouble,
+      textAlign: 'left',
       textTransform: 'none',
       fontWeight: 'normal',
     },
@@ -58,14 +64,15 @@ export default theme => ({
   },
   menuPanel: {
     display: 'flex',
+    flexDirection: 'column',
     position: 'absolute',
-    width: '185px',
-    marginLeft: '5px',
-    borderWidth: 'thin',
-    borderColor: 'black',
-    borderStyle: 'none',
+    width: 'inherit',
+    padding: theme.spacing.unit,
+    boxSizing: 'border-box',
     backgroundColor: 'white',
     color: 'black',
     zIndex: 2,
+    border: `${theme.palette.detail.alpha} solid 0.5px`,
+    borderRadius: 4,
   },
 });

--- a/src/components/ListItems/UnitItem/index.js
+++ b/src/components/ListItems/UnitItem/index.js
@@ -6,7 +6,7 @@ import UnitItem from './UnitItem';
 import { getLocaleString } from '../../../redux/selectors/locale';
 import { changeSelectedUnit } from '../../../redux/actions/selectedUnit';
 import styles from './styles';
-import { calculateDistance } from '../../../redux/selectors/unit';
+import { calculateDistance, getCurrentlyUsedPosition } from '../../../redux/selectors/unit';
 import { formatDistanceObject } from '../../../utils';
 
 // Listen to redux state
@@ -19,7 +19,7 @@ const mapStateToProps = (state, props) => {
     navigator, settings,
   } = state;
   return {
-    distance: formatDistanceObject(intl, calculateDistance(state)(unit)),
+    distance: formatDistanceObject(intl, calculateDistance(unit, getCurrentlyUsedPosition(state))),
     getLocaleText,
     navigator,
     settings,

--- a/src/components/ToolMenu/ToolMenu.js
+++ b/src/components/ToolMenu/ToolMenu.js
@@ -1,11 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Build } from '@material-ui/icons';
+import {
+  Build, GetApp,
+} from '@material-ui/icons';
 import DropDownMenuButton from '../DropDownMenuButton';
+import useDownloadData from '../../utils/downloadData';
 
 const ToolMenu = ({
-  intl
+  intl,
 }) => {
+  const downloadToolData = useDownloadData();
   const menuItems = [
     // Example shape
     // {
@@ -17,6 +21,18 @@ const ToolMenu = ({
     //   },
     //   srText: intl.formatMessage({ id: 'general.open' }),
     // },
+    {
+      key: 'downloadTool',
+      text: intl.formatMessage({ id: 'tool.download' }),
+      icon: <GetApp />,
+      onClick: () => {
+        const content = JSON.stringify(downloadToolData, null, 2);
+        const tab = window.open();
+        tab.document.open();
+        tab.document.write(`<html><body><pre style="white-space: pre;">${content}</pre></body></html>`);
+        tab.document.close();
+      },
+    },
   ];
   const toolMenuText = intl.formatMessage({ id: 'general.tools' });
 

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -404,6 +404,9 @@ export default {
   'settings.aria.opened': 'Settings have been opened',
   'settings.aria.saved': 'Settings have been saved',
 
+  // Tools
+  'tool.download': 'Download data (new tab)',
+
   'info.title': 'About the service and accessibility statement',
   'info.statement': 'Accessibility statement',
 

--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -404,6 +404,9 @@ export default {
   'settings.aria.opened': 'Asetukset avattu',
   'settings.aria.saved': 'Asetukset on tallennettu',
 
+  // Tools
+  'tool.download': 'Lataa tiedot (uusi välilehti)',
+
   'info.title': 'Tietoa palvelusta ja saavutettavuusseloste',
   'info.statement': 'Saavutettavuusseloste',
 

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -404,6 +404,9 @@ export default {
   'settings.aria.opened': 'Inställningarna har öppnats',
   'settings.aria.saved': 'Inställningarna har sparats',
 
+  // Tools
+  'tool.download': 'Exportera (ny flik)',
+
   'info.title': 'Om tjänsten och tillgänglighetsredogörelsen',
   'info.statement': 'Tillgänglighetsredogörelsen',
 

--- a/src/redux/selectors/ordering.js
+++ b/src/redux/selectors/ordering.js
@@ -1,100 +1,19 @@
 import { createSelector } from 'reselect';
-import { getLocaleString } from './locale';
-import UnitHelper from '../../utils/unitHelper';
-import { calculateDistance } from './unit';
+import { getCurrentlyUsedPosition } from './unit';
 
 const direction = state => state.sort.direction;
 const order = state => state.sort.order;
 const locale = state => state.user.locale;
 const settings = state => state.settings;
-// Return function that accepts unit as parameter
-const calculateDistanceFunc = state => calculateDistance(state);
 
-const getOrderedData = data => createSelector(
-  [calculateDistanceFunc, direction, order, locale, settings],
-  (calculateDistanceFunc, direction, order, locale, settings) => {
-    if (!data) {
-      throw new Error('Invalid data provided to getOrderedData selector');
+// Get parameters that are used in sorting units.
+const getSortingParameters = createSelector(
+  [getCurrentlyUsedPosition, direction, order, locale, settings],
+  (usedPosition, direction, order, locale, settings) => (
+    {
+      usedPosition, direction, order, locale, settings,
     }
-    let results = Array.from(data);
-
-    switch (order) {
-    // Accessibility
-      case 'accessibility': {
-        results.forEach((element) => {
-        // eslint-disable-next-line no-param-reassign
-          element.shorcomingCount = UnitHelper.getShortcomingCount(element, settings);
-        });
-        results.sort((a, b) => {
-          if (a.object_type !== 'unit' || b.object_type !== 'unit') {
-            return 0;
-          }
-          const aSC = a.shorcomingCount;
-          const bSC = b.shorcomingCount;
-
-          if (aSC === null || (aSC === null && bSC === null)) { return -1; }
-          if (bSC === null) { return 1; }
-          if (aSC > bSC) { return -1; }
-          if (aSC < bSC) { return 1; }
-          return 0;
-        });
-
-        // If reversed alphabetical ordering
-        if (direction === 'desc') {
-          results.reverse();
-        }
-        break;
-      }
-      // Alphabetical ordering
-      case 'alphabetical': {
-        results.sort((a, b) => {
-          const x = getLocaleString(locale, a.name || a.street.name).toLowerCase();
-          const y = getLocaleString(locale, b.name || b.street.name).toLowerCase();
-          if (x > y) { return -1; }
-          if (x < y) { return 1; }
-          return 0;
-        });
-
-        // If reversed alphabetical ordering
-        if (direction === 'desc') {
-          results.reverse();
-        }
-        break;
-      }
-      case 'distance': {
-        const unitsWithoutLocation = results.filter(unit => unit.location === null);
-        const filteredLsit = results.filter(unit => unit.location !== null);
-        filteredLsit.forEach((element) => {
-        // eslint-disable-next-line no-param-reassign
-          element.distanceFromUser = calculateDistanceFunc(element);
-        });
-        filteredLsit.sort((a, b) => {
-          const aDistance = a.distanceFromUser;
-          const bDistance = b.distanceFromUser;
-          if (aDistance < bDistance) return -1;
-          if (aDistance > bDistance) return 1;
-          return 0;
-        });
-
-        // If reversed distance ordering
-        if (direction === 'desc') {
-          filteredLsit.reverse();
-        }
-
-        results = [...filteredLsit, ...unitsWithoutLocation];
-        break;
-      }
-      // Ordering based on match score
-      case 'match': {
-      // Using sort_index with assumption that default sort from API is relevance
-        results.sort((a, b) => (direction === 'asc' ? b.sort_index - a.sort_index : a.sort_index - b.sort_index));
-        break;
-      }
-      default:
-    }
-
-    return results;
-  },
+  ),
 );
 
-export default getOrderedData;
+export default getSortingParameters;

--- a/src/redux/selectors/results.js
+++ b/src/redux/selectors/results.js
@@ -1,70 +1,66 @@
 import { createSelector } from 'reselect';
 import { filterEmptyServices, filterCities } from '../../utils/filters';
-import getOrderedData from './ordering';
+import isClient from '../../utils';
+import orderUnits from '../../utils/orderUnits';
+import getSortingParameters from './ordering';
 
 const isFetching = state => state.units.isFetching;
 const units = state => state.units.data;
-const cities = state => [
-  ...state.settings.helsinki ? ['helsinki'] : [],
-  ...state.settings.vantaa ? ['vantaa'] : [],
-  ...state.settings.espoo ? ['espoo'] : [],
-  ...state.settings.kauniainen ? ['kauniainen'] : [],
-];
+const settings = state => state.settings;
 
 /**
  * Returns given data after filtering it
  * @param {*} data - search data to be filtered
  * @param {*} options - options for filtering - municipality: to override city setting filtering
+ * @param {*} settings - user settings, used in filtering
  */
-const getFilteredData = (data, options = {}) => createSelector(
-  [cities],
-  (cities) => {
-    let filteredData = data
-      .filter(filterEmptyServices(cities));
-    if (options.municipality) {
-      filteredData = filteredData.filter(filterCities(options.municipality.split(',')));
-    } else {
-      filteredData = filteredData.filter(filterCities(cities));
+const getFilteredData = (data, options, settings) => {
+  const cities = [
+    ...settings.helsinki ? ['helsinki'] : [],
+    ...settings.vantaa ? ['vantaa'] : [],
+    ...settings.espoo ? ['espoo'] : [],
+    ...settings.kauniainen ? ['kauniainen'] : [],
+  ];
+  let filteredData = data
+    .filter(filterEmptyServices(cities));
+  if (options && options.municipality) {
+    filteredData = filteredData.filter(filterCities(options.municipality.split(',')));
+  } else {
+    filteredData = filteredData.filter(filterCities(cities));
+  }
+  return filteredData;
+};
+
+/**
+ * Gets unordered processed result data for rendering search results
+ */
+export const getProcessedData = createSelector(
+  [units, isFetching, settings],
+  (data, isFetching, settings) => {
+    // Prevent processing data if fetch is in process
+    if (isFetching) return [];
+
+    const options = {};
+    const overrideMunicipality = isClient() && new URLSearchParams().get('municipality');
+    if (overrideMunicipality) {
+      options.municipality = overrideMunicipality;
     }
+
+    const filteredData = getFilteredData(data, options, settings);
     return filteredData;
   },
 );
 
 /**
- * Gets processed data for rendering search results
- * @param {*} state - redux state object
- * @param {*} options - options for filtering
+ * Gets ordered processed result data for rendering search results
  */
-export const getProcessedData = (state, options = {}) => createSelector(
-  [units, isFetching],
-  (data, isFetching) => {
-    // Prevent processing data if fetch is in process
-    if (isFetching) {
-      return [];
+export const getOrderedData = createSelector(
+  [getProcessedData, getSortingParameters],
+  (unitData, sortingParameters) => {
+    if (!unitData) {
+      throw new Error('Invalid data provided to getOrderedData selector');
     }
-
-    const filteredData = getFilteredData(data, options)(state);
-    const orderedData = getOrderedData(filteredData)(state);
-
-    return orderedData;
+    const orderedUnits = orderUnits(unitData, sortingParameters);
+    return orderedUnits;
   },
-)(state);
-
-/**
- * Get processed data for map rendering
- * @param {*} state - redux state object
- * @param {*} options - options for filtering
- */
-export const getProcessedMapData = (state, options = {}) => createSelector(
-  [units, isFetching],
-  (data, isFetching) => {
-    // Prevent processing data if fetch is in process
-    if (isFetching) {
-      return [];
-    }
-
-    const filteredData = getFilteredData(data, options)(state);
-
-    return filteredData;
-  },
-)(state);
+);

--- a/src/redux/selectors/service.js
+++ b/src/redux/selectors/service.js
@@ -1,23 +1,25 @@
 import { createSelector } from 'reselect';
 import { filterCities } from '../../utils/filters';
-import getOrderedData from './ordering';
+import getSortingParameters from './ordering';
+import orderUnits from '../../utils/orderUnits';
 
 
-const units = state => state.service.data;
-const cities = state => [
-  ...state.settings.helsinki ? ['helsinki'] : [],
-  ...state.settings.vantaa ? ['vantaa'] : [],
-  ...state.settings.espoo ? ['espoo'] : [],
-  ...state.settings.kauniainen ? ['kauniainen'] : [],
-];
+const getUnits = state => state.service.data;
+const getSettings = state => state.settings;
 
-export const getServiceUnits = state => createSelector(
-  [units, cities],
-  (units, cities) => {
+export const getServiceUnits = createSelector(
+  [getUnits, getSettings, getSortingParameters],
+  (units, settings, sortingParameters) => {
+    const cities = [
+      ...settings.helsinki ? ['helsinki'] : [],
+      ...settings.vantaa ? ['vantaa'] : [],
+      ...settings.espoo ? ['espoo'] : [],
+      ...settings.kauniainen ? ['kauniainen'] : [],
+    ];
     const filteredUnits = units.filter(filterCities(cities, true));
-    const orderedUnits = getOrderedData(filteredUnits)(state);
+    const orderedUnits = orderUnits(filteredUnits, sortingParameters);
     return orderedUnits;
   },
-)(state);
+);
 
 export default { getServiceUnits };

--- a/src/redux/selectors/unit.js
+++ b/src/redux/selectors/unit.js
@@ -1,31 +1,30 @@
+import { createSelector } from 'reselect';
+
 const getCustomPosition = state => state.user.customPosition.coordinates;
 const getUserPosition = state => state.user.position.coordinates;
 const getAddress = state => state.address;
 const getCurrentPage = state => state.user.page;
 
-export const getCurrentlyUsedPosition = (state) => {
-  const customPosition = getCustomPosition(state);
-  const userPosition = getUserPosition(state);
-  const address = getAddress(state);
-  const currentPage = getCurrentPage(state);
+export const getCurrentlyUsedPosition = createSelector(
+  [getCustomPosition, getUserPosition, getAddress, getCurrentPage],
+  (customPosition, userPosition, address, currentPage) => {
+    const addressPosition = currentPage === 'address' && address && address.addressCoordinates ? {
+      latitude: address.addressCoordinates[1],
+      longitude: address.addressCoordinates[0],
+    } : null;
 
-  const addressPosition = currentPage === 'address' && address && address.addressCoordinates ? {
-    latitude: address.addressCoordinates[1],
-    longitude: address.addressCoordinates[0],
-  } : null;
+    const usedPosition = customPosition || addressPosition || userPosition;
+    if (usedPosition && usedPosition.latitude && usedPosition.longitude) {
+      return usedPosition;
+    }
+    return null;
+  },
+);
 
-  const usedPosition = customPosition || addressPosition || userPosition;
-  if (usedPosition && usedPosition.latitude && usedPosition.longitude) {
-    return usedPosition;
-  }
-  return null;
-};
-
-export const calculateDistance = state => (unit) => {
+export const calculateDistance = (unit, usedPosition) => {
   if (!unit || !unit.location) {
     return null;
   }
-  const usedPosition = getCurrentlyUsedPosition(state);
 
   if (!usedPosition) {
     return null;

--- a/src/utils/downloadData.js
+++ b/src/utils/downloadData.js
@@ -2,7 +2,7 @@ import { useSelector } from 'react-redux';
 import { getOrderedData } from '../redux/selectors/results';
 import { getServiceUnits } from '../redux/selectors/service';
 
-// Cutom hook that returns correct set of data for download data tool
+// Custom hook that returns correct set of data for download data tool
 const useDownloadData = () => {
   let selector;
   const page = useSelector(state => state.user.page);

--- a/src/utils/downloadData.js
+++ b/src/utils/downloadData.js
@@ -1,0 +1,28 @@
+import { useSelector } from 'react-redux';
+import { getOrderedData } from '../redux/selectors/results';
+import { getServiceUnits } from '../redux/selectors/service';
+
+// Returns correct set of data for download data tool
+const useDownloadData = (page) => {
+  let selector;
+  switch (page) {
+    case 'search':
+      selector = getOrderedData;
+      break;
+    case 'unit':
+      selector = state => state.selectedUnit.unit.data;
+      break;
+    case 'service':
+      selector = getServiceUnits;
+      break;
+    case 'address':
+      selector = state => state.address.units;
+      break;
+    default:
+      selector = () => [];
+      break;
+  }
+  return useSelector(selector);
+};
+
+export default useDownloadData;

--- a/src/utils/downloadData.js
+++ b/src/utils/downloadData.js
@@ -2,9 +2,10 @@ import { useSelector } from 'react-redux';
 import { getOrderedData } from '../redux/selectors/results';
 import { getServiceUnits } from '../redux/selectors/service';
 
-// Returns correct set of data for download data tool
-const useDownloadData = (page) => {
+// Cutom hook that returns correct set of data for download data tool
+const useDownloadData = () => {
   let selector;
+  const page = useSelector(state => state.user.page);
   switch (page) {
     case 'search':
       selector = getOrderedData;

--- a/src/utils/orderUnits.js
+++ b/src/utils/orderUnits.js
@@ -1,0 +1,90 @@
+import UnitHelper from './unitHelper';
+import { getLocaleString } from '../redux/selectors/locale';
+import { calculateDistance } from '../redux/selectors/unit';
+
+const orderUnits = (unitData, sortingParameters) => {
+  const {
+    usedPosition, direction, order, locale, settings,
+  } = sortingParameters;
+
+  let results = Array.from(unitData);
+
+  switch (order) {
+    // Accessibility
+    case 'accessibility': {
+      results.forEach((element) => {
+        // eslint-disable-next-line no-param-reassign
+        element.shorcomingCount = UnitHelper.getShortcomingCount(element, settings);
+      });
+      results.sort((a, b) => {
+        if (a.object_type !== 'unit' || b.object_type !== 'unit') {
+          return 0;
+        }
+        const aSC = a.shorcomingCount;
+        const bSC = b.shorcomingCount;
+
+        if (aSC === null || (aSC === null && bSC === null)) { return -1; }
+        if (bSC === null) { return 1; }
+        if (aSC > bSC) { return -1; }
+        if (aSC < bSC) { return 1; }
+        return 0;
+      });
+
+      // If reversed alphabetical ordering
+      if (direction === 'desc') {
+        results.reverse();
+      }
+      break;
+    }
+    // Alphabetical ordering
+    case 'alphabetical': {
+      results.sort((a, b) => {
+        const x = getLocaleString(locale, a.name || a.street.name).toLowerCase();
+        const y = getLocaleString(locale, b.name || b.street.name).toLowerCase();
+        if (x > y) { return -1; }
+        if (x < y) { return 1; }
+        return 0;
+      });
+
+      // If reversed alphabetical ordering
+      if (direction === 'desc') {
+        results.reverse();
+      }
+      break;
+    }
+    case 'distance': {
+      const unitsWithoutLocation = results.filter(unit => unit.location === null);
+      const filteredLsit = results.filter(unit => unit.location !== null);
+      filteredLsit.forEach((element) => {
+        // eslint-disable-next-line no-param-reassign
+        element.distanceFromUser = calculateDistance(element, usedPosition);
+      });
+      filteredLsit.sort((a, b) => {
+        const aDistance = a.distanceFromUser;
+        const bDistance = b.distanceFromUser;
+        if (aDistance < bDistance) return -1;
+        if (aDistance > bDistance) return 1;
+        return 0;
+      });
+
+      // If reversed distance ordering
+      if (direction === 'desc') {
+        filteredLsit.reverse();
+      }
+
+      results = [...filteredLsit, ...unitsWithoutLocation];
+      break;
+    }
+    // Ordering based on match score
+    case 'match': {
+      // Using sort_index with assumption that default sort from API is relevance
+      results.sort((a, b) => (direction === 'asc' ? b.sort_index - a.sort_index : a.sort_index - b.sort_index));
+      break;
+    }
+    default:
+  }
+
+  return results;
+};
+
+export default orderUnits;

--- a/src/views/AddressView/index.js
+++ b/src/views/AddressView/index.js
@@ -15,7 +15,7 @@ import styles from './styles';
 import AddressView from './AddressView';
 import { getAddressNavigatorParamsConnector } from '../../utils/address';
 import { formatDistanceObject } from '../../utils';
-import { calculateDistance } from '../../redux/selectors/unit';
+import { calculateDistance, getCurrentlyUsedPosition } from '../../redux/selectors/unit';
 
 const mapStateToProps = (state, props) => {
   const {
@@ -25,7 +25,8 @@ const mapStateToProps = (state, props) => {
   const getLocaleText = textObject => getLocaleString(state, textObject);
   const { address, user, navigator } = state;
   const getAddressNavigatorParams = getAddressNavigatorParamsConnector(getLocaleText, user.locale);
-  const getDistance = unit => formatDistanceObject(intl, calculateDistance(state)(unit));
+  const currentPosition = getCurrentlyUsedPosition(state);
+  const getDistance = unit => formatDistanceObject(intl, calculateDistance(unit, currentPosition));
   const { units, adminDistricts } = address;
   return {
     addressData: address.addressData,

--- a/src/views/AddressView/utils/fetchAddressUnits.js
+++ b/src/views/AddressView/utils/fetchAddressUnits.js
@@ -6,6 +6,8 @@ const fetchAddressUnits = async (lnglat) => {
     lon: `${lnglat[0]}`,
     distance: 500,
     only: 'name,location,accessibility_shortcoming_count,',
+    include: '',
+    geometry: false,
     page: 1,
     page_size: 500,
   };

--- a/src/views/AddressView/utils/fetchAddressUnits.js
+++ b/src/views/AddressView/utils/fetchAddressUnits.js
@@ -6,7 +6,6 @@ const fetchAddressUnits = async (lnglat) => {
     lon: `${lnglat[0]}`,
     distance: 500,
     only: 'name,location,accessibility_shortcoming_count,',
-    include: '',
     geometry: false,
     page: 1,
     page_size: 500,

--- a/src/views/EventDetailView/EventDetailView.js
+++ b/src/views/EventDetailView/EventDetailView.js
@@ -74,7 +74,7 @@ class EventDetailView extends React.Component {
       map,
     } = this.props;
     const { centered } = this.state;
-    if (unit && unit.location && map && map._layersMaxZoom && !centered) {
+    if (unit && unit.location && map && map.options.maxZoom && !centered) {
       const { location } = unit;
       this.setState({ centered: true });
       focusToPosition(map, location.coordinates);

--- a/src/views/MapView/MapView.js
+++ b/src/views/MapView/MapView.js
@@ -7,7 +7,7 @@ import { MyLocation, LocationDisabled } from '@material-ui/icons';
 import { mapOptions } from './config/mapConfig';
 import CreateMap from './utils/createMap';
 import UnitMarkers from './components/UnitMarkers';
-import { focusToPosition } from './utils/mapActions';
+import { focusToPosition, fitUnitsToMap } from './utils/mapActions';
 import styles from './styles';
 import Districts from './components/Districts';
 import TransitStops from './components/TransitStops';
@@ -70,7 +70,10 @@ const MapView = (props) => {
     let mapUnits = [];
     let unitGeometry = null;
 
-    if (currentPage === 'home' || currentPage === 'search' || currentPage === 'division') {
+    if (currentPage === 'home' && embeded) {
+      mapUnits = unitList;
+    }
+    if (currentPage === 'search' || currentPage === 'division') {
       mapUnits = unitList;
     } else if (currentPage === 'address') {
       switch (addressToRender) {
@@ -96,6 +99,8 @@ const MapView = (props) => {
         unitGeometry = coordinates;
       }
     }
+
+    if (mapRef.current) fitUnitsToMap(mapUnits, mapRef.current.leafletElement);
 
     const data = { units: mapUnits, unitGeometry };
 
@@ -282,7 +287,13 @@ const MapView = (props) => {
     if (map) {
       renderUnitMarkers(leaflet, map, data, classes, markerCluster, embeded);
     }
-  }, [unitList, highlightedUnit, markerCluster, addressUnits, serviceUnits, highlightedDistrict]);
+  }, [unitList,
+    highlightedUnit,
+    markerCluster,
+    addressUnits,
+    serviceUnits,
+    highlightedDistrict,
+    currentPage]);
 
   // Render
 

--- a/src/views/MapView/index.js
+++ b/src/views/MapView/index.js
@@ -39,7 +39,9 @@ const mapStateToProps = (state, props) => {
   const getPath = (id, data) => generatePath(id, locale, data);
   const distanceCoordinates = getCurrentlyUsedPosition(state);
   const userLocation = customPosition.coordinates || position.coordinates;
-  const getDistance = unit => formatDistanceObject(intl, calculateDistance(state)(unit));
+  const getDistance = unit => (
+    formatDistanceObject(intl, calculateDistance(unit, distanceCoordinates))
+  );
   return {
     addressUnits: units,
     addressToRender: toRender,

--- a/src/views/MapView/index.js
+++ b/src/views/MapView/index.js
@@ -9,7 +9,7 @@ import { setAddressLocation } from '../../redux/actions/address';
 import { findUserLocation } from '../../redux/actions/user';
 import MapView from './MapView';
 import { getServiceUnits } from '../../redux/selectors/service';
-import { getProcessedMapData } from '../../redux/selectors/results';
+import { getProcessedData } from '../../redux/selectors/results';
 import { markerClusterConnector, renderMarkerConnector } from './utils/unitMarkers';
 import { getAddressNavigatorParamsConnector } from '../../utils/address';
 import { generatePath } from '../../utils/path';
@@ -24,7 +24,7 @@ const mapStateToProps = (state, props) => {
   const {
     address, navigator, settings, user,
   } = state;
-  const unitList = getProcessedMapData(state);
+  const unitList = getProcessedData(state);
   const unitsLoading = state.service.isFetching;
   const serviceUnits = getServiceUnits(state);
   // const serviceUnits = state.service.data;

--- a/src/views/MapView/utils/mapActions.js
+++ b/src/views/MapView/utils/mapActions.js
@@ -7,6 +7,7 @@ const fitUnitsToMap = (units, map) => {
 
   const corner1 = map.options.maxBounds.getNorthWest();
   const corner2 = map.options.maxBounds.getSouthEast();
+  const { maxZoom } = map.options;
 
   const mapBounds = new L.LatLngBounds([
     [corner1.lat, corner1.lng],
@@ -24,13 +25,13 @@ const fitUnitsToMap = (units, map) => {
     }
   });
   if (bounds.length > 0) {
-    map.fitBounds(bounds, { padding: [15, 15], maxZoom: map._layersMaxZoom - 1 });
+    map.fitBounds(bounds, { padding: [15, 15], maxZoom: maxZoom - 1 });
   }
 };
 
 
 const focusToPosition = (map, coordinates, zoomOption) => {
-  const zoom = typeof zoomOption === 'number' ? zoomOption : map._layersMaxZoom - 1;
+  const zoom = typeof zoomOption === 'number' ? zoomOption : map.options.maxZoom - 1;
   map.setView(
     [coordinates[1], coordinates[0]],
     zoom,

--- a/src/views/SearchView/SearchView.js
+++ b/src/views/SearchView/SearchView.js
@@ -215,7 +215,7 @@ class SearchView extends React.Component {
     if (getSearchParam(location, 'bbox')) {
       return;
     }
-    if (map && map._layersMaxZoom) {
+    if (map && map.options.maxZoom) {
       fitUnitsToMap(units, map);
     }
   }

--- a/src/views/SearchView/index.js
+++ b/src/views/SearchView/index.js
@@ -3,8 +3,7 @@ import SearchView from './SearchView';
 import { fetchUnits } from '../../redux/actions/unit';
 import fetchRedirectService from '../../redux/actions/redirectService';
 import { changeSelectedUnit } from '../../redux/actions/selectedUnit';
-import { getProcessedData } from '../../redux/selectors/results';
-import isClient from '../../utils';
+import { getOrderedData } from '../../redux/selectors/results';
 import { getLocaleString } from '../../redux/selectors/locale';
 import { getAddressNavigatorParamsConnector } from '../../utils/address';
 
@@ -18,12 +17,7 @@ const mapStateToProps = (state) => {
     isFetching, count, max, previousSearch,
   } = units;
   const isRedirectFetching = redirectService.isFetching;
-  const options = {};
-  const municipality = isClient() && new URLSearchParams().get('municipality');
-  if (municipality) {
-    options.municipality = municipality;
-  }
-  const unitData = getProcessedData(state, options);
+  const unitData = getOrderedData(state);
   const getLocaleText = textObject => getLocaleString(state, textObject);
   const getAddressNavigatorParams = getAddressNavigatorParamsConnector(getLocaleText, user.locale);
 

--- a/src/views/ServiceView/ServiceView.js
+++ b/src/views/ServiceView/ServiceView.js
@@ -78,7 +78,7 @@ class ServiceView extends React.Component {
   focusMap = (unit) => {
     const { customPosition, map } = this.props;
     const { mapMoved } = this.state;
-    if (!map || !map._layersMaxZoom || mapMoved) {
+    if (!map || !map.options.maxZoom || mapMoved) {
       return;
     }
 

--- a/src/views/UnitView/index.js
+++ b/src/views/UnitView/index.js
@@ -11,13 +11,14 @@ import { getLocaleString } from '../../redux/selectors/locale';
 
 import UnitView from './UnitView';
 import styles from './styles/styles';
-import { calculateDistance } from '../../redux/selectors/unit';
+import { calculateDistance, getCurrentlyUsedPosition } from '../../redux/selectors/unit';
 import { formatDistanceObject } from '../../utils';
 
 // Listen to redux state
 const mapStateToProps = (state, props) => {
   const { intl } = props;
   const stateUnit = state.selectedUnit.unit.data;
+  const currentPosition = getCurrentlyUsedPosition(state);
   const unitFetching = state.selectedUnit.unit.isFetching;
   const {
     accessibilitySentences, events, reservations, hearingMaps,
@@ -29,7 +30,7 @@ const mapStateToProps = (state, props) => {
 
   return {
     accessibilitySentences: accessibilitySentences.data,
-    distance: formatDistanceObject(intl, calculateDistance(state)(stateUnit)),
+    distance: formatDistanceObject(intl, calculateDistance(stateUnit, currentPosition)),
     stateUnit,
     unitFetching,
     eventsData: events,


### PR DESCRIPTION
- Refactor reselect selectors to work correctly by removing state passing: previously state was given as parameter to selector, this causes memoization to not work.
- Update react-redux to get new redux hook useSelector, that is used in download tool hook.
- Add download tool hook
- Changed tool menu styles

**Note**: new redux hooks allows easier access to state on functional components. These can be used to replace the connect HOC and mapStateToProps.