### PR TITLE
Fix/jest and browser tests

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,5 +5,8 @@
         "useBuiltIns": "entry"
       }
     ]
+  ],
+  "plugins": [
+    "@babel/plugin-proposal-optional-chaining"
   ]
 }

--- a/src/views/DivisionView/DivisionView.js
+++ b/src/views/DivisionView/DivisionView.js
@@ -27,7 +27,7 @@ const DivisionView = ({
       };
     } else if (area && city) {
       options = {
-        division: `${city}/${area}`,
+        division: `ocd-division/country:fi/${area}`,
         level: 'all',
         only: 'root_service_nodes,services,location,name,street_address,contract_type,municipality',
         page: 1,


### PR DESCRIPTION
Add babel option chaining plugin

Backend doesn't accept `municipality/type:id` format anymore and requires `ocd-division/country:id/type:id`