### PR TITLE
Fix/search view focus

### DIFF
--- a/src/components/Lists/PaginatedList/PaginatedList.js
+++ b/src/components/Lists/PaginatedList/PaginatedList.js
@@ -9,6 +9,7 @@ import PaginationComponent from '../../PaginationComponent';
 import { parseSearchParams, stringifySearchParams } from '../../../utils';
 
 const PaginatedList = ({
+  beforePagination,
   customComponent,
   data,
   id,
@@ -102,6 +103,9 @@ const PaginatedList = ({
         customComponent={customComponent}
       />
       {
+        beforePagination || null
+      }
+      {
         data.length > 0
         && (
           <PaginationComponent
@@ -116,6 +120,7 @@ const PaginatedList = ({
 };
 
 PaginatedList.propTypes = {
+  beforePagination: PropTypes.node,
   customComponent: PropTypes.func,
   data: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.any)).isRequired,
   id: PropTypes.string.isRequired,
@@ -127,6 +132,7 @@ PaginatedList.propTypes = {
 };
 
 PaginatedList.defaultProps = {
+  beforePagination: null,
   customComponent: null,
   itemsPerPage: 10,
   navigator: null,

--- a/src/components/TabLists/TabLists.js
+++ b/src/components/TabLists/TabLists.js
@@ -2,16 +2,15 @@
 import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import {
-  Typography, Tabs, Tab,
+  Tabs, Tab,
 } from '@material-ui/core';
 import { FormattedMessage } from 'react-intl';
 import { parseSearchParams, stringifySearchParams } from '../../utils';
-import ResultList from '../Lists/ResultList';
-import PaginationComponent from '../PaginationComponent';
 import ResultOrderer from '../ResultOrderer';
 import config from '../../../config';
 import useMobileStatus from '../../utils/isMobile';
 import AddressSearchBar from '../AddressSearchBar';
+import PaginatedList from '../Lists/PaginatedList';
 
 const TabLists = ({
   changeCustomUserLocation,
@@ -20,17 +19,12 @@ const TabLists = ({
   headerComponents,
   navigator,
   classes,
-  intl,
   userAddress,
 }) => {
-  // Option to change number of items shown per page
-  const itemsPerPage = 10;
-
   const isMobile = useMobileStatus();
 
   const searchParams = parseSearchParams(location.search);
   const filteredData = data.filter(item => item.component || (item.data && item.data.length > 0));
-  const getPagefromUrl = () => parseInt(searchParams.p, 10) || 1;
   const getTabfromUrl = () => {
     let index = data.findIndex(tab => tab.id === searchParams.t);
     if (index === -1) index = parseInt(searchParams.t, 10) || 0;
@@ -40,10 +34,8 @@ const TabLists = ({
     return index;
   };
 
-  const tabTitleClass = 'TabResultTitle';
   const sidebarClass = 'SidebarWrapper';
 
-  const [currentPage, setCurrentPage] = useState(getPagefromUrl());
   const [scrollDistance, setScrollDistance] = useState(0);
   const [tabIndex, setTabIndex] = useState(getTabfromUrl());
   const [styles, setStyles] = useState({});
@@ -54,27 +46,6 @@ const TabLists = ({
   if (filteredData.length <= tabIndex) {
     setTabIndex(0);
   }
-
-  // Handle page number changes
-  const handlePageChange = (pageNum, pageCount) => {
-    if (pageNum >= 1 && pageNum <= pageCount) {
-      // Change page parameter in searchParams
-      const searchParams = parseSearchParams(location.search);
-      searchParams.p = pageNum;
-
-      // Get new search search params string
-      const searchString = stringifySearchParams(searchParams);
-      setCurrentPage(pageNum);
-      // Update p(page) param to current history
-      if (navigator) {
-        navigator.replace({
-          ...location,
-          search: `?${searchString || ''}`,
-        });
-      }
-    }
-  };
-
 
   const handleAddressChange = (address) => {
     if (address) {
@@ -129,7 +100,6 @@ const TabLists = ({
 
     // Get new search search params string
     const searchString = stringifySearchParams(searchParams);
-    setCurrentPage(1);
     setTabIndex(value);
 
     // Update p(page) param to current history
@@ -182,15 +152,6 @@ const TabLists = ({
       setStyles({ top: stickyElementPadding });
       setScrollDistance(tabsDistanceFromTop);
     }
-  };
-
-  // Calculate pageCount
-  const calculatePageCount = (data) => {
-    if (data && data.length) {
-      const newPageCount = Math.ceil(data.length / itemsPerPage);
-      return newPageCount;
-    }
-    return null;
   };
 
   const renderHeader = () => {
@@ -290,18 +251,6 @@ const TabLists = ({
     calculateHeaderStylings();
   }, [isMobile]);
 
-  useEffect(() => {
-    const firstListResult = document.querySelectorAll(`.${tabTitleClass}`)[0];
-    if (firstListResult) {
-      try {
-        firstListResult.focus();
-      } catch (e) {
-        console.error('Unable to focus on list title');
-      }
-    }
-  }, [currentPage]);
-
-
   const render = () => (
     <>
       {
@@ -339,20 +288,6 @@ const TabLists = ({
             );
           }
 
-          // Calculate pageCount and adjust currentPage
-          const pageCount = calculatePageCount(item.data);
-          const adjustedCurrentPage = currentPage > pageCount ? pageCount : currentPage;
-
-          // Calculate shown data
-          const endIndex = item.data.length >= itemsPerPage
-            ? adjustedCurrentPage * itemsPerPage
-            : item.data.length;
-          const startIndex = adjustedCurrentPage > 1
-            ? (adjustedCurrentPage - 1) * itemsPerPage
-            : 0;
-          const shownData = item.data.slice(startIndex, endIndex);
-
-          const additionalText = `${intl.formatMessage({ id: 'general.pagination.pageCount' }, { current: adjustedCurrentPage, max: pageCount })}`;
 
           return (
             <div
@@ -364,22 +299,12 @@ const TabLists = ({
                 index === tabIndex
                 && (
                   <>
-                    <Typography className={tabTitleClass} variant="srOnly" component="p" tabIndex="-1">
-                      {`${item.title} ${additionalText}`}
-                    </Typography>
-                    <ResultList
-                      data={shownData}
-                      listId={`${item.title}-results`}
-                      resultCount={item.data.length}
+                    <PaginatedList
+                      id={`${item.title}-results`}
+                      data={item.data}
                       titleComponent="h3"
-                    />
-                    {
-                      item.beforePagination || null
-                    }
-                    <PaginationComponent
-                      current={adjustedCurrentPage}
-                      pageCount={pageCount}
-                      handlePageChange={handlePageChange}
+                      beforePagination={item.beforePagination || null}
+                      srTitle={item.title}
                     />
                   </>
                 )

--- a/src/components/TabLists/TabLists.js
+++ b/src/components/TabLists/TabLists.js
@@ -2,7 +2,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import {
-  Tabs, Tab,
+  Tabs, Tab, Typography,
 } from '@material-ui/core';
 import { FormattedMessage } from 'react-intl';
 import { parseSearchParams, stringifySearchParams } from '../../utils';
@@ -16,6 +16,8 @@ const TabLists = ({
   changeCustomUserLocation,
   location,
   data,
+  focusClass,
+  focusText,
   headerComponents,
   navigator,
   classes,
@@ -193,6 +195,13 @@ const TabLists = ({
             </>
           )
         }
+        {
+          focusClass
+          && focusText
+          && (
+            <Typography variant="srOnly" className={focusClass} tabIndex="-1">{focusText}</Typography>
+          )
+        }
         <Tabs
           ref={tabsRef}
           className={`sticky ${classes.root}`}
@@ -335,12 +344,16 @@ TabLists.propTypes = {
   intl: PropTypes.objectOf(PropTypes.any).isRequired,
   location: PropTypes.objectOf(PropTypes.any).isRequired,
   navigator: PropTypes.objectOf(PropTypes.any),
+  focusClass: PropTypes.string,
+  focusText: PropTypes.string,
 };
 
 TabLists.defaultProps = {
   headerComponents: null,
   navigator: null,
   userAddress: null,
+  focusClass: null,
+  focusText: null,
 };
 
 export default TabLists;

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -387,6 +387,7 @@ const translations = {
   'search.infoText': '{count} Search results',
   'search.searchbar.headerText': 'Find services near your home',
   'search.searchbar.infoText': 'Search for services, locations or addresses',
+  'search.skipLink': 'Jump link to the search results',
   'search.suggestions.suggest': 'Did you mean..?',
   'search.suggestions.expand': 'Search suggestions',
   'search.suggestions.loading': 'Loading suggestions',

--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -387,6 +387,7 @@ const translations = {
   'search.infoText': '{count} Hakutulosta',
   'search.searchbar.headerText': 'Pääkaupunkiseudun kaikki julkiset palvelut ulottuvillasi.',
   'search.searchbar.infoText': 'Hae palveluita, toimipisteitä tai osoitteita',
+  'search.skipLink': 'Hyppylinkki hakutuloksiin',
   'search.suggestions.suggest': 'Tarkoititko..?',
   'search.suggestions.expand': 'Hakuehdotukset',
   'search.suggestions.loading': 'Ladataan ehdotuksia',

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -387,6 +387,7 @@ const translations = {
   'search.infoText': '{count} sökresultat',
   'search.searchbar.headerText': 'Alla tjänster i huvudstadsregionen inom räckhåll.',
   'search.searchbar.infoText': 'Sök tjänster, verksamhetsställen eller adresser',
+  'search.skipLink': 'Hoppa till sökresultaten',
   'search.suggestions.suggest': 'Menade du..?',
   'search.suggestions.expand': 'Sökförslag',
   'search.suggestions.loading': 'Laddar förslag',

--- a/src/views/SearchView/SearchView.js
+++ b/src/views/SearchView/SearchView.js
@@ -11,7 +11,7 @@ import styles from './styles';
 import Loading from '../../components/Loading';
 import SearchBar from '../../components/SearchBar';
 import { fitUnitsToMap } from '../MapView/utils/mapActions';
-import { parseSearchParams, getSearchParam } from '../../utils';
+import { parseSearchParams, getSearchParam, keyboardHandler } from '../../utils';
 import TabLists from '../../components/TabLists';
 import SMButton from '../../components/ServiceMapButton';
 import Container from '../../components/Container';
@@ -22,6 +22,8 @@ import DesktopComponent from '../../components/DesktopComponent';
 import MobileComponent from '../../components/MobileComponent';
 
 class SearchView extends React.Component {
+  focusClass = 'TabListFocusTarget';
+
   constructor(props) {
     super(props);
 
@@ -246,6 +248,13 @@ class SearchView extends React.Component {
     };
   }
 
+  skipToContent = () => {
+    const elem = document.getElementsByClassName(this.focusClass)[0];
+    if (elem) {
+      elem.focus();
+    }
+  }
+
   // Handles redirect if only single result is found
   handleSingleResultRedirect() {
     const {
@@ -342,6 +351,15 @@ class SearchView extends React.Component {
 
     return (
       <NoSsr>
+        <Typography
+          role="link"
+          tabIndex="-1"
+          onClick={this.skipToContent}
+          onKeyPress={() => { keyboardHandler(this.skipToContent(), ['space', 'enter']); }}
+          variant="srOnly"
+        >
+          <FormattedMessage id="search.skipLink" />
+        </Typography>
         {!isFetching && (
           <div align="left" className={className}>
             <div aria-live="polite" className={classes.infoContainer}>
@@ -475,6 +493,8 @@ class SearchView extends React.Component {
     return (
       <TabLists
         data={searchResults}
+        focusClass={this.focusClass}
+        focusText={intl.formatMessage({ id: 'search.results.title' })}
       />
     );
   }


### PR DESCRIPTION
Extended from #547 

Changed SearchView to use fixed PaginatedList component so we don't need pagination handling in two places.

Removed automatic focus on SearchView since it skipped all result ordering and tabs. Now when user comes to search page directly they'll start from the beginning of the page. If they come to search view from another page in Servicemap then focus is moved to back button like on all views. There might be a problem with user getting thrown behind search input. If user searched something on front page and now need to navigate through the same input-field to get to results. 

Not sure how this should work. Maybe focus to "x Hakutulosta" text automatically? But in that case finding back button becomes confusing.