### PR TITLE
Fix/address search bar accesiibility

### DIFF
--- a/browserTests/areaTest.js
+++ b/browserTests/areaTest.js
@@ -1,6 +1,6 @@
 /* eslint-disable */
 import { waitForReact, ReactSelector } from 'testcafe-react-selectors';
-import { ClientFunction } from 'testcafe';
+import { ClientFunction, Selector } from 'testcafe';
 
 import config from './config';
 const { server } = config;
@@ -66,18 +66,17 @@ test('District lists are fetched and rendered correctly', async (t) => {
 // })
 
 test('Address search bar field updates and gets results', async (t, inputText = 'mann') => {
-  const addressBar = ReactSelector('AddressSearchBar WithStyles(ForwardRef(InputBase))');
+  const addressBar = Selector('#addressSearchbar')
   const suggestions = ReactSelector('AddressSearchBar WithStyles(ForwardRef(ListItem))');
 
   await t
     .typeText(addressBar, inputText)
-    .expect(addressBar.getReact(({props}) => props.value)).eql(inputText)
     .expect(suggestions.count).gt(0)
 
-  const suggestion = suggestions.nth(1);
+  const suggestion = suggestions.nth(0);
 
   await t
     .pressKey('down')
     .pressKey('enter')
-    .expect(addressBar.getReact(({props}) => props.value)).eql(await suggestion.textContent, 'Address search bar did not update text when suggesttion was selected')
+    .expect(addressBar.value).eql(await suggestion.textContent, 'Address search bar did not update text when suggesttion was selected');
 });

--- a/src/components/AddressSearchBar/AddressSearchBar.js
+++ b/src/components/AddressSearchBar/AddressSearchBar.js
@@ -126,13 +126,14 @@ const AddressSearchBar = ({
       <Typography color="inherit">{title}</Typography>
       <form action="" onSubmit={e => handleSubmit(e)}>
         <InputBase
+          id="addressSearchbar"
           inputRef={inputRef}
           inputProps={{
             role: 'combobox',
             'aria-haspopup': !!showSuggestions,
             'aria-label': `${intl.formatMessage({ id: 'search.searchField' })} ${intl.formatMessage({ id: 'address.search' })}`,
             'aria-owns': showSuggestions ? 'address-results' : null,
-            'aria-activedescendant': showSuggestions ? `address-suggestion${resultIndex}` : null,
+            'aria-activedescendant': showSuggestions && resultIndex !== null ? `address-suggestion${resultIndex}` : null,
           }}
           type="text"
           onBlur={isMobile ? () => {} : e => clearSuggestions(e)}

--- a/src/components/AddressSearchBar/AddressSearchBar.js
+++ b/src/components/AddressSearchBar/AddressSearchBar.js
@@ -6,7 +6,7 @@ import {
 } from '@material-ui/core';
 import { Clear, Search } from '@material-ui/icons';
 import config from '../../../config';
-import { uppercaseFirst } from '../../utils';
+import { keyboardHandler, uppercaseFirst } from '../../utils';
 
 const AddressSearchBar = ({
   defaultAddress,
@@ -131,7 +131,10 @@ const AddressSearchBar = ({
             role: 'combobox',
             'aria-haspopup': !!showSuggestions,
             'aria-label': `${intl.formatMessage({ id: 'search.searchField' })} ${intl.formatMessage({ id: 'address.search' })}`,
+            'aria-owns': showSuggestions ? 'address-results' : null,
+            'aria-activedescendant': showSuggestions ? `address-suggestion${resultIndex}` : null,
           }}
+          type="text"
           type="search"
           className={`${classes.searchBar} ${inputClassName}`}
           value={searchBarValue}
@@ -158,13 +161,16 @@ const AddressSearchBar = ({
         <Typography aria-live="polite" id="resultLength" variant="srOnly">{infoText}</Typography>
         {showSuggestions ? (
           <Paper>
-            <List>
+            <List role="listbox" id="address-results">
               {addressResults.map((address, i) => (
                 <ListItem
+                  id={`address-suggestion${i}`}
+                  role="option"
                   selected={i === resultIndex}
                   key={formAddressString(address)}
                   button
                   onClick={() => handleAddressSelect(address)}
+                  onKeyDown={keyboardHandler(() => handleAddressSelect(address), ['space', 'enter'])}
                 >
                   <Typography>
                     {formAddressString(address)}

--- a/src/components/AddressSearchBar/AddressSearchBar.js
+++ b/src/components/AddressSearchBar/AddressSearchBar.js
@@ -26,8 +26,7 @@ const AddressSearchBar = ({
     : '');
 
   const [addressResults, setAddressResults] = useState([]);
-  const [resultIndex, setResultIndex] = useState(0);
-  const [searchBarValue, setSearchBarValue] = useState(formAddressString(defaultAddress));
+  const [resultIndex, setResultIndex] = useState(null);
   const [currentLocation, setCurrentLocation] = useState(null);
   const [cleared, setCleared] = useState(false);
 
@@ -38,7 +37,7 @@ const AddressSearchBar = ({
     if (inputRef.current) {
       inputRef.current.focus();
     }
-    setSearchBarValue(formAddressString(address));
+    inputRef.current.value = formAddressString(address);
     setAddressResults([]);
     setCurrentLocation(formAddressString(address));
     setDirection('asc');
@@ -76,7 +75,6 @@ const AddressSearchBar = ({
     if (cleared) {
       setCleared(false);
     }
-    setSearchBarValue(text);
     // Fetch address suggestions
     if (text.length && text.length > 1) {
       if (currentLocation) {
@@ -92,18 +90,10 @@ const AddressSearchBar = ({
   };
 
   useEffect(() => {
-    setSearchBarValue(formAddressString(defaultAddress));
+    inputRef.current.value = formAddressString(defaultAddress);
   }, [defaultAddress]);
 
-  // change searchbar value if resultIndex changes to
-  useEffect(() => {
-    const address = addressResults && addressResults[resultIndex];
-    if (address) {
-      setSearchBarValue(formAddressString(address));
-    }
-  }, [resultIndex]);
-
-  const showSuggestions = searchBarValue.length > 1 && addressResults && addressResults.length;
+  const showSuggestions = inputRef.current?.value.length > 1 && addressResults?.length;
   // Add info text for location selection
   const locationInfoText = currentLocation ? intl.formatMessage({ id: 'address.search.location' }, { location: currentLocation }) : '';
   // Figure out which info text to use
@@ -137,7 +127,7 @@ const AddressSearchBar = ({
           type="text"
           type="search"
           className={`${classes.searchBar} ${inputClassName}`}
-          value={searchBarValue}
+          defaultValue={formAddressString(defaultAddress)}
           onChange={e => handleInputChange(e.target.value)}
           onKeyDown={e => showSuggestions && handleSearchBarKeyPress(e)}
           endAdornment={(
@@ -149,7 +139,7 @@ const AddressSearchBar = ({
                 onClick={() => {
                   setCleared(true);
                   handleAddressChange(null);
-                  setSearchBarValue('');
+                  inputRef.current.value = '';
                 }}
                 className={classes.IconButton}
               >

--- a/src/components/AddressSearchBar/AddressSearchBar.js
+++ b/src/components/AddressSearchBar/AddressSearchBar.js
@@ -7,6 +7,7 @@ import {
 import { Clear, Search } from '@material-ui/icons';
 import config from '../../../config';
 import { keyboardHandler, uppercaseFirst } from '../../utils';
+import useMobileStatus from '../../utils/isMobile';
 
 const AddressSearchBar = ({
   defaultAddress,
@@ -24,6 +25,8 @@ const AddressSearchBar = ({
   const formAddressString = address => (address
     ? `${getLocaleText(address.street.name)} ${address.number}${address.number_end ? address.number_end : ''}${address.letter ? address.letter : ''}, ${uppercaseFirst(address.street.municipality)}`
     : '');
+
+  const isMobile = useMobileStatus();
 
   const [addressResults, setAddressResults] = useState([]);
   const [resultIndex, setResultIndex] = useState(null);
@@ -46,11 +49,9 @@ const AddressSearchBar = ({
   };
 
   const handleSearchBarKeyPress = (e) => {
-    if (e.key === 'Enter') {
-      handleAddressSelect(addressResults[resultIndex]);
-    } else if (e.key === 'ArrowDown') {
+    if (e.key === 'ArrowDown') {
       e.preventDefault();
-      if (resultIndex === addressResults.length - 1) {
+      if (resultIndex === null || resultIndex === addressResults.length - 1) {
         setResultIndex(0);
       } else {
         setResultIndex(resultIndex + 1);
@@ -65,9 +66,18 @@ const AddressSearchBar = ({
     }
   };
 
-  const blurSearchfield = (e) => {
+  const clearSuggestions = (e) => {
     e.preventDefault();
-    document.activeElement.blur();
+    setAddressResults([]);
+  };
+
+  const handleSubmit = (e) => {
+    if (resultIndex !== null) {
+      handleAddressSelect(addressResults[resultIndex]);
+    } else {
+      handleAddressSelect(addressResults[0]);
+    }
+    clearSuggestions(e);
   };
 
   const handleInputChange = (text) => {
@@ -114,7 +124,7 @@ const AddressSearchBar = ({
   return (
     <div className={containerClassName}>
       <Typography color="inherit">{title}</Typography>
-      <form action="" onSubmit={e => blurSearchfield(e)}>
+      <form action="" onSubmit={e => handleSubmit(e)}>
         <InputBase
           inputRef={inputRef}
           inputProps={{
@@ -125,7 +135,8 @@ const AddressSearchBar = ({
             'aria-activedescendant': showSuggestions ? `address-suggestion${resultIndex}` : null,
           }}
           type="text"
-          type="search"
+          onBlur={isMobile ? () => {} : e => clearSuggestions(e)}
+          onFocus={() => setResultIndex(null)}
           className={`${classes.searchBar} ${inputClassName}`}
           defaultValue={formAddressString(defaultAddress)}
           onChange={e => handleInputChange(e.target.value)}


### PR DESCRIPTION
- Address bar and suggestions uses now aria-owns and aria-activedescendant to control selected suggestions. 
- Changed address search bar to use ref instead of state to control bar value

Also fixes the issue, where screen reader users would not know when suggestions appear.