### PR TITLE
Area view bugs

### DIFF
--- a/src/components/TitleBar/TitleBar.js
+++ b/src/components/TitleBar/TitleBar.js
@@ -76,7 +76,7 @@ TitleBar.propTypes = {
   backButtonSrText: PropTypes.string,
   classes: PropTypes.objectOf(PropTypes.any).isRequired,
   title: PropTypes.node.isRequired,
-  titleComponent: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']).isRequired,
+  titleComponent: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p']).isRequired,
   icon: PropTypes.objectOf(PropTypes.any),
   className: PropTypes.string,
   distance: PropTypes.string,

--- a/src/views/AreaView/components/UnitTab/UnitTab.js
+++ b/src/views/AreaView/components/UnitTab/UnitTab.js
@@ -45,9 +45,12 @@ const UnitTab = ({
     categories.sort((a, b) => getLocaleText(a.name).localeCompare(getLocaleText(b.name)));
   };
 
-  const distanceToAddress = coord => (
-    Math.round(distance(coord, selectedAddress.location.coordinates) * 1000)
-  );
+  const distanceToAddress = (coord) => {
+    if (coord) {
+      return Math.round(distance(coord, selectedAddress.location.coordinates) * 1000);
+    }
+    return null;
+  };
 
   const handleCheckboxChange = (event, category) => {
     let newArray;
@@ -215,14 +218,14 @@ const UnitTab = ({
       localDistrict.forEach((district) => {
         if (district.unit) {
           const newValue = district;
-          newValue.unit.distance = distanceToAddress(district.unit.location.coordinates);
+          newValue.unit.distance = distanceToAddress(district.unit.location?.coordinates);
           localUnitDistricts.push(newValue);
         }
         if (district.overlaping) {
           district.overlaping.forEach((obj) => {
             if (obj.unit) {
               const newValue = obj;
-              newValue.unit.distance = distanceToAddress(obj.unit.location.coordinates);
+              newValue.unit.distance = distanceToAddress(obj.unit.location?.coordinates);
               localUnitDistricts.push(newValue);
             }
           });
@@ -233,14 +236,14 @@ const UnitTab = ({
         if (district.municipality === selectedAddress.street.municipality) {
           if (district.unit) {
             const newValue = district;
-            newValue.unit.distance = distanceToAddress(district.unit.location.coordinates);
+            newValue.unit.distance = distanceToAddress(district.unit.location?.coordinates);
             otherUnitDistricts.push(newValue);
           }
           if (district.overlaping) {
             district.overlaping.forEach((obj) => {
               if (obj.unit) {
                 const newValue = obj;
-                newValue.unit.distance = distanceToAddress(obj.unit.location.coordinates);
+                newValue.unit.distance = distanceToAddress(obj.unit.location?.coordinates);
                 otherUnitDistricts.push(newValue);
               }
             });


### PR DESCRIPTION
- Units without location caused a crash when area unit tab was opened with address selected (example: choose an address, choose Finnish primary school area, select unit tab)
- Updated title bar to allow p tag as title prop. New area view title bar caused errors.