### PR TITLE
Fix measuring mode interaction on marker clusters

### DIFF
--- a/src/views/MapView/components/MarkerCluster/MarkerCluster.js
+++ b/src/views/MapView/components/MarkerCluster/MarkerCluster.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import 'leaflet.markercluster/dist/MarkerCluster.css';
@@ -387,6 +387,25 @@ const MarkerCluster = ({
       if (measuringMode) item.classList.remove('leaflet-interactive');
     });
   }, [cluster, data, measuringMode]);
+
+  const removeMarkerInteraction = useCallback(() => {
+    /* Remove interactions from markers during measuring mode.
+     Use callback is used so that cluster.off() works correctly */
+    document.querySelectorAll('.leaflet-marker-icon').forEach((item) => {
+      item.classList.remove('leaflet-interactive');
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!cluster) return;
+    if (measuringMode) {
+      // Add event listener to remove marker interactions when new clusters are generated
+      cluster.on('animationend', removeMarkerInteraction);
+    } else {
+      // Remove event listener when measuring mode is closed
+      cluster.off('animationend', removeMarkerInteraction);
+    }
+  }, [measuringMode]);
 
   return null;
 };


### PR DESCRIPTION
Disabled cluster interaction during measuring mode also on clusters that are generated/modified by zooming map.