### PR TITLE
Fix/map marker handling

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -54,7 +54,6 @@ function Main() {
   // Remove server side styles
   React.useEffect(() => {
     const jssStyles = document.querySelector('#jss-server-side');
-    console.log(jssStyles);
     if (jssStyles) {
       jssStyles.parentElement.removeChild(jssStyles);
     }

--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -102,7 +102,7 @@ class SearchBar extends React.Component {
   }
 
   handleSubmit = (search) => {
-    const { isFetching } = this.props;
+    const { changeSelectedUnit, isFetching } = this.props;
     if (!isFetching && search && search !== '') {
       const {
         fetchUnits, navigator, previousSearch,
@@ -112,6 +112,7 @@ class SearchBar extends React.Component {
       if (search !== previousSearch) {
         this.setState({ search }); // Change current search text to new one
         fetchUnits({ q: search });
+        changeSelectedUnit(null);
       }
 
       if (navigator) {
@@ -390,6 +391,7 @@ class SearchBar extends React.Component {
 
 SearchBar.propTypes = {
   background: PropTypes.oneOf(['default', 'none']),
+  changeSelectedUnit: PropTypes.func.isRequired,
   classes: PropTypes.objectOf(PropTypes.any).isRequired,
   className: PropTypes.string,
   fetchUnits: PropTypes.func.isRequired,

--- a/src/components/SearchBar/index.js
+++ b/src/components/SearchBar/index.js
@@ -4,6 +4,7 @@ import { injectIntl } from 'react-intl';
 import SearchBar from './SearchBar';
 import styles from './styles';
 import { fetchUnits } from '../../redux/actions/unit';
+import { changeSelectedUnit } from '../../redux/actions/selectedUnit';
 
 // Listen to redux state
 const mapStateToProps = (state) => {
@@ -20,5 +21,5 @@ const mapStateToProps = (state) => {
 
 export default withStyles(styles)(injectIntl(connect(
   mapStateToProps,
-  { fetchUnits },
+  { changeSelectedUnit, fetchUnits },
 )(SearchBar)));

--- a/src/index.css
+++ b/src/index.css
@@ -63,5 +63,6 @@ input[type="search"]::-webkit-search-cancel-button{
 
 .leaflet-popup-close-button {
   font-size: 24px !important;
+  color: #4A4A4C !important;
 }
 

--- a/src/utils/unitHelper.js
+++ b/src/utils/unitHelper.js
@@ -36,6 +36,8 @@ class UnitHelper {
 
   static isValidUnit = unit => unit && unit.object_type === 'unit';
 
+  static isUnitPage = () => paths.unit.regex.test(window.location.href);
+
   static getShortcomingCount(unit, settings) {
     if (unit && settings) {
       // Check if user has settings

--- a/src/utils/unitHelper.js
+++ b/src/utils/unitHelper.js
@@ -2,6 +2,8 @@ import { drawUnitIcon } from '../views/MapView/utils/drawIcon';
 import isClient from '.';
 import SettingsUtility from './settings';
 import config from '../../config';
+import { isEmbed } from './path';
+import paths from '../../config/paths';
 
 // TODO: If berries are not used anymore, clean this class
 
@@ -119,6 +121,29 @@ class UnitHelper {
     const icon = UnitHelper.markerIcons[markerType][iconIndex];
 
     return icon;
+  }
+
+  static unitElementClick = (navigator, unit) => {
+    if (!global.window) {
+      throw Error('Can\'t run unitElementClick without window');
+    }
+    if (!navigator || !navigator.push || !navigator.replace) {
+      throw Error('Invalid navigator argument given.');
+    }
+    if (!unit || (typeof unit !== 'number' && !unit.id)) {
+      throw Error('Invalid unit argument given.');
+    }
+    const id = typeof unit === 'number' ? unit : unit.id;
+    const embeded = isEmbed();
+    if (embeded) {
+      const { origin } = window.location;
+      const path = navigator.generatePath('unit', { id });
+      window.open(`${origin}${path}`);
+      return;
+    }
+    const action = paths.unit.regex.test(window.location.href)
+      ? 'replace' : 'push';
+    navigator[action]('unit', { id });
   }
 }
 

--- a/src/views/MapView/MapView.js
+++ b/src/views/MapView/MapView.js
@@ -190,9 +190,14 @@ const MapView = (props) => {
   });
 
   useEffect(() => {
-    if (highlightedUnit && !unitList.length && mapUtility) {
-      mapUtility.centerMapToUnit(highlightedUnit);
+    if (!highlightedUnit || !mapUtility) {
+      return;
     }
+    if (!unitList.length) {
+      mapUtility.centerMapToUnit(highlightedUnit);
+      return;
+    }
+    mapUtility.panInside(highlightedUnit);
   }, [highlightedUnit, mapUtility]);
 
   useEffect(() => { // On map type change

--- a/src/views/MapView/MapView.js
+++ b/src/views/MapView/MapView.js
@@ -23,6 +23,7 @@ import DistanceMeasure from './components/DistanceMeasure';
 import MarkerCluster from './components/MarkerCluster';
 import swapCoordinates from './utils/swapCoordinates';
 import UnitGeometry from './components/UnitGeometry';
+import MapUtility from './utils/mapUtility';
 
 if (global.window) {
   require('leaflet');
@@ -67,6 +68,7 @@ const MapView = (props) => {
   const [refSaved, setRefSaved] = useState(false);
   const [prevMap, setPrevMap] = useState(null);
   const [unitData, setUnitData] = useState(null);
+  const [mapUtility, setMapUtility] = useState(null);
 
   const embeded = isEmbed({ url: location.pathname });
 
@@ -78,7 +80,11 @@ const MapView = (props) => {
     if (currentPage === 'home' && embeded) {
       mapUnits = unitList;
     }
-    if (currentPage === 'search' || currentPage === 'division') {
+    if (
+      currentPage === 'search'
+      || currentPage === 'division'
+      || (currentPage === 'unit' && unitList.length)
+    ) {
       mapUnits = unitList;
     } else if (currentPage === 'address') {
       switch (addressToRender) {
@@ -183,12 +189,25 @@ const MapView = (props) => {
     }
   });
 
+  useEffect(() => {
+    if (highlightedUnit && !unitList.length && mapUtility) {
+      mapUtility.centerMapToUnit(highlightedUnit);
+    }
+  }, [highlightedUnit, mapUtility]);
+
   useEffect(() => { // On map type change
     // Init new map and set new ref to redux
     initializeMap();
     setRefSaved(false);
   }, [settings.mapType]);
 
+  useEffect(() => {
+    if (!mapUtility && mapRef.current) {
+      setMapUtility(new MapUtility({ leaflet: mapRef.current.leafletElement }));
+    }
+  }, [mapRef.current]);
+
+  // Attempt to render unit markers on page change or unitList change
   useEffect(() => {
     setUnitData(getMapUnits());
   }, [

--- a/src/views/MapView/components/MarkerCluster/MarkerCluster.js
+++ b/src/views/MapView/components/MarkerCluster/MarkerCluster.js
@@ -8,13 +8,12 @@ import { generatePath, isEmbed } from '../../../../utils/path';
 import { createMarkerClusterLayer, createMarkerContent } from './clusterUtils';
 import { mapTypes } from '../../config/mapConfig';
 import { keyboardHandler } from '../../../../utils';
-import { fitUnitsToMap } from '../../utils/mapActions';
 
 // Handle unit markers
-const tooltipOptions = (markerCount, classes) => ({
+const tooltipOptions = (permanent, classes) => ({
   className: classes.unitTooltipContainer,
   direction: 'top',
-  permanent: markerCount === 1,
+  permanent,
   opacity: 1,
   offset: [0, -25],
 });
@@ -32,7 +31,7 @@ const clusterData = {};
 
 const MarkerCluster = ({
   classes,
-  currentPage,
+  // currentPage,
   data,
   getDistance,
   getLocaleText,
@@ -75,7 +74,7 @@ const MarkerCluster = ({
         const tooltipContent = createMarkerContent(
           clusterData.highlightedUnit, classes, getLocaleText, distance,
         );
-        cluster.bindTooltip(tooltipContent, tooltipOptions(1, classes));
+        cluster.bindTooltip(tooltipContent, tooltipOptions(true, classes));
       }
     }
     return icon;
@@ -245,6 +244,7 @@ const MarkerCluster = ({
         // Distance
         const distance = getDistance(unit, intl);
         const tooltipContent = createMarkerContent(unit, classes, getLocaleText, distance);
+        const tooltipPermanent = highlightedUnit && highlightedUnit.id === unit.id;
 
         const markerElem = global.L.marker(
           [unit.location.coordinates[1], unit.location.coordinates[0]],
@@ -255,7 +255,7 @@ const MarkerCluster = ({
           },
         ).bindTooltip(
           tooltipContent,
-          tooltipOptions(unitListFiltered.length, classes),
+          tooltipOptions(tooltipPermanent, classes),
         );
 
         if (unitListFiltered.length > 1 || embeded) {
@@ -288,16 +288,12 @@ const MarkerCluster = ({
       item.setAttribute('aria-hidden', 'true');
     });
 
-    if (map && data.units.length && !(currentPage === 'address' || currentPage === 'area')) {
-      // TODO: this should be revisited once new map focusing is implemented
-      /* Zoom out map to fit all unit markers when unit data changes.
-      Do not do this on area view and address view */
-      fitUnitsToMap(data.units, map);
-    }
-
-    // optionally center the map around the markers
-    // map.fitBounds(mcg.getBounds());
-    // // add the marker cluster group to the map
+    // if (map && data.units.length && !(currentPage === 'address' || currentPage === 'area')) {
+    //   // TODO: this should be revisited once new map focusing is implemented
+    //   /* Zoom out map to fit all unit markers when unit data changes.
+    //   Do not do this on area view and address view */
+    //   // fitUnitsToMap(data.units, map);
+    // }
   }, [cluster, data]);
 
   return null;
@@ -305,7 +301,7 @@ const MarkerCluster = ({
 
 MarkerCluster.propTypes = {
   classes: PropTypes.objectOf(PropTypes.any).isRequired,
-  currentPage: PropTypes.string.isRequired,
+  // currentPage: PropTypes.string.isRequired,
   data: PropTypes.shape({
     units: PropTypes.arrayOf(
       PropTypes.shape({

--- a/src/views/MapView/components/MarkerCluster/MarkerCluster.js
+++ b/src/views/MapView/components/MarkerCluster/MarkerCluster.js
@@ -20,7 +20,7 @@ const tooltipOptions = (permanent, classes) => ({
 
 const popupOptions = () => ({
   autoClose: false,
-  autoPan: true,
+  autoPan: false,
   closeButton: true,
   closeOnClick: false,
   direction: 'top',

--- a/src/views/MapView/components/MarkerCluster/MarkerCluster.js
+++ b/src/views/MapView/components/MarkerCluster/MarkerCluster.js
@@ -173,9 +173,6 @@ const MarkerCluster = ({
   };
 
   const clusterMouseover = (a) => {
-    if (clusterData.highlightedUnit) {
-      return;
-    }
     const clusterMarkers = a.layer.getAllChildMarkers();
     const units = clusterMarkers.map((marker) => {
       if (marker && marker.options && marker.options.customUnitData) {

--- a/src/views/MapView/components/MarkerCluster/MarkerCluster.js
+++ b/src/views/MapView/components/MarkerCluster/MarkerCluster.js
@@ -81,14 +81,10 @@ const MarkerCluster = ({
   };
 
 
-  const { clusterPopupVisibility, maxZoom, minZoom } = mapTypes[settings.mapType || 'servicemap'];
+  const { clusterPopupVisibility } = mapTypes[settings.mapType || 'servicemap'];
   const popupTexts = {
     title: intl.formatMessage({ id: 'unit.plural' }),
     info: count => intl.formatMessage({ id: 'map.unit.cluster.popup.info' }, { count }),
-  };
-  const maxClusterRadius = (zoom) => {
-    const normalizedZoom = (zoom - minZoom) / (maxZoom - minZoom);
-    return Math.round(100 * (1 - normalizedZoom));
   };
   const onClusterItemClick = (unit) => {
     UnitHelper.unitElementClick(navigator, unit);
@@ -205,7 +201,6 @@ const MarkerCluster = ({
       clusterMouseover,
       clusterMouseout,
       null,
-      maxClusterRadius,
     );
     // Add cluster to map
     map.addLayer(mcg);

--- a/src/views/MapView/components/MarkerCluster/MarkerCluster.js
+++ b/src/views/MapView/components/MarkerCluster/MarkerCluster.js
@@ -4,10 +4,11 @@ import { useIntl } from 'react-intl';
 import 'leaflet.markercluster/dist/MarkerCluster.css';
 import 'leaflet.markercluster/dist/MarkerCluster.Default.css';
 import { drawMarkerIcon } from '../../utils/drawIcon';
-import { generatePath, isEmbed } from '../../../../utils/path';
+import { isEmbed } from '../../../../utils/path';
 import { createMarkerClusterLayer, createMarkerContent } from './clusterUtils';
 import { mapTypes } from '../../config/mapConfig';
 import { keyboardHandler } from '../../../../utils';
+import UnitHelper from '../../../../utils/unitHelper';
 
 // Handle unit markers
 const tooltipOptions = (permanent, classes) => ({
@@ -31,7 +32,6 @@ const clusterData = {};
 
 const MarkerCluster = ({
   classes,
-  // currentPage,
   data,
   getDistance,
   getLocaleText,
@@ -91,9 +91,7 @@ const MarkerCluster = ({
     return Math.round(100 * (1 - normalizedZoom));
   };
   const onClusterItemClick = (unit) => {
-    if (navigator && unit) {
-      navigator.push('unit', { id: unit.id });
-    }
+    UnitHelper.unitElementClick(navigator, unit);
   };
   // eslint-disable-next-line no-underscore-dangle
   const showListOfUnits = () => (map._zoom > clusterPopupVisibility);
@@ -260,15 +258,7 @@ const MarkerCluster = ({
 
         if (unitListFiltered.length > 1 || embeded) {
           markerElem.on('click', () => {
-            if (embeded) {
-              const { origin } = window.location;
-              const path = generatePath('unit', { id: unit.id });
-              window.open(`${origin}${path}`);
-              return;
-            }
-            if (navigator) {
-              navigator.push('unit', { id: unit.id });
-            }
+            UnitHelper.unitElementClick(navigator, unit);
           })
             .on('mouseover', () => {
               map.closePopup();
@@ -301,7 +291,6 @@ const MarkerCluster = ({
 
 MarkerCluster.propTypes = {
   classes: PropTypes.objectOf(PropTypes.any).isRequired,
-  // currentPage: PropTypes.string.isRequired,
   data: PropTypes.shape({
     units: PropTypes.arrayOf(
       PropTypes.shape({

--- a/src/views/MapView/components/MarkerCluster/MarkerCluster.js
+++ b/src/views/MapView/components/MarkerCluster/MarkerCluster.js
@@ -64,7 +64,7 @@ const MarkerCluster = ({
     });
 
     // Add cluster tooltip for highlightedUnit
-    if (clusterData.highlightedUnit) {
+    if (clusterData.highlightedUnit && UnitHelper.isUnitPage()) {
       const markers = cluster.getAllChildMarkers();
       const marker = markers.find(
         obj => obj.options.customUnitData.id === clusterData.highlightedUnit.id,
@@ -234,7 +234,8 @@ const MarkerCluster = ({
         // Distance
         const distance = getDistance(unit, intl);
         const tooltipContent = createMarkerContent(unit, classes, getLocaleText, distance);
-        const tooltipPermanent = highlightedUnit && highlightedUnit.id === unit.id;
+        const tooltipPermanent = highlightedUnit
+          && (highlightedUnit.id === unit.id && UnitHelper.isUnitPage());
 
         const markerElem = global.L.marker(
           [unit.location.coordinates[1], unit.location.coordinates[0]],

--- a/src/views/MapView/components/MarkerCluster/clusterUtils.js
+++ b/src/views/MapView/components/MarkerCluster/clusterUtils.js
@@ -5,7 +5,6 @@ import { isEmbed } from '../../../../utils/path';
 
 export const createMarkerClusterLayer = (
   createClusterCustomIcon,
-  createPopupContent,
   clusterMouseover,
   clusterMouseout,
   clusterAnimationend,
@@ -32,23 +31,6 @@ export const createMarkerClusterLayer = (
   if (!embeded) {
     clusterLayer.on('clustermouseover', (a) => {
       if (clusterMouseover) clusterMouseover(a);
-
-      const clusterMarkers = a.layer.getAllChildMarkers();
-      const units = clusterMarkers.map((marker) => {
-        if (marker && marker.options && marker.options.customUnitData) {
-          const data = marker.options.customUnitData;
-          return data;
-        }
-        return null;
-      });
-
-      // Create popuelement and add events
-      const elem = createPopupContent(units);
-      // Bind and open popup with content to cluster
-      a.layer.bindPopup(elem, {
-        closeButton: true,
-        offset: [4, -14],
-      }).openPopup();
     });
   } else {
     // Add cluster click only when embeded

--- a/src/views/MapView/components/MarkerCluster/clusterUtils.js
+++ b/src/views/MapView/components/MarkerCluster/clusterUtils.js
@@ -8,7 +8,6 @@ export const createMarkerClusterLayer = (
   clusterMouseover,
   clusterMouseout,
   clusterAnimationend,
-  maxClusterRadius,
 ) => {
   if (!isClient()) {
     return null;
@@ -23,7 +22,7 @@ export const createMarkerClusterLayer = (
     spiderfyOnMaxZoom: false,
     showCoverageOnHover: false,
     iconCreateFunction: createClusterCustomIcon,
-    maxClusterRadius,
+    maxClusterRadius: 40,
     removeOutsideVisibleBounds: true,
     zoomToBoundsOnClick: !embeded,
   });

--- a/src/views/MapView/components/MarkerCluster/clusterUtils.js
+++ b/src/views/MapView/components/MarkerCluster/clusterUtils.js
@@ -49,17 +49,45 @@ export const createMarkerClusterLayer = (
   });
 
   // Run clustermouseout function
-  clusterLayer.on('clustermouseout', () => {
-    if (clusterMouseout) clusterMouseout();
+  clusterLayer.on('clustermouseout', (a) => {
+    if (clusterMouseout) clusterMouseout(a);
   });
 
 
   return clusterLayer;
 };
 
-export const createMarkerContent = (unit, classes, getLocaleText, distance) => (
+export const createTooltipContent = (unit, classes, getLocaleText, distance) => (
   ReactDOMServer.renderToStaticMarkup(
     <div>
+      <p className={classes.unitTooltipTitle}>{unit.name && getLocaleText(unit.name)}</p>
+      <div className={classes.unitTooltipSubContainer}>
+        {
+          unit.street_address
+          && (
+            <p className={classes.unitTooltipSubtitle}>
+              {getLocaleText(unit.street_address)}
+            </p>
+          )
+        }
+        {
+          distance
+          && (
+            <p className={classes.unitTooltipSubtitle}>
+              {distance.distance}
+              {distance.type}
+            </p>
+          )
+        }
+      </div>
+    </div>,
+  )
+);
+
+
+export const createPopupContent = (unit, classes, getLocaleText, distance) => (
+  ReactDOMServer.renderToStaticMarkup(
+    <div className={classes.unitTooltipWrapper}>
       <p className={classes.unitTooltipTitle}>{unit.name && getLocaleText(unit.name)}</p>
       <div className={classes.unitTooltipSubContainer}>
         {

--- a/src/views/MapView/components/MarkerCluster/index.js
+++ b/src/views/MapView/components/MarkerCluster/index.js
@@ -6,6 +6,7 @@ import { generatePath } from '../../../../utils/path';
 import { formatDistanceObject } from '../../../../utils';
 import { calculateDistance, getCurrentlyUsedPosition } from '../../../../redux/selectors/unit';
 import styles from '../../styles';
+import { getSelectedUnit } from '../../../../redux/selectors/selectedUnit';
 
 
 const mapStateToProps = (state) => {
@@ -17,12 +18,14 @@ const mapStateToProps = (state) => {
   const getDistance = (unit, intl) => (
     formatDistanceObject(intl, calculateDistance(unit, distanceCoordinates))
   );
+  const highlightedUnit = getSelectedUnit(state);
 
   return {
     currentPage: page,
     getDistance,
     getLocaleText,
     getPath,
+    highlightedUnit,
     navigator,
     settings,
     theme,

--- a/src/views/MapView/styles.js
+++ b/src/views/MapView/styles.js
@@ -114,6 +114,9 @@ const styles = theme => ({
     ...theme.typography.body2,
     margin: theme.spacing(0, 1),
   },
+  unitTooltipWrapper: {
+    padding: theme.spacing(2),
+  },
   unitPopupList: {
     listStyleType: 'none',
     padding: 0,

--- a/src/views/MapView/utils/mapUtility.js
+++ b/src/views/MapView/utils/mapUtility.js
@@ -1,6 +1,10 @@
 import { focusToPosition, focusDistrict } from './mapActions';
 
 
+const panOptions = {
+  padding: [200, 200],
+};
+
 class MapUtility {
   constructor(props) {
     if (!props.leaflet) {
@@ -23,6 +27,18 @@ class MapUtility {
       } else if (location) {
         focusToPosition(this.leaflet, location.coordinates);
       }
+    }
+  }
+
+  panInside = (unit) => {
+    if (!unit) {
+      throw Error('Invalid unit given to MapUtility panInside');
+    }
+    const { location } = unit;
+    if (location) {
+      const coords = location.coordinates;
+      // Pan to swapped coordinates
+      this.leaflet.panInside([coords[1], coords[0]], panOptions);
     }
   }
 }

--- a/src/views/MapView/utils/mapUtility.js
+++ b/src/views/MapView/utils/mapUtility.js
@@ -1,0 +1,30 @@
+import { focusToPosition, focusDistrict } from './mapActions';
+
+
+class MapUtility {
+  constructor(props) {
+    if (!props.leaflet) {
+      throw Error('MapUtility requires leaflet element as option');
+    }
+    this.leaflet = props.leaflet;
+  }
+
+  leaflet;
+
+  centerMapToUnit = (unit) => {
+    if (!unit || !unit.id) {
+      throw Error('centerMapToUnit requires valid unit to center');
+    }
+
+    if (unit && this.leaflet) {
+      const { geometry, location } = unit;
+      if (geometry && geometry.type === 'MultiLineString') {
+        focusDistrict(this.leaflet, [geometry.coordinates]);
+      } else if (location) {
+        focusToPosition(this.leaflet, location.coordinates);
+      }
+    }
+  }
+}
+
+export default MapUtility;

--- a/src/views/UnitView/UnitView.js
+++ b/src/views/UnitView/UnitView.js
@@ -63,16 +63,6 @@ const UnitView = (props) => {
 
   const [unit, setUnit] = useState(checkCorrectUnit(stateUnit) ? stateUnit : null);
 
-  const centerMap = () => {
-    if (unit && map) {
-      const { geometry, location } = unit;
-      if (geometry && geometry.type === 'MultiLineString') {
-        focusDistrict(map, [geometry.coordinates]);
-      } else if (location) {
-        focusToPosition(map, location.coordinates);
-      }
-    }
-  };
 
   const intializeUnitData = () => {
     const { params } = match;
@@ -136,10 +126,6 @@ const UnitView = (props) => {
       intializeUnitData();
     }
   }, [match.params.unit]);
-
-  useEffect(() => {
-    centerMap();
-  }, [unit, map]);
 
   if (embed) {
     return null;


### PR DESCRIPTION
- Changing map marker handling to not remove search results when browsing results by selecting specific units. Selected unit is also highlighted by tooltip above cluster if marker is inside it.
- Changed new search to remove selected unit so it doesn't show tooltip on new results