### PR TITLE
Add support for loading accessibility sentences with PTV id

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -88,6 +88,10 @@ if (typeof settings.FEEDBACK_ADDITIONAL_INFO_LINK === 'undefined') {
   settings.FEEDBACK_ADDITIONAL_INFO_LINK = "https://www.hel.fi/helsinki/fi/kaupunki-ja-hallinto/osallistu-ja-vaikuta/palaute/ohjeita-palautteesta";
 }
 
+if (typeof settings.USE_PTV_ACCESSIBILITY_API === 'undefined') {
+  settings.USE_PTV_ACCESSIBILITY_API = false;
+}
+
 export default {
   "version": version.tag,
   "commit": version.commit,
@@ -175,4 +179,5 @@ export default {
   "show_area_selection": (settings.SHOW_AREA_SELECTION === 'true'),
   "show_read_speaker_button": (settings.SHOW_READ_SPEAKER_BUTTON === 'true'),
   "feedback_additional_info_link": settings.FEEDBACK_ADDITIONAL_INFO_LINK,
+  "usePtvAccessibilityApi": (settings.USE_PTV_ACCESSIBILITY_API) === 'true',
 }

--- a/server/server.js
+++ b/server/server.js
@@ -192,6 +192,7 @@ const htmlTemplate = (reactDom, preloadedState, css, cssString, locale, helmet, 
         window.nodeEnvSettings.SHOW_AREA_SELECTION = "${process.env.SHOW_AREA_SELECTION}";
         window.nodeEnvSettings.SHOW_READ_SPEAKER_BUTTON = "${process.env.SHOW_READ_SPEAKER_BUTTON}";
         window.nodeEnvSettings.FEEDBACK_ADDITIONAL_INFO_LINK = "${process.env.FEEDBACK_ADDITIONAL_INFO_LINK}";
+        window.nodeEnvSettings.USE_PTV_ACCESSIBILITY_API = "${process.env.USE_PTV_ACCESSIBILITY_API}";
 
         window.appVersion = {};
         window.appVersion.tag = "${versionTag}";

--- a/src/utils/fetch/constants.js
+++ b/src/utils/fetch/constants.js
@@ -7,7 +7,7 @@ import config from '../../../config';
 // API handlers
 export const APIHandlers = {
   accessibilitySentences: {
-    url: id => `${config.accessibilitySentenceAPI.root}/unit/${id}`,
+    url: id => `${config.accessibilitySentenceAPI.root}/` + (config.usePtvAccessibilityApi ? `${id}/sentences/` : `unit/${id}`),
     options: {},
   },
   address: {

--- a/src/views/UnitView/UnitView.js
+++ b/src/views/UnitView/UnitView.js
@@ -74,6 +74,17 @@ const UnitView = (props) => {
     }
   };
 
+  const initializePTVAccessibilitySentences = () => {
+    if (unit) {
+      unit.identifiers.forEach((element) => {
+        if (element.namespace === 'ptv' ) {
+          const ptvId = element.value;
+          fetchAccessibilitySentences(ptvId);
+        }
+      });
+    }
+  }
+
   const intializeUnitData = () => {
     const { params } = match;
     const unitId = params.unit;
@@ -140,6 +151,12 @@ const UnitView = (props) => {
   useEffect(() => {
     centerMap();
   }, [unit, map]);
+
+  if (config.usePtvAccessibilityApi) {
+    useEffect(() => {
+      initializePTVAccessibilitySentences();
+    }, [unit]);
+  }
 
   if (embed) {
     return null;


### PR DESCRIPTION
Helsinki’s accessibility sentences are loaded from a system with servicemap’s unit ids. Add support for loading the sentences from a system that uses PTV ids as identifiers.

Settings for using this API:
```
ACCESSIBILITY_SENTENCE_API: <URL>
USE_PTV_ACCESSIBILITY_API="true"
```