### PR TITLE
Hide ReadSpeaker button from screenreaders

### DIFF
--- a/src/components/ReadSpeakerButton/ReadSpeakerButton.js
+++ b/src/components/ReadSpeakerButton/ReadSpeakerButton.js
@@ -39,7 +39,7 @@ const ReadSpeakerButton = ({
     return null;
   }
   return (
-    <div id="readspeaker_button1" className={`rs_skip rsbtn rs_preserve ${className || ''}`}>
+    <div aria-hidden="true" id="readspeaker_button1" className={`rs_skip rsbtn rs_preserve ${className || ''}`}>
       <a
         rel="nofollow"
         className="rsbtn_play"


### PR DESCRIPTION
Hiding ReadSpeaker button from screen readers until ReadSpeaker fixes their accessibility