### PR TITLE
Fix/jest tests

### DIFF
--- a/src/components/DrawerMenu/__tests__/__snapshots__/DrawerButton.test.js.snap
+++ b/src/components/DrawerMenu/__tests__/__snapshots__/DrawerButton.test.js.snap
@@ -5,7 +5,7 @@ exports[`<DrawerButton /> should work 1`] = `
   active={false}
   disableRipple={true}
   disabled={false}
-  icon={<UNDEFINED />}
+  icon={<Memo />}
   isOpen={false}
   onClick={[Function]}
   subText="Drawer button subtext"
@@ -28,7 +28,7 @@ exports[`<DrawerButton /> should work 1`] = `
     }
     disableRipple={true}
     disabled={false}
-    icon={<UNDEFINED />}
+    icon={<Memo />}
     isOpen={false}
     onClick={[Function]}
     subText="Drawer button subtext"

--- a/src/components/ListItems/SimpleListItem/SimpleListItem.js
+++ b/src/components/ListItems/SimpleListItem/SimpleListItem.js
@@ -50,11 +50,6 @@ const SimpleListItem = (props) => {
         <ListItemText
           classes={{ root: classes.textContainer }}
         >
-          {/* ReadSpeaker text - hidden form view and screen readers */}
-          <Typography aria-hidden variant="srOnly">
-            {`${srText || ''}`}
-          </Typography>
-
           <Typography
             color="inherit"
             variant="body2"

--- a/src/components/ListItems/SimpleListItem/__tests__/SimpleListItem.test.js
+++ b/src/components/ListItems/SimpleListItem/__tests__/SimpleListItem.test.js
@@ -91,14 +91,14 @@ describe('<SimpleListItem />', () => {
   it('does use default accessibility attributes correctly', () => {
     const component = mount(<SimpleListItem {...mockProps} />);
 
-    const srText = component.find('span').at(1);
+    const srText = component.find('span').at(0);
     const text = component.find('p').at(0);
 
     // Expect screen reader texts to render correctly
-    expect(component.find('ForwardRef(ListItem)').props()['aria-label'].indexOf(mockProps.text) !== -1).toBeTruthy();
+    expect(component.find('ForwardRef(ListItem)').text().indexOf(mockProps.text) !== -1).toBeTruthy();
     // Expect aria-hidden attributes to be placed correctly
-    expect(srText.props()['aria-hidden']).toBeTruthy();
-    expect(text.props()['aria-hidden']).toBeTruthy();
+    expect(srText.props()['aria-hidden']).toBeFalsy();
+    expect(text.props()['aria-hidden']).toBeFalsy();
     // Expect role to be set
     expect(component.find('ForwardRef(ListItem)').props().role).toEqual(null);
     // Expect element to have tabIndex -1
@@ -116,16 +116,18 @@ describe('<SimpleListItem />', () => {
       />,
     );
 
-    const srText = component.find('span').at(1).text();
-    const containsText = srText.indexOf('Screen reader text') !== -1;
-    const alText = component.find('ForwardRef(ListItem)').props()['aria-label'];
-    const alContainsText = alText.indexOf(mockProps.text) !== -1
-    && alText.indexOf('Screen reader text') !== -1;
+    const srText = component.find('span').at(0);
+    const visibleText = component.find('p').at(0);
+    const srTextContains = srText.text().indexOf('Screen reader text') !== -1;
+    const visibleTextContains = visibleText.text().indexOf(mockProps.text) !== -1;
 
-    // Expect screen reader text to contain both text and srText values
-    expect(alContainsText).toBeTruthy();
+    // Expect aria-hidden attributes to be placed correctly
+    expect(srText.props()['aria-hidden']).toBeFalsy();
+    expect(visibleText.props()['aria-hidden']).toBeFalsy();
+    // Expect visible text to contain given attribute
+    expect(visibleTextContains).toBeTruthy();
     // Expect screen reader only text to exist in separate span element
-    expect(containsText).toBeTruthy();
+    expect(srTextContains).toBeTruthy();
     // Expect role to be set
     expect(component.props().role).toEqual('button');
     // Expect divider element to be hidden from screen readers

--- a/src/components/ListItems/SimpleListItem/__tests__/__snapshots__/SimpleListItem.test.js.snap
+++ b/src/components/ListItems/SimpleListItem/__tests__/__snapshots__/SimpleListItem.test.js.snap
@@ -29,9 +29,8 @@ exports[`<SimpleListItem /> should work 1`] = `
     text="Title text"
   >
     <WithStyles(ForwardRef(ListItem))
-      aria-label=" Title text"
       button={false}
-      className={null}
+      className="null "
       classes={
         Object {
           "root": "SimpleListItem-listItem-1",
@@ -46,9 +45,8 @@ exports[`<SimpleListItem /> should work 1`] = `
       tabIndex={-1}
     >
       <ForwardRef(ListItem)
-        aria-label=" Title text"
         button={false}
-        className={null}
+        className="null "
         classes={
           Object {
             "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
@@ -72,8 +70,7 @@ exports[`<SimpleListItem /> should work 1`] = `
         tabIndex={-1}
       >
         <li
-          aria-label=" Title text"
-          className="MuiListItem-root SimpleListItem-listItem-1 MuiListItem-gutters"
+          className="MuiListItem-root SimpleListItem-listItem-1 null  MuiListItem-gutters"
           disabled={false}
           onClick={null}
           onKeyDown={null}
@@ -104,13 +101,15 @@ exports[`<SimpleListItem /> should work 1`] = `
                 className="MuiListItemText-root SimpleListItem-textContainer-2"
               >
                 <WithStyles(ForwardRef(Typography))
-                  className="MuiListItemText-primary"
-                  component="span"
-                  display="block"
-                  variant="body1"
+                  classes={
+                    Object {
+                      "root": "null ",
+                    }
+                  }
+                  color="inherit"
+                  variant="body2"
                 >
                   <ForwardRef(Typography)
-                    className="MuiListItemText-primary"
                     classes={
                       Object {
                         "alignCenter": "MuiTypography-alignCenter",
@@ -139,25 +138,22 @@ exports[`<SimpleListItem /> should work 1`] = `
                         "noWrap": "MuiTypography-noWrap",
                         "overline": "MuiTypography-overline",
                         "paragraph": "MuiTypography-paragraph",
-                        "root": "MuiTypography-root",
+                        "root": "MuiTypography-root null ",
                         "srOnly": "MuiTypography-srOnly",
                         "subtitle1": "MuiTypography-subtitle1",
                         "subtitle2": "MuiTypography-subtitle2",
                       }
                     }
-                    component="span"
-                    display="block"
-                    variant="body1"
+                    color="inherit"
+                    variant="body2"
                   >
-                    <span
-                      className="MuiTypography-root MuiListItemText-primary MuiTypography-body1 MuiTypography-displayBlock"
+                    <p
+                      className="MuiTypography-root null  MuiTypography-body2 MuiTypography-colorInherit"
                     >
                       <WithStyles(ForwardRef(Typography))
-                        aria-hidden={true}
                         variant="srOnly"
                       >
                         <ForwardRef(Typography)
-                          aria-hidden={true}
                           classes={
                             Object {
                               "alignCenter": "MuiTypography-alignCenter",
@@ -195,69 +191,12 @@ exports[`<SimpleListItem /> should work 1`] = `
                           variant="srOnly"
                         >
                           <span
-                            aria-hidden={true}
                             className="MuiTypography-root MuiTypography-srOnly"
                           />
                         </ForwardRef(Typography)>
                       </WithStyles(ForwardRef(Typography))>
-                      <WithStyles(ForwardRef(Typography))
-                        aria-hidden={true}
-                        classes={
-                          Object {
-                            "root": "null ",
-                          }
-                        }
-                        color="inherit"
-                        variant="body2"
-                      >
-                        <ForwardRef(Typography)
-                          aria-hidden={true}
-                          classes={
-                            Object {
-                              "alignCenter": "MuiTypography-alignCenter",
-                              "alignJustify": "MuiTypography-alignJustify",
-                              "alignLeft": "MuiTypography-alignLeft",
-                              "alignRight": "MuiTypography-alignRight",
-                              "body1": "MuiTypography-body1",
-                              "body2": "MuiTypography-body2",
-                              "button": "MuiTypography-button",
-                              "caption": "MuiTypography-caption",
-                              "colorError": "MuiTypography-colorError",
-                              "colorInherit": "MuiTypography-colorInherit",
-                              "colorPrimary": "MuiTypography-colorPrimary",
-                              "colorSecondary": "MuiTypography-colorSecondary",
-                              "colorTextPrimary": "MuiTypography-colorTextPrimary",
-                              "colorTextSecondary": "MuiTypography-colorTextSecondary",
-                              "displayBlock": "MuiTypography-displayBlock",
-                              "displayInline": "MuiTypography-displayInline",
-                              "gutterBottom": "MuiTypography-gutterBottom",
-                              "h1": "MuiTypography-h1",
-                              "h2": "MuiTypography-h2",
-                              "h3": "MuiTypography-h3",
-                              "h4": "MuiTypography-h4",
-                              "h5": "MuiTypography-h5",
-                              "h6": "MuiTypography-h6",
-                              "noWrap": "MuiTypography-noWrap",
-                              "overline": "MuiTypography-overline",
-                              "paragraph": "MuiTypography-paragraph",
-                              "root": "MuiTypography-root null ",
-                              "srOnly": "MuiTypography-srOnly",
-                              "subtitle1": "MuiTypography-subtitle1",
-                              "subtitle2": "MuiTypography-subtitle2",
-                            }
-                          }
-                          color="inherit"
-                          variant="body2"
-                        >
-                          <p
-                            aria-hidden={true}
-                            className="MuiTypography-root null  MuiTypography-body2 MuiTypography-colorInherit"
-                          >
-                            Title text
-                          </p>
-                        </ForwardRef(Typography)>
-                      </WithStyles(ForwardRef(Typography))>
-                    </span>
+                      Title text
+                    </p>
                   </ForwardRef(Typography)>
                 </WithStyles(ForwardRef(Typography))>
               </div>

--- a/src/components/ListItems/SuggestionItem/__tests__/__snapshots__/SuggestionItem.test.js.snap
+++ b/src/components/ListItems/SuggestionItem/__tests__/__snapshots__/SuggestionItem.test.js.snap
@@ -2,12 +2,12 @@
 
 exports[`<SuggestionItem /> should work 1`] = `
 <injectIntl(WithStyles(SuggestionItem))
-  icon={<UNDEFINED />}
+  icon={<Memo />}
   subtitle="Subtitle text"
   text="Title text"
 >
   <WithStyles(SuggestionItem)
-    icon={<UNDEFINED />}
+    icon={<Memo />}
     intl={
       Object {
         "defaultFormats": Object {},
@@ -66,7 +66,7 @@ exports[`<SuggestionItem /> should work 1`] = `
       divider={false}
       handleArrowClick={null}
       handleItemClick={null}
-      icon={<UNDEFINED />}
+      icon={<Memo />}
       intl={
         Object {
           "defaultFormats": Object {},


### PR DESCRIPTION
- Fix ReadSpeaker interaction with SimpleListItem. After changing from aria-label to hidden DOM element in #534 hidden ReadSpeaker element is not necessary and causes multiple label readings for SimpleListItems.
- Fix jest tests
- Update snapshots 