### PR TITLE
Fix/pagination accessibility

### DIFF
--- a/browserTests/serviceTest.js
+++ b/browserTests/serviceTest.js
@@ -127,3 +127,18 @@ test('Pagination attributes change correctly', async (t) => {
     .expect(buttons.nth(4).getAttribute('tabindex')).eql('-1')
   ;
 });
+
+test('Pagination\'s page change focuses correctly', async(t) => {
+  const resultList = ReactSelector('ResultList');
+  const focusTarget = resultList.find('p').nth(1);
+  const pagination = ReactSelector('PaginationComponent');
+  const buttons = pagination.find('button');
+
+  await t
+    .click(buttons.nth(3))
+    // Focus target should be focused
+    .expect(focusTarget.focused).ok()
+    // Focus target should be screen reader text with pagination information
+    .expect(focusTarget.innerText).contains('sivu 2 kautta')
+  ;
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -18519,6 +18519,12 @@
         "lodash._bindcallback": "^3.0.0"
       }
     },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "dev": true
+    },
     "lodash.istypedarray": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
@@ -24436,6 +24442,15 @@
       "requires": {
         "loose-envify": "^1.4.0",
         "symbol-observable": "^1.2.0"
+      }
+    },
+    "redux-mock-store": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.5.4.tgz",
+      "integrity": "sha512-xmcA0O/tjCLXhh9Fuiq6pMrJCwFRaouA8436zcikdIpYWWCjU76CRk+i2bHx8EeiSiMGnB85/lZdU3wIJVXHTA==",
+      "dev": true,
+      "requires": {
+        "lodash.isplainobject": "^4.0.6"
       }
     },
     "redux-thunk": {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "jest": "^24.9.0",
     "jest-canvas-mock": "^2.3.0",
     "jest-enzyme": "^7.1.2",
+    "redux-mock-store": "^1.5.4",
     "testcafe": "^1.9.4",
     "testcafe-react-selectors": "^4.1.1",
     "webpack": "^4.44.2",

--- a/src/components/Lists/ResultList/ResultList.js
+++ b/src/components/Lists/ResultList/ResultList.js
@@ -18,7 +18,7 @@ class ResultList extends React.Component {
 
   render() {
     const {
-      classes, data, customComponent, listId, resultCount, title, titleComponent,
+      beforeList, classes, data, customComponent, listId, resultCount, title, titleComponent,
     } = this.props;
 
     return (
@@ -53,6 +53,7 @@ class ResultList extends React.Component {
           )
         }
         <Divider aria-hidden="true" />
+        {beforeList}
         <List className={classes.list} id={listId}>
           {
             data && data.length
@@ -94,6 +95,7 @@ export default ResultList;
 
 // Typechecking
 ResultList.propTypes = {
+  beforeList: PropTypes.node,
   classes: PropTypes.objectOf(PropTypes.any),
   customComponent: PropTypes.func,
   data: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.any)).isRequired,
@@ -104,6 +106,7 @@ ResultList.propTypes = {
 };
 
 ResultList.defaultProps = {
+  beforeList: null,
   classes: {},
   customComponent: null,
   resultCount: null,

--- a/src/components/Lists/ResultList/__tests__/ResultList.test.js
+++ b/src/components/Lists/ResultList/__tests__/ResultList.test.js
@@ -1,0 +1,109 @@
+// Link.react.test.js
+import React from 'react';
+import { createShallow } from '@material-ui/core/test-utils';
+import { MuiThemeProvider } from '@material-ui/core';
+import { IntlProvider } from 'react-intl';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import themes from '../../../../themes';
+import ResultList from '../ResultList';
+import { initialState } from '../../../../redux/reducers/user';
+
+const mockData = [
+  {
+    accessibility_properties: [],
+    accessibility_shortcoming_count: {},
+    contract_type: {
+      id: 'municipal_service',
+      description: { fi: 'kunnallinen palvelu', sv: 'kommunal tjänst', en: 'municipal service' },
+    },
+    id: 63115,
+    municipality: 'espoo',
+    name: { fi: 'Lippulaivan kirjasto', sv: 'Lippulaivabiblioteket', en: 'Lippulaiva library' },
+    object_type: 'unit',
+    street_address: { fi: 'Merikarhunkuja 11', sv: 'Sjöbjörnsgränden 11', en: 'Merikarhunkuja 11' },
+  },
+  {
+    accessibility_properties: [],
+    accessibility_shortcoming_count: {},
+    contract_type: {
+      id: 'municipal_service',
+      description: { fi: 'kunnallinen palvelu', sv: 'kommunal tjänst', en: 'municipal service' },
+    },
+    id: 62032,
+    municipality: 'vantaa',
+    name: {
+      fi: 'Kivistön kirjasto',
+      sv: 'Kivistö bibliotek',
+      en: 'Kivistö Library',
+    },
+    object_type: 'unit',
+    street_address: { fi: 'Topaasikuja 11', sv: 'Topasgränden 11', en: 'Topaasikuja 11' },
+  },
+];
+
+// Generic required props for SimpleListItem
+const mockProps = {
+  beforeList: <p>Test before list</p>,
+  customComponent: null,
+  data: mockData,
+  listId: 'testID',
+  resultCount: 5,
+  title: 'Title text',
+  titleComponent: 'h3',
+};
+
+// Mock props for intl provider
+const intlMock = {
+  locale: 'en',
+  messages: {
+    'search.resultList': 'Search result text',
+    'general.pagination.pageCount': 'Page {current} of {max}',
+  },
+};
+
+const mockStore = configureStore([]);
+
+// eslint-disable-next-line react/prop-types
+const Providers = ({ children }) => {
+  const store = mockStore({
+    user: initialState,
+    settings: {},
+  });
+
+  return (
+    <Provider store={store}>
+      <IntlProvider {...intlMock}>
+        <MuiThemeProvider theme={themes.SMTheme}>
+          {children}
+        </MuiThemeProvider>
+      </IntlProvider>
+    </Provider>
+  );
+};
+
+describe('<ResultList />', () => {
+  // let render;
+  let shallow;
+
+  beforeEach(() => {
+    shallow = createShallow({ wrappingComponent: Providers });
+  });
+
+  it('should work', () => {
+    const component = shallow(<ResultList {...mockProps} />);
+    expect(component).toMatchSnapshot();
+  });
+
+  it('does render list', () => {
+    const component = shallow(<ResultList {...mockProps} />);
+    const count = component.find('injectIntl(WithStyles(Connect(UnitItem)))').length;
+    expect(count === 2).toBeTruthy();
+  });
+
+  it('does render beforeList', () => {
+    const component = shallow(<ResultList {...mockProps} />);
+    const text = component.find('p').at(0).text();
+    expect(text).toEqual('Test before list');
+  });
+});

--- a/src/components/Lists/ResultList/__tests__/__snapshots__/ResultList.test.js.snap
+++ b/src/components/Lists/ResultList/__tests__/__snapshots__/ResultList.test.js.snap
@@ -1,0 +1,107 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ResultList /> should work 1`] = `
+<div>
+  <div>
+    <div>
+      <WithStyles(ForwardRef(Typography))
+        aria-labelledby="testID-result-title testID-result-title-info"
+        className="undefined undefined SearchResultTitle"
+        component="h3"
+        id="testID-result-title"
+        tabIndex="-1"
+        variant="subtitle1"
+      >
+        Title text
+      </WithStyles(ForwardRef(Typography))>
+      <WithStyles(ForwardRef(Typography))
+        aria-hidden="true"
+        component="p"
+        id="testID-result-title-info"
+        variant="caption"
+      >
+        <FormattedMessage
+          id="search.resultList"
+          values={
+            Object {
+              "count": 5,
+            }
+          }
+        />
+      </WithStyles(ForwardRef(Typography))>
+    </div>
+  </div>
+  <WithStyles(ForwardRef(Divider))
+    aria-hidden="true"
+  />
+  <p>
+    Test before list
+  </p>
+  <WithStyles(ForwardRef(List))
+    id="testID"
+  >
+    <injectIntl(WithStyles(Connect(UnitItem)))
+      className="unit-63115"
+      key="unit-63115"
+      unit={
+        Object {
+          "accessibility_properties": Array [],
+          "accessibility_shortcoming_count": Object {},
+          "contract_type": Object {
+            "description": Object {
+              "en": "municipal service",
+              "fi": "kunnallinen palvelu",
+              "sv": "kommunal tjänst",
+            },
+            "id": "municipal_service",
+          },
+          "id": 63115,
+          "municipality": "espoo",
+          "name": Object {
+            "en": "Lippulaiva library",
+            "fi": "Lippulaivan kirjasto",
+            "sv": "Lippulaivabiblioteket",
+          },
+          "object_type": "unit",
+          "street_address": Object {
+            "en": "Merikarhunkuja 11",
+            "fi": "Merikarhunkuja 11",
+            "sv": "Sjöbjörnsgränden 11",
+          },
+        }
+      }
+    />
+    <injectIntl(WithStyles(Connect(UnitItem)))
+      className="unit-62032"
+      key="unit-62032"
+      unit={
+        Object {
+          "accessibility_properties": Array [],
+          "accessibility_shortcoming_count": Object {},
+          "contract_type": Object {
+            "description": Object {
+              "en": "municipal service",
+              "fi": "kunnallinen palvelu",
+              "sv": "kommunal tjänst",
+            },
+            "id": "municipal_service",
+          },
+          "id": 62032,
+          "municipality": "vantaa",
+          "name": Object {
+            "en": "Kivistö Library",
+            "fi": "Kivistön kirjasto",
+            "sv": "Kivistö bibliotek",
+          },
+          "object_type": "unit",
+          "street_address": Object {
+            "en": "Topaasikuja 11",
+            "fi": "Topaasikuja 11",
+            "sv": "Topasgränden 11",
+          },
+        }
+      }
+    />
+  </WithStyles(ForwardRef(List))>
+</div>
+`;

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -221,7 +221,7 @@ const translations = {
   'general.pagination.next': 'Next page',
   'general.pagination.openPage': 'Open page {count}',
   'general.pagination.currentlyOpenedPage': 'Page {count} currently opened',
-  'general.pagination.pageCount': 'page {current} / {max}',
+  'general.pagination.pageCount': 'page {current} of {max}',
 
   'general.previousSearch': 'Previous searches',
   'general.return.viewTitle': 'Return to beginning of main content',

--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -220,7 +220,7 @@ const translations = {
   'general.pagination.next': 'Seuraava sivu',
   'general.pagination.openPage': 'Avaa sivu {count}',
   'general.pagination.currentlyOpenedPage': 'Sivu {count}, avattu',
-  'general.pagination.pageCount': 'sivu {current} / {max}',
+  'general.pagination.pageCount': 'sivu {current} kautta {max}',
 
   'general.previousSearch': 'Aikaisemmat haut',
   'general.return.viewTitle': 'Siirry pääsisällön alkuun',

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -217,7 +217,7 @@ const translations = {
   'general.pagination.next': 'Följande sida',
   'general.pagination.openPage': 'Öppna sida {count}',
   'general.pagination.currentlyOpenedPage': 'Sida {count} öppnad',
-  'general.pagination.pageCount': 'sida {current} / {max}',
+  'general.pagination.pageCount': 'sida {current} av {max}',
 
   'general.previousSearch': 'Föregående sökningar',
   'general.return.viewTitle': 'Gå till början av huvudinnehållet',

--- a/src/redux/reducers/user.js
+++ b/src/redux/reducers/user.js
@@ -1,5 +1,5 @@
 
-const initialState = {
+export const initialState = {
   initialLoad: false,
   locale: 'fi',
   page: 'home',

--- a/src/views/ServiceView/ServiceView.js
+++ b/src/views/ServiceView/ServiceView.js
@@ -134,6 +134,7 @@ class ServiceView extends React.Component {
     const showServiceWithoutUnits = current && !isFetching && !serviceUnits;
 
     const initialOrder = customPosition ? 'distance-asc' : null;
+    const paginatedListTitle = intl.formatMessage({ id: 'unit.plural' });
 
     return (
       <div>
@@ -171,7 +172,8 @@ class ServiceView extends React.Component {
           <PaginatedList
             id="events"
             data={serviceUnits || []}
-            title={intl.formatMessage({ id: 'unit.plural' })}
+            srTitle={paginatedListTitle}
+            title={paginatedListTitle}
             titleComponent="h4"
           />
         </Loading>

--- a/src/views/UnitView/components/ExtendedData/ExtendedData.js
+++ b/src/views/UnitView/components/ExtendedData/ExtendedData.js
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { useIntl } from 'react-intl';
 import { useParams } from 'react-router-dom';
 import EventItem from '../../../../components/ListItems/EventItem';
 import PaginatedList from '../../../../components/Lists/PaginatedList';
@@ -18,6 +18,7 @@ const ExtendedData = ({
   reservations,
   type,
 }) => {
+  const intl = useIntl();
   const { unit } = useParams();
   const title = currentUnit && currentUnit.name ? getLocaleText(currentUnit.name) : '';
 
@@ -45,13 +46,14 @@ const ExtendedData = ({
     }
   }, []);
 
+  const getTitleText = messageID => `${title} - ${intl.formatMessage({ id: messageID })}`;
+
   const renderTitleBar = messageID => (
     <TitleBar
       sticky
       title={(
         <>
-          {`${title} - `}
-          <FormattedMessage id={messageID} />
+          {getTitleText(messageID)}
         </>
       )}
       titleComponent="h3"
@@ -62,6 +64,8 @@ const ExtendedData = ({
 
   const renderEvents = () => {
     const { data } = events;
+    const titleText = intl.formatMessage({ id: 'unit.events' });
+    const srTitle = `${title} ${titleText}`;
 
     return (
       <div>
@@ -75,6 +79,8 @@ const ExtendedData = ({
             customComponent={event => (
               <EventItem key={event.id} event={event} />
             )}
+            srTitle={srTitle}
+            title={titleText}
             titleComponent="h3"
           />
         </Loading>
@@ -84,6 +90,8 @@ const ExtendedData = ({
 
   const renderReservations = () => {
     const { data } = reservations;
+    const titleText = intl.formatMessage({ id: 'unit.reservations' });
+    const srTitle = `${title} ${titleText}`;
 
     return (
       <div>
@@ -97,6 +105,8 @@ const ExtendedData = ({
             customComponent={item => (
               <ReservationItem key={item.id} reservation={item} />
             )}
+            srTitle={srTitle}
+            title={titleText}
             titleComponent="h3"
           />
         </Loading>


### PR DESCRIPTION
Fix pagination list to focus correctly to info element designed for screen readers. This helps both screen reader users and keyboard users to move into beginning of the list on page change.

Added jest tests for ResultList
Added browser test for service view's pagination focus handling