### PR TITLE
Parse duplicates away from adminDistrict mapUnits

### DIFF
--- a/src/views/MapView/MapView.js
+++ b/src/views/MapView/MapView.js
@@ -95,7 +95,17 @@ const MapView = (props) => {
         case 'adminDistricts':
           mapUnits = adminDistricts ? adminDistricts
             .filter(d => d.unit)
-            .map(d => d.unit)
+            .reduce((unique, o) => {
+              // Ignore districts without unit
+              if (!o.unit) {
+                return unique;
+              }
+              // Add only unique units
+              if (!unique.some(obj => obj.id === o.unit.id)) {
+                unique.push(o.unit);
+              }
+              return unique;
+            }, [])
             : [];
           break;
         case 'units':


### PR DESCRIPTION
Use reducer to parse duplicate map units in address view.