### PR TITLE
Fix/map change error

### DIFF
--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -2,7 +2,8 @@
     "extends": ["airbnb"],
     "rules": {
         "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
-        "no-shadow": 0
+        "no-shadow": 0,
+        "no-console": ["error", { "allow": ["warn"] }] 
     },
     "env": {
         "browser": true,

--- a/src/views/MapView/MapView.js
+++ b/src/views/MapView/MapView.js
@@ -124,7 +124,7 @@ const MapView = (props) => {
       }
     }
     return null;
-  }
+  };
 
   const setClickCoordinates = (ev) => {
     setMapClickPoint(null);
@@ -217,7 +217,7 @@ const MapView = (props) => {
   }, [settings.mapType]);
 
   useEffect(() => {
-    if (!mapUtility && mapRef.current) {
+    if (mapRef.current) {
       setMapUtility(new MapUtility({ leaflet: mapRef.current.leafletElement }));
     }
   }, [mapRef.current]);

--- a/src/views/MapView/utils/mapActions.js
+++ b/src/views/MapView/utils/mapActions.js
@@ -25,7 +25,11 @@ const fitUnitsToMap = (units, map) => {
     }
   });
   if (bounds.length > 0) {
-    map.fitBounds(bounds, { padding: [15, 15], maxZoom: maxZoom - 1 });
+    try {
+      map.fitBounds(bounds, { padding: [15, 15], maxZoom: maxZoom - 1 });
+    } catch (err) {
+      console.warn('Fit units to map failed', err);
+    }
   }
 };
 

--- a/src/views/SearchView/SearchView.js
+++ b/src/views/SearchView/SearchView.js
@@ -33,7 +33,7 @@ class SearchView extends React.Component {
 
   componentDidMount() {
     const {
-      fetchUnits, units, map,
+      fetchUnits, units,
     } = this.props;
     const options = this.searchParamData();
 
@@ -45,13 +45,13 @@ class SearchView extends React.Component {
 
     if (this.shouldFetch() && Object.keys(options).length) {
       fetchUnits(options);
-      this.focusMap(units, map);
+      this.focusMap(units);
     }
   }
 
   shouldComponentUpdate(nextProps) {
     const {
-      fetchUnits, units, map,
+      fetchUnits, units,
     } = this.props;
     const {
       isRedirectFetching,
@@ -65,12 +65,12 @@ class SearchView extends React.Component {
     if (this.shouldFetch(nextProps)) {
       const searchData = this.searchParamData(nextProps);
       fetchUnits(searchData);
-      this.focusMap(units, map);
+      this.focusMap(units);
       return false;
     }
-    // If new search results, call map focus functio
-    if (nextProps.units.length > 0 && units !== nextProps.units) {
-      this.focusMap(nextProps.units, map);
+    // If new search results, call map focus function
+    if (nextProps.units.length > 0 && JSON.stringify(units) !== JSON.stringify(nextProps.units)) {
+      this.focusMap(nextProps.units);
     }
     return true;
   }
@@ -217,8 +217,8 @@ class SearchView extends React.Component {
     return false;
   }
 
-  focusMap = (units, map) => {
-    const { location } = this.props;
+  focusMap = (units) => {
+    const { location, map } = this.props;
     if (getSearchParam(location, 'bbox')) {
       return;
     }


### PR DESCRIPTION
- Fixed crash that happened when changing map to high contrast map and then opening unit from search results. This was caused by MapUtility not updating and using old map object.
- Fixed broken search view array compare that caused map to be centered to results every time props changed (when changing to high contrast)