### PR TITLE
Prevent dialog showing error message when modalOpen changes to false

### DIFF
--- a/src/views/FeedbackView/FeedbackView.js
+++ b/src/views/FeedbackView/FeedbackView.js
@@ -129,26 +129,31 @@ const FeedbackView = ({
         message={intl.formatMessage({ id: 'feedback.modal.leave' })}
       />
       {/* Confirm dialog */}
-      <Dialog open={!!modalOpen}>
-        <div className={classes.modalContainer}>
-          <Typography className={classes.modalTitle}>
-            <FormattedMessage id={modalOpen === 'send' ? 'feedback.modal.success' : 'feedback.modal.error'} />
-          </Typography>
-          <SMButton
-            margin
-            role="button"
-            className={classes.modalButton}
-            messageID="feedback.modal.confirm"
-            color="primary"
-            onClick={() => {
-              setModalOpen(false);
-              if (modalOpen === 'send') {
-                navigator.goBack();
-              }
-            }}
-          />
-        </div>
-      </Dialog>
+      {
+        modalOpen
+        && (
+          <Dialog open={!!modalOpen}>
+            <div className={classes.modalContainer}>
+              <Typography className={classes.modalTitle}>
+                <FormattedMessage id={modalOpen === 'send' ? 'feedback.modal.success' : 'feedback.modal.error'} />
+              </Typography>
+              <SMButton
+                margin
+                role="button"
+                className={classes.modalButton}
+                messageID="feedback.modal.confirm"
+                color="primary"
+                onClick={() => {
+                  setModalOpen(false);
+                  if (modalOpen === 'send') {
+                    navigator.goBack();
+                  }
+                }}
+              />
+            </div>
+          </Dialog>
+        )
+      }
 
       <form className={classes.container}>
         <TitleBar


### PR DESCRIPTION
Feedback dialog showed error message when `modalOpen` changed from `send` to `false`. It seems like the dialog content updates before `open` value is changed to `false`. This caused flashing error message because text is changed in dialog but it did not close the dialog right away.

Changed dialog to not be rendered if `modalOpen` is `false`