### PR TITLE
Check if unit has root service nodes

### DIFF
--- a/src/views/UnitView/components/Services/Services.js
+++ b/src/views/UnitView/components/Services/Services.js
@@ -22,7 +22,7 @@ class Services extends React.Component {
     // List of normal services without period infomration
     let serviceList = [];
 
-    if (unit.root_service_nodes.includes(educationNode)) {
+    if (unit.root_service_nodes && unit.root_service_nodes.includes(educationNode)) {
       unit.services.forEach((service) => {
         if (service.period && service.period.length > 1) {
           const yearString = `${service.period[0]}–${service.period[1]}`;


### PR DESCRIPTION
If unit does not have any services the API returns `root_service_nodes` as null. This broke the “Services and events” tab in the unit details.