### PR TITLE
Hide description <br> elements from screen readers

### DIFF
--- a/src/components/DescriptionText/DescriptionText.js
+++ b/src/components/DescriptionText/DescriptionText.js
@@ -6,6 +6,9 @@ import isClient from '../../utils';
 const DescriptionText = ({
   description, html, classes, title, titleComponent,
 }) => {
+  // Hide linebreak html elements from screen readers
+  const hideBRFromSR = text => text.replaceAll('<br>', '<br aria-hidden="true" />');
+
   // Rendering only in client since dangerouslySetInnerHTML causes mismatch errors
   // between server and client HTML and not rendering anything on client side
   // TODO: Figure out a way to have server render description text identical to client
@@ -25,7 +28,7 @@ const DescriptionText = ({
             {description}
           </Typography>
         ) : (
-          <Typography dangerouslySetInnerHTML={{ __html: description }} className={classes.paragraph} variant="body2" />
+          <Typography dangerouslySetInnerHTML={{ __html: hideBRFromSR(description) }} className={classes.paragraph} variant="body2" />
         )}
       </div>
     );


### PR DESCRIPTION
Description text includes HTML code on event view. Some descriptions contain <br> elements without aria-hidden attribute. Change `<br>` elements to `<br aria-hidden="true" />`

Example: https://palvelukartta.hel.fi/fi/event/helmet:215044