### PR TITLE
Fix/mobile suggestion accessibility

### DIFF
--- a/src/components/ListItems/SuggestionItem/SuggestionItem.js
+++ b/src/components/ListItems/SuggestionItem/SuggestionItem.js
@@ -19,7 +19,6 @@ const SuggestionItem = (props) => {
     handleItemClick,
     handleArrowClick,
     icon,
-    intl,
     selected,
     subtitle,
     query,
@@ -53,13 +52,10 @@ const SuggestionItem = (props) => {
         onKeyDown={keyboardHandler(onClick, ['space', 'enter'])}
         onKeyUp={() => setMouseDown(false)}
         role="link"
-        tabIndex="0"
+        aria-label={`${text} ${subtitle || ''}`}
       >
         <span
           className={classes.container}
-          type="submit"
-          role="link"
-          tabIndex="-1"
         >
           <ListItemIcon aria-hidden className={`${classes.listIcon}`}>
             {icon}
@@ -69,9 +65,6 @@ const SuggestionItem = (props) => {
             className={classes.text}
             classes={{ root: classes.textContainer }}
           >
-            <Typography variant="srOnly">
-              {`${text} ${subtitle || ''}`}
-            </Typography>
 
             <Typography
               aria-hidden
@@ -108,7 +101,6 @@ const SuggestionItem = (props) => {
           && (
             <Button
               aria-hidden
-              aria-label={intl.formatMessage({ id: 'search.arrowLabel' })}
               className={`${classes.suggestIcon}`}
               classes={{
                 label: classes.suggestIconLabel,
@@ -140,7 +132,6 @@ export default SuggestionItem;
 SuggestionItem.propTypes = {
   classes: PropTypes.objectOf(PropTypes.any).isRequired,
   text: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
-  intl: PropTypes.objectOf(PropTypes.any).isRequired,
   icon: PropTypes.objectOf(PropTypes.any),
   handleArrowClick: PropTypes.func,
   handleItemClick: PropTypes.func,

--- a/src/components/ListItems/SuggestionItem/SuggestionItem.js
+++ b/src/components/ListItems/SuggestionItem/SuggestionItem.js
@@ -107,6 +107,7 @@ const SuggestionItem = (props) => {
           && handleArrowClick
           && (
             <Button
+              aria-hidden
               aria-label={intl.formatMessage({ id: 'search.arrowLabel' })}
               className={`${classes.suggestIcon}`}
               classes={{

--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -230,7 +230,7 @@ class SearchBar extends React.Component {
           onChange={this.onInputChange}
           onFocus={this.activateSearch}
           onKeyDown={e => keyboardHandler(this.keyHandler(e), ['up, down'])}
-          onBlur={this.handleBlur}
+          onBlur={isMobile ? () => {} : this.handleBlur}
           endAdornment={
             inputValue
             && inputValue !== ''

--- a/src/components/SearchBar/components/SuggestionBox/SuggestionBox.js
+++ b/src/components/SearchBar/components/SuggestionBox/SuggestionBox.js
@@ -258,12 +258,12 @@ const SuggestionBox = (props) => {
       : `${classes.suggestionArea}`;
 
     return (
-      <>
+      <section aria-label={intl.formatMessage({ id: 'search.suggestions.expand' })}>
         <Paper elevation={20} className={containerStyles}>
           <p className="sr-only" aria-live="polite">{srText}</p>
           {component}
         </Paper>
-      </>
+      </section>
     );
   }
   return <></>;


### PR DESCRIPTION
- Suggestion arrow was not working at all on VoiceOver and TalkBack had issues with focus after pressing it. I suggest we disable it completely from screen readers, since it is a function that can be accessed later from search results. (Google does it like this as well)
- Added section-tag to tell screen readers where results start and end. Especially useful when browsing search history. Does not seem to work on TalkBack however.
- Disabled onBlur on mobile. On blur causes suggestion box to disappear when keyboard is closed on iOS. I think onBlur closing is not necessary on mobile?