### PR TITLE
Add back button to area view

### DIFF
--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -210,7 +210,7 @@ const translations = {
   'general.pageTitles.list.reservations': 'Varauslista',
   'general.pageTitles.info': 'Tietoa palvelusta',
   'general.pageTitles.feedback': 'Palautenäkymä',
-  'general.pageTitles.area': 'Aluenäkymä.',
+  'general.pageTitles.area': 'Aluenäkymä',
   // Readspeaker
   'general.readspeaker.buttonText': 'Kuuntele',
   'general.readspeaker.title': 'Kuuntele ReadSpeaker webReaderilla',

--- a/src/views/AreaView/AreaView.js
+++ b/src/views/AreaView/AreaView.js
@@ -12,6 +12,7 @@ import { parseSearchParams, uppercaseFirst } from '../../utils';
 import AreaTab from './components/AreaTab';
 import { districtFetch } from '../../utils/fetch';
 import fetchAddress from '../MapView/utils/fetchAddress';
+import TitleBar from '../../components/TitleBar';
 
 
 const fetchReducer = (state, action) => {
@@ -465,7 +466,11 @@ const AreaView = ({
     if (!embed) {
       return (
         <div>
-          <div className={classes.topBar} />
+          <TitleBar
+            title={intl.formatMessage({ id: 'general.pageTitles.area' })}
+            titleComponent="p"
+            backButton
+          />
           <TabLists
             data={tabs}
           />


### PR DESCRIPTION
Added title bar to area view. Decided to use "p" instead of heading, since the page title with the same name is just before title bar.