### PR TITLE
Fix/sentry errors

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -21,7 +21,10 @@ import config from '../config';
 if (config.sentryDSN) {
   Sentry.init({
     dsn: config.sentryDSN,
-    ignoreErrors: ['AbortError'],
+    ignoreErrors: [
+      'AbortError',
+      /adrum/,
+    ],
   });
 }
 

--- a/src/redux/selectors/district.js
+++ b/src/redux/selectors/district.js
@@ -37,10 +37,10 @@ export const getSubdistrictServices = createSelector(
   [getSubdistrictSelection, getSubdistrictUnits, settings],
   (selectedSubdistricts, unitData, settings) => {
     const selectedCities = Object.values(settings.cities).filter(city => city);
-    const cityFilteredUnits = selectedCities.length
+    const cityFilteredUnits = selectedCities?.length
       ? unitData.filter(unit => settings.cities[unit.municipality])
       : unitData;
-    if (selectedSubdistricts.length && unitData) {
+    if (selectedSubdistricts?.length && unitData) {
       return cityFilteredUnits.filter(
         unit => selectedSubdistricts.some(district => district === unit.division_id),
       );

--- a/src/utils/fetch/fetch.js
+++ b/src/utils/fetch/fetch.js
@@ -135,7 +135,11 @@ const handleFetch = async (
       return res;
     })
     .catch((err) => {
-      console.error(`Error while fetching data: ${err.message}`);
+      if (err instanceof TypeError) {
+        console.warn(`TypeError while fetching data: ${err.message}`);
+      } else {
+        console.error(`Error while fetching data: ${err.message}`);
+      }
       // eslint-disable-next-line no-param-reassign
       abortController = null;
       if (onError) {


### PR DESCRIPTION
Fixed errors shown in Sentry logs.

- Prevent TypeErrors caught in fetch from being logged as errors
- Ignore adrum errors in Sentry
- Fix getSubdistrictServices trying to access length of undefined value