### PR TITLE
Improve district grouping and sorting

### DIFF
--- a/src/views/AreaView/AreaView.js
+++ b/src/views/AreaView/AreaView.js
@@ -223,7 +223,7 @@ const AreaView = ({
       });
   };
 
-  const fetchDistrictsByType = async (type) => {
+  const fetchDistrictsByType = async (type, id) => {
     const options = {
       page: 1,
       page_size: 300,
@@ -234,7 +234,7 @@ const AreaView = ({
     return districtFetch(options)
       .then(data => ({ data, type }))
       .catch(() => {
-        dispatchFetching({ type: 'remove', value: type });
+        dispatchFetching({ type: 'remove', value: id });
       });
   };
 
@@ -251,10 +251,10 @@ const AreaView = ({
       && !fetching.includes(item.title)
     ) {
       dispatchFetching({ type: 'add', value: item.title });
-      Promise.all(item.districts.map(i => fetchDistrictsByType(i)))
+      Promise.all(item.districts.map(i => fetchDistrictsByType(i, item.title)))
         .then((results) => {
-          results.forEach(result => filterFetchData(result.data, result.type));
           dispatchFetching({ type: 'remove', value: item.title });
+          results.forEach(result => filterFetchData(result.data, result.type));
         });
     }
   };

--- a/src/views/AreaView/AreaView.js
+++ b/src/views/AreaView/AreaView.js
@@ -180,7 +180,7 @@ const AreaView = ({
 
   const filterFetchData = (data, type) => {
     let filteredData = [];
-    data.results.forEach((district) => {
+    data.forEach((district) => {
       // Skip if district is already marked as overlaping with another district
       if (filteredData.some(obj => obj.overlaping
         && obj.overlaping.some(item => item.id === district.id))) {
@@ -189,7 +189,7 @@ const AreaView = ({
       const returnItem = district;
 
       // Combine other districts that are duplicates or within this district
-      const overlapingDistricts = data.results.filter(obj => compareBoundaries(district, obj));
+      const overlapingDistricts = data.filter(obj => compareBoundaries(district, obj));
 
       if (overlapingDistricts.length) {
         returnItem.overlaping = overlapingDistricts;
@@ -232,7 +232,10 @@ const AreaView = ({
       unit_include: 'name,location,street_address',
     };
     return districtFetch(options)
-      .then(data => ({ data, type }))
+      .then((data) => {
+        const filteredData = data.results.filter(i => i.boundary && i.boundary.coordinates);
+        return { data: filteredData, type };
+      })
       .catch(() => {
         dispatchFetching({ type: 'remove', value: id });
       });

--- a/src/views/AreaView/AreaView.js
+++ b/src/views/AreaView/AreaView.js
@@ -115,31 +115,41 @@ const AreaView = ({
   };
 
   const changeDistrictData = (data, type) => {
-    // Collect different periods from district data
-    const dateArray = [];
-    data.forEach((item) => {
-      if (item.start && item.end) {
-        const period = `${item.start}-${item.end}`;
-        if (period.includes('2019')) {
-          // FIXME: remove temporary solution to hide older school years once period data is updated
-          return;
-        }
-        if (!dateArray.includes(period)) {
-          dateArray.push(period);
-        }
+    // Group data by periods (used in school districts)
+    const groupedData = data.reduce((acc, cur) => {
+      if (cur.start && cur.start.includes(2019)) {
+        // FIXME: remove temporary solution to hide older school years once period data is updated
+        return acc;
+      }
+      const district = cur;
+      // Remove days and months from district start and end values
+      if (district.start && district.end) {
+        district.start = new Date(district.start).getFullYear();
+        district.end = new Date(district.end).getFullYear();
+      }
+      const duplicate = acc.find(
+        list => list[0].start === district.start && list[0].end === district.end,
+      );
+      if (duplicate) {
+        duplicate.push(district);
+      } else {
+        acc.push([district]);
+      }
+      return acc;
+    }, []);
+
+    groupedData.sort((a, b) => a[0].start - b[0].start);
+
+    groupedData.forEach((periodData) => {
+      const { start, end } = periodData[0];
+      if (start && end) {
+        setDistrictData({
+          id: `${type}${start}-${end}`, data: periodData, date: [start, end], name: type,
+        });
+      } else {
+        setDistrictData({ id: type, data: periodData, name: type });
       }
     });
-    // If different periods were found, seperate them into idividual objects
-    if (dateArray.length) {
-      const dataItems = dateArray.map(period => data.filter(district => `${district.start}-${district.end}` === period));
-      dataItems.forEach((data, i) => {
-        setDistrictData({
-          id: `${type}${dateArray[i]}`, data, date: dateArray[i], name: type,
-        });
-      });
-    } else {
-      setDistrictData({ id: type, data, name: type });
-    }
   };
 
   const compareBoundaries = (a, b) => {
@@ -216,15 +226,13 @@ const AreaView = ({
   const fetchDistrictsByType = async (type) => {
     const options = {
       page: 1,
-      page_size: 200,
+      page_size: 300,
       type,
       geometry: true,
       unit_include: 'name,location,street_address',
     };
-    await districtFetch(options)
-      .then((data) => {
-        filterFetchData(data, type);
-      })
+    return districtFetch(options)
+      .then(data => ({ data, type }))
       .catch(() => {
         dispatchFetching({ type: 'remove', value: type });
       });
@@ -244,7 +252,10 @@ const AreaView = ({
     ) {
       dispatchFetching({ type: 'add', value: item.title });
       Promise.all(item.districts.map(i => fetchDistrictsByType(i)))
-        .then(() => dispatchFetching({ type: 'remove', value: item.title }));
+        .then((results) => {
+          results.forEach(result => filterFetchData(result.data, result.type));
+          dispatchFetching({ type: 'remove', value: item.title });
+        });
     }
   };
 

--- a/src/views/AreaView/components/AreaTab/AreaTab.js
+++ b/src/views/AreaView/components/AreaTab/AreaTab.js
@@ -46,7 +46,7 @@ const AreaTab = ({
                   <FormattedMessage id={`area.list.${district.name}`} />
                 </Typography>
                 <Typography id={`${district.id}Period`} aria-hidden className={classes.captionText} variant="caption">
-                  {`${district.date ? `${district.date.slice(0, 4)}-${district.date.slice(11, 15)}` : ''}`}
+                  {`${district.date ? `${district.date[0]}-${district.date[1]}` : ''}`}
                 </Typography>
               </>
             )}


### PR DESCRIPTION
- Use reduce() to group district data instead of map()+ filter()
- Sort district data by period year
- Do fetch result handling after all concurrent district fetches have finished (so that the order of districts on UI is not determined by fetch speed)