### PR TITLE
Fix/area view usability

### DIFF
--- a/src/views/AreaView/AreaView.js
+++ b/src/views/AreaView/AreaView.js
@@ -317,6 +317,11 @@ const AreaView = ({
     if (selectedAddress && addressDistrict) {
       const district = selectedDistrictData.find(obj => obj.id === addressDistrict);
       focusMapToDistrict(district);
+      // Add local geographical district
+      const selectedCategory = dataStructure.find(i => i.districts.includes(selectedDistrictType));
+      if (selectedCategory?.id === 'geographical') {
+        setSelectedSubdistricts([...selectedSubdistricts, district.ocd_id]);
+      }
     }
   }, [addressDistrict, map]);
 

--- a/src/views/AreaView/components/AreaTab/AreaTab.js
+++ b/src/views/AreaView/components/AreaTab/AreaTab.js
@@ -50,6 +50,7 @@ const AreaTab = (props) => {
     setSelectedSubdistricts([]);
     setDistrictRadioValue(district.id);
     setExpandedSubcategory(null);
+    setSelectedDistrictServices([]);
   };
 
   const handleCheckboxChange = (event, district) => {


### PR DESCRIPTION
- Remove selected services (on geographical district services tab) when area selection changes
- If user has selected an address, automatically select address district checkbox when choosing a geographical district 