### PR TITLE
Fix/mobile sticky tab

### DIFF
--- a/src/components/ExpandedSuggestions/ExpandedSuggestions.js
+++ b/src/components/ExpandedSuggestions/ExpandedSuggestions.js
@@ -11,7 +11,6 @@ import SMButton from '../ServiceMapButton';
 import SuggestionItem from '../ListItems/SuggestionItem';
 import TitleBar from '../TitleBar';
 import AddressItem from '../ListItems/AddressItem';
-import useMobileStatus from '../../utils/isMobile';
 
 
 const ExpandedSuggestions = (props) => {
@@ -23,6 +22,7 @@ const ExpandedSuggestions = (props) => {
     navigator,
     onClick,
     isVisible,
+    isMobile,
     locale,
   } = props;
 
@@ -31,7 +31,6 @@ const ExpandedSuggestions = (props) => {
   const [suggestionError, setSuggestionError] = useState(false);
   // Query word on which suggestion list is based
   const [suggestionQuery, setSuggestionQuery] = useState(null);
-  const isMobile = useMobileStatus();
 
   const listRef = useRef(null);
   const fetchController = useRef(null);
@@ -204,14 +203,14 @@ const ExpandedSuggestions = (props) => {
     const sidebar = document.getElementsByClassName('SidebarWrapper')[0];
     const app = document.getElementsByClassName('App')[0];
     if (isVisible) {
-      sidebar.style.overflow = isMobile ? 'hidden' : 'hidden';
+      sidebar.style.overflow = 'hidden';
       if (app) {
         app.style.height = '100%';
       }
     }
 
     return () => {
-      sidebar.style.overflow = isMobile ? '' : 'auto';
+      sidebar.style.overflow = isMobile ? 'visible' : 'auto';
       if (app) {
         app.style.height = null;
       }
@@ -261,6 +260,7 @@ ExpandedSuggestions.propTypes = {
   classes: PropTypes.objectOf(PropTypes.any).isRequired,
   intl: PropTypes.objectOf(PropTypes.any).isRequired,
   isVisible: PropTypes.bool,
+  isMobile: PropTypes.bool,
   navigator: PropTypes.objectOf(PropTypes.any),
   onClick: PropTypes.func.isRequired,
   searchQuery: PropTypes.string,
@@ -272,6 +272,7 @@ ExpandedSuggestions.defaultProps = {
   searchQuery: null,
   navigator: null,
   isVisible: false,
+  isMobile: false,
 };
 
 export default ExpandedSuggestions;

--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -151,15 +151,29 @@ class SearchBar extends React.Component {
     return (
       <>
         <Divider aria-hidden />
-        <SuggestionBox
-          visible={showSuggestions}
-          focusedSuggestion={focusedSuggestion}
-          searchQuery={searchQuery}
-          handleArrowClick={value => this.onInputChange(value)}
-          handleSubmit={this.handleSubmit}
-          setSearch={value => this.setState({ search: value })}
-          isMobile
-        />
+        {/* TODO: Modify this class to functional component, to use useMobile hook
+        instead of individual mobile/desktop components. */}
+        <MobileComponent>
+          <SuggestionBox
+            visible={showSuggestions}
+            focusedSuggestion={focusedSuggestion}
+            searchQuery={searchQuery}
+            handleArrowClick={value => this.onInputChange(value)}
+            handleSubmit={this.handleSubmit}
+            setSearch={value => this.setState({ search: value })}
+            isMobile
+          />
+        </MobileComponent>
+        <DesktopComponent>
+          <SuggestionBox
+            visible={showSuggestions}
+            focusedSuggestion={focusedSuggestion}
+            searchQuery={searchQuery}
+            handleArrowClick={value => this.onInputChange(value)}
+            handleSubmit={this.handleSubmit}
+            setSearch={value => this.setState({ search: value })}
+          />
+        </DesktopComponent>
       </>
     );
   }
@@ -379,7 +393,7 @@ class SearchBar extends React.Component {
                 this.renderInput()
               }
               {
-                this.renderSuggestionBox()
+                this.renderSuggestionBox(true)
               }
             </Paper>
           </div>

--- a/src/components/SearchBar/components/SuggestionBox/SuggestionBox.js
+++ b/src/components/SearchBar/components/SuggestionBox/SuggestionBox.js
@@ -11,7 +11,6 @@ import createSuggestions from '../../createSuggestions';
 import config from '../../../../../config';
 import SuggestionItem from '../../../ListItems/SuggestionItem';
 import AddressItem from '../../../ListItems/AddressItem';
-import useMobileStatus from '../../../../utils/isMobile';
 import { getAddressText } from '../../../../utils/address';
 
 
@@ -25,6 +24,7 @@ const SuggestionBox = (props) => {
     focusedSuggestion,
     getLocaleText,
     setSearch,
+    isMobile,
     intl,
     locale,
   } = props;
@@ -35,7 +35,6 @@ const SuggestionBox = (props) => {
   const [history] = useState(getPreviousSearches());
   // Query word on which suggestion list is based
   const [suggestionQuery, setSuggestionQuery] = useState(null);
-  const isMobile = useMobileStatus();
 
   const listRef = useRef(null);
   const fetchController = useRef(null);
@@ -219,14 +218,14 @@ const SuggestionBox = (props) => {
     const sidebar = document.getElementsByClassName('SidebarWrapper')[0];
     const app = document.getElementsByClassName('App')[0];
     if (visible) {
-      sidebar.style.overflow = isMobile ? 'hidden' : 'hidden';
+      sidebar.style.overflow = 'hidden';
       if (app) {
         app.style.height = '100%';
       }
     }
 
     return () => {
-      sidebar.style.overflow = isMobile ? '' : 'auto';
+      sidebar.style.overflow = isMobile ? 'visible' : 'auto';
       if (app) {
         app.style.height = null;
       }
@@ -278,6 +277,7 @@ SuggestionBox.propTypes = {
   classes: PropTypes.objectOf(PropTypes.any).isRequired,
   focusedSuggestion: PropTypes.number,
   setSearch: PropTypes.func,
+  isMobile: PropTypes.bool,
   intl: PropTypes.objectOf(PropTypes.any).isRequired,
   locale: PropTypes.oneOf(config.supportedLanguages).isRequired,
 };
@@ -287,6 +287,7 @@ SuggestionBox.defaultProps = {
   searchQuery: null,
   focusedSuggestion: null,
   setSearch: null,
+  isMobile: false,
 };
 
 export default SuggestionBox;

--- a/src/components/TabLists/TabLists.js
+++ b/src/components/TabLists/TabLists.js
@@ -159,15 +159,13 @@ const TabLists = ({
       const classes = sibling.className;
       if (classes.indexOf('sticky') > -1 && typeof sibling.clientHeight === 'number') {
         // Calculate top padding by checking previous sticky siblings top value and height
-        stickyElementPadding += parseInt(getComputedStyle(sibling).top, 10);
         stickyElementPadding += sibling.clientHeight;
       }
     }
 
-    if (isMobile && stickyElementPadding === 0) {
-      stickyElementPadding = appBarHeight;
+    if (isMobile) {
+      stickyElementPadding += appBarHeight;
     }
-
     if (
       typeof stickyElementPadding === 'number'
       && typeof tabsDistanceFromTop === 'number'
@@ -175,7 +173,7 @@ const TabLists = ({
     ) {
       // Set new styles and scrollDistance value to state
       setStyles({ top: stickyElementPadding });
-      setScrollDistance(tabsDistanceFromTop - stickyElementPadding);
+      setScrollDistance(tabsDistanceFromTop);
     }
   };
 
@@ -221,8 +219,6 @@ const TabLists = ({
           )
         }
         <Tabs
-          // TODO: In materialUI 4.*
-          // Change to use ref and update height calculations in componentDidMount
           ref={tabsRef}
           className={`sticky ${classes.root}`}
           classes={{

--- a/src/views/SearchView/SearchView.js
+++ b/src/views/SearchView/SearchView.js
@@ -19,6 +19,7 @@ import { generatePath } from '../../utils/path';
 import ExpandedSuggestions from '../../components/ExpandedSuggestions';
 import SettingsInfo from '../../components/SettingsInfo';
 import DesktopComponent from '../../components/DesktopComponent';
+import MobileComponent from '../../components/MobileComponent';
 
 class SearchView extends React.Component {
   constructor(props) {
@@ -380,19 +381,41 @@ class SearchView extends React.Component {
     }
 
     return (
-      <ExpandedSuggestions
-        searchQuery={query}
-        onClick={() => {
-          this.setState({ expandVisible: false });
-          setTimeout(() => {
-            const elem = document.getElementById('ExpandSuggestions');
-            if (elem) {
-              elem.focus();
-            }
-          }, 1);
-        }}
-        isVisible
-      />
+      <>
+        <DesktopComponent>
+          {/* TODO: Modify this class to functional component, to use useMobile hook
+        instead of individual mobile/desktop components. */}
+          <ExpandedSuggestions
+            searchQuery={query}
+            onClick={() => {
+              this.setState({ expandVisible: false });
+              setTimeout(() => {
+                const elem = document.getElementById('ExpandSuggestions');
+                if (elem) {
+                  elem.focus();
+                }
+              }, 1);
+            }}
+            isVisible
+          />
+        </DesktopComponent>
+        <MobileComponent>
+          <ExpandedSuggestions
+            searchQuery={query}
+            onClick={() => {
+              this.setState({ expandVisible: false });
+              setTimeout(() => {
+                const elem = document.getElementById('ExpandSuggestions');
+                if (elem) {
+                  elem.focus();
+                }
+              }, 1);
+            }}
+            isVisible
+            isMobile
+          />
+        </MobileComponent>
+      </>
     );
   }
 

--- a/src/views/UnitView/UnitView.js
+++ b/src/views/UnitView/UnitView.js
@@ -63,6 +63,8 @@ const UnitView = (props) => {
 
   const [unit, setUnit] = useState(checkCorrectUnit(stateUnit) ? stateUnit : null);
 
+  const isMobile = useMobileStatus();
+
 
   const initializePTVAccessibilitySentences = () => {
     if (unit) {
@@ -302,25 +304,17 @@ const UnitView = (props) => {
 
     const TopArea = (
       <>
-        <DesktopComponent>
+        {!isMobile && (
           <SearchBar margin />
+        )}
           <TitleBar
             sticky
-            icon={<AddressIcon className={classes.icon} />}
+          icon={!isMobile ? <AddressIcon className={classes.icon} /> : null}
             title={title}
+          backButton={!!isMobile}
             titleComponent="h3"
             distance={distance && distance.text}
           />
-        </DesktopComponent>
-        <MobileComponent>
-          <TitleBar
-            sticky
-            title={title}
-            titleComponent="h3"
-            backButton
-            distance={distance && distance.text}
-          />
-        </MobileComponent>
       </>
     );
 

--- a/src/views/UnitView/UnitView.js
+++ b/src/views/UnitView/UnitView.js
@@ -5,12 +5,10 @@ import { Typography } from '@material-ui/core';
 import { FormattedMessage } from 'react-intl';
 import { Map, Mail, Hearing } from '@material-ui/icons';
 import SearchBar from '../../components/SearchBar';
-import { focusToPosition, focusDistrict } from '../MapView/utils/mapActions';
 import TitleBar from '../../components/TitleBar';
 import Container from '../../components/Container';
 import { uppercaseFirst } from '../../utils';
 import AccessibilityInfo from './components/AccessibilityInfo';
-
 import ContactInfo from './components/ContactInfo';
 import Highlights from './components/Highlights';
 import ElectronicServices from './components/ElectronicServices';
@@ -26,16 +24,14 @@ import SocialMediaLinks from './components/SocialMediaLinks';
 import UnitLinks from './components/UnitLinks';
 import SimpleListItem from '../../components/ListItems/SimpleListItem';
 import TitledList from '../../components/Lists/TitledList';
-import DesktopComponent from '../../components/DesktopComponent';
-import MobileComponent from '../../components/MobileComponent';
 import ReadSpeakerButton from '../../components/ReadSpeakerButton';
 import config from '../../../config';
+import useMobileStatus from '../../utils/isMobile';
 
 const UnitView = (props) => {
   const {
     distance,
     stateUnit,
-    map,
     intl,
     classes,
     embed,
@@ -69,13 +65,13 @@ const UnitView = (props) => {
   const initializePTVAccessibilitySentences = () => {
     if (unit) {
       unit.identifiers.forEach((element) => {
-        if (element.namespace === 'ptv' ) {
+        if (element.namespace === 'ptv') {
           const ptvId = element.value;
           fetchAccessibilitySentences(ptvId);
         }
       });
     }
-  }
+  };
 
   const intializeUnitData = () => {
     const { params } = match;
@@ -208,9 +204,7 @@ const UnitView = (props) => {
           <Description unit={unit} getLocaleText={getLocaleText} />
           <UnitLinks unit={unit} />
           <ElectronicServices unit={unit} />
-          <DesktopComponent>
-            {feedbackButton()}
-          </DesktopComponent>
+          {!isMobile && feedbackButton()}
         </div>
       </div>
     );
@@ -279,24 +273,22 @@ const UnitView = (props) => {
   };
 
   const renderMobileButtons = () => (
-    <MobileComponent>
-      <div className={classes.mobileButtonArea}>
-        <SMButton
-          aria-hidden
-          messageID="general.showOnMap"
-          icon={<Map />}
-          onClick={(e) => {
-            e.preventDefault();
-            if (navigator) {
-              navigator.openMap();
-            }
-          }}
-          margin
-          role="link"
-        />
-        {feedbackButton()}
-      </div>
-    </MobileComponent>
+    <div className={classes.mobileButtonArea}>
+      <SMButton
+        aria-hidden
+        messageID="general.showOnMap"
+        icon={<Map />}
+        onClick={(e) => {
+          e.preventDefault();
+          if (navigator) {
+            navigator.openMap();
+          }
+        }}
+        margin
+        role="link"
+      />
+      {feedbackButton()}
+    </div>
   );
 
   const render = () => {
@@ -307,14 +299,14 @@ const UnitView = (props) => {
         {!isMobile && (
           <SearchBar margin />
         )}
-          <TitleBar
-            sticky
+        <TitleBar
+          sticky
           icon={!isMobile ? <AddressIcon className={classes.icon} /> : null}
-            title={title}
+          title={title}
           backButton={!!isMobile}
-            titleComponent="h3"
-            distance={distance && distance.text}
-          />
+          titleComponent="h3"
+          distance={distance && distance.text}
+        />
       </>
     );
 
@@ -391,7 +383,7 @@ const UnitView = (props) => {
                   </div>
                 )
               }
-                {renderMobileButtons()}
+                {isMobile && renderMobileButtons()}
               </>
           )}
           />

--- a/src/views/UnitView/components/SocialMediaLinks/styles.js
+++ b/src/views/UnitView/components/SocialMediaLinks/styles.js
@@ -46,6 +46,6 @@ export default theme => ({
     height: 25,
   },
   someDivider: {
-    marginRight: -32,
+    marginRight: -theme.spacing(3),
   },
 });

--- a/src/views/UnitView/index.js
+++ b/src/views/UnitView/index.js
@@ -24,8 +24,7 @@ const mapStateToProps = (state, props) => {
     accessibilitySentences, events, reservations, hearingMaps,
   } = state.selectedUnit;
   const getLocaleText = textObject => getLocaleString(state, textObject);
-  const { mapRef, navigator, user } = state;
-  const map = mapRef && mapRef.leafletElement;
+  const { navigator, user } = state;
 
   return {
     accessibilitySentences: accessibilitySentences.data,
@@ -34,7 +33,6 @@ const mapStateToProps = (state, props) => {
     unitFetching,
     eventsData: events,
     getLocaleText,
-    map,
     navigator,
     reservationsData: reservations,
     userLocation: user.position,


### PR DESCRIPTION
- Fixed TabList sticky calculations.
- Fixed issue with isMobile-hook in ExpandedSuggestions and Suggestion box: for some reason mobile check returned always false, thus causing sidebar overflow style to break on mobile view.
- Improved UnitView component to use isMobile hook instead of MobileComponent/DesktopComponent. Old implementation would briefly render non-mobile content (search bar etc.) when rendering UnitView.