### PR TITLE
Add info text for UnitTab when district data doesn't have any units

### DIFF
--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -48,7 +48,7 @@ const translations = {
   'area.choose.subdistrict': 'Choose and open {category}',
   'area.close.subdistrict': 'Close {category}',
   'area.noSelection': 'Choose area from the Choice of Area tab',
-  'area.noUnits': 'Chosen area doesn\'t have units',
+  'area.noUnits': 'There are no service locations in your chosen area',
   'area.list.geographical': 'Geographical',
   'area.list.protection': 'Civil defence',
   'area.list.health': 'Health',

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -48,6 +48,7 @@ const translations = {
   'area.choose.subdistrict': 'Choose and open {category}',
   'area.close.subdistrict': 'Close {category}',
   'area.noSelection': 'Choose area from the Choice of Area tab',
+  'area.noUnits': 'Chosen area doesn\'t have units',
   'area.list.geographical': 'Geographical',
   'area.list.protection': 'Civil defence',
   'area.list.health': 'Health',

--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -48,6 +48,7 @@ const translations = {
   'area.choose.subdistrict': 'Valitse ja avaa {category}',
   'area.close.subdistrict': 'Sulje {category}',
   'area.noSelection': 'Valitse alue Alueen Valinta -välilehdeltä',
+  'area.noUnits': 'Valitsemallasi alueella ei ole toimipisteitä',
   'area.list.geographical': 'Maantieteellinen',
   'area.list.protection': 'Väestönsuojelu',
   'area.list.health': 'Terveys',

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -48,6 +48,7 @@ const translations = {
   'area.choose.subdistrict': 'Väl och öppna {category}',
   'area.close.subdistrict': 'Stäng {category}',
   'area.noSelection': 'Väl område under fliken Val av område',
+  'area.noUnits': 'Välj område har inga tjänster',
   'area.list.geographical': 'Geografisk',
   'area.list.protection': 'Befolkningsskydd',
   'area.list.health': 'Hälsa',

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -48,7 +48,7 @@ const translations = {
   'area.choose.subdistrict': 'Väl och öppna {category}',
   'area.close.subdistrict': 'Stäng {category}',
   'area.noSelection': 'Väl område under fliken Val av område',
-  'area.noUnits': 'Välj område har inga tjänster',
+  'area.noUnits': 'Det finns inga verksamhetsställen i ditt valda område',
   'area.list.geographical': 'Geografisk',
   'area.list.protection': 'Befolkningsskydd',
   'area.list.health': 'Hälsa',

--- a/src/views/AreaView/components/UnitTab/UnitTab.js
+++ b/src/views/AreaView/components/UnitTab/UnitTab.js
@@ -35,6 +35,7 @@ const UnitTab = ({
   classes,
   intl,
 }) => {
+  const districtsWithUnits = selectedDistrictData.filter(obj => obj.unit);
   const [checkedServices, setCheckedServices] = useState(selectedDistrictServices);
 
   const sortDistricts = (districts) => {
@@ -183,6 +184,16 @@ const UnitTab = ({
       );
     }
 
+    if (!districtsWithUnits.length) {
+      return (
+        <div>
+          <Typography className={classes.infoText} variant="body2">
+            <FormattedMessage id="area.noUnits" />
+          </Typography>
+        </div>
+      );
+    }
+
     if (selectedSubdistricts.length) {
       // If geographical subdistrict is selected, list units within the district
       return (
@@ -299,7 +310,7 @@ const UnitTab = ({
     return (
       <div>
         <List>
-          {selectedDistrictData.filter(obj => obj.unit).map(district => (
+          {districtsWithUnits.map(district => (
             renderDistrictUnitItem(district)
           ))}
         </List>


### PR DESCRIPTION
UnitTab didn't show anything if district didn't have any units. Added info text to solve this problem.