### PR TITLE
Fix/mobile map improvements

### DIFF
--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -280,6 +280,7 @@ const translations = {
 
   // Units
   'unit': 'Location',
+  'unit.showInformation': 'Näytä toimipisteen tiedot', // TODO: Translate
   'unit.accessibility.hearingMaps': 'Coverage maps',
   'unit.accessibility.hearingMaps.extra': '(New tab. The service is not accessible)',
   'unit.accessibility.noInfo': 'No accessibility information',

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -280,7 +280,7 @@ const translations = {
 
   // Units
   'unit': 'Location',
-  'unit.showInformation': 'Näytä toimipisteen tiedot', // TODO: Translate
+  'unit.showInformation': 'Show the details for the location',
   'unit.accessibility.hearingMaps': 'Coverage maps',
   'unit.accessibility.hearingMaps.extra': '(New tab. The service is not accessible)',
   'unit.accessibility.noInfo': 'No accessibility information',

--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -280,6 +280,7 @@ const translations = {
 
   // Units
   'unit': 'Toimipiste',
+  'unit.showInformation': 'Näytä toimipisteen tiedot',
   'unit.accessibility.hearingMaps': 'Kuuluvuuskartat',
   'unit.accessibility.hearingMaps.extra': '(Uusi välilehti. Palvelu ei ole saavutettava)',
   'unit.accessibility.noInfo': 'Ei esteettömyystietoja',

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -280,7 +280,7 @@ const translations = {
 
   // Units
   'unit': 'Verksamhetsställe',
-  'unit.showInformation': 'Näytä toimipisteen tiedot', // TODO: Translate
+  'unit.showInformation': 'Visa uppgifterna för verksamhetsstället',
   'unit.accessibility.hearingMaps': 'Täckningskartor',
   'unit.accessibility.hearingMaps.extra': '(Ny flik. Tjänsten är inte tillgänglig)',
   'unit.accessibility.noInfo': 'Inga tillgänglighetsuppgifter',

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -280,6 +280,7 @@ const translations = {
 
   // Units
   'unit': 'Verksamhetsställe',
+  'unit.showInformation': 'Näytä toimipisteen tiedot', // TODO: Translate
   'unit.accessibility.hearingMaps': 'Täckningskartor',
   'unit.accessibility.hearingMaps.extra': '(Ny flik. Tjänsten är inte tillgänglig)',
   'unit.accessibility.noInfo': 'Inga tillgänglighetsuppgifter',

--- a/src/views/MapView/MapView.js
+++ b/src/views/MapView/MapView.js
@@ -341,6 +341,7 @@ const MapView = (props) => {
         {renderTopBar()}
         {renderEmbedOverlay()}
         <Map
+          tap={false} // This should fix leaflet safari double click bug
           preferCanvas
           className={`${classes.map} ${measuringMode ? classes.measuringCursor : ''}`}
           key={mapObject.options.name}

--- a/src/views/MapView/MapView.js
+++ b/src/views/MapView/MapView.js
@@ -136,7 +136,7 @@ const MapView = (props) => {
 
   const setClickCoordinates = (ev) => {
     setMapClickPoint(null);
-    if (document.getElementsByClassName('popup').length > 0) {
+    if (document.getElementsByClassName('leaflet-popup').length > 0) {
       mapRef.current.leafletElement.closePopup();
     } else {
       setMapClickPoint(ev.latlng);

--- a/src/views/MapView/components/Districts/Districts.js
+++ b/src/views/MapView/components/Districts/Districts.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { Typography } from '@material-ui/core';
 import { useSelector } from 'react-redux';
@@ -9,7 +9,6 @@ import AddressMarker from '../AddressMarker';
 import useMobileStatus from '../../../../utils/isMobile';
 import { parseSearchParams } from '../../../../utils';
 
-let districtClicked = null;
 
 const Districts = ({
   highlightedDistrict,
@@ -36,21 +35,11 @@ const Districts = ({
   const location = useLocation();
   const citySettings = useSelector(state => state.settings.cities);
 
-  /* TODO: The following useEffect is used to prevent double click bug with
-  lealfet + safari. Should be removed when the bug is fixed by lealfet */
-  useEffect(() => {
-    setTimeout(() => {
-      districtClicked = null;
-    }, 1000);
-  }, [selectedSubdistricts]);
-
   const districtOnClick = (e, district) => {
     if (measuringMode) return;
     if (district.category === 'geographical') {
       // Disable normal map click event
       e.originalEvent.view.L.DomEvent.stopPropagation(e);
-      if (districtClicked === district.ocd_id) return; // Prevent safari double click
-      districtClicked = district.ocd_id;
       // Add/remove district from selected geographical districts
       let newArray;
       if (selectedSubdistricts.some(item => item === district.ocd_id)) {

--- a/src/views/MapView/components/MarkerCluster/MarkerCluster.js
+++ b/src/views/MapView/components/MarkerCluster/MarkerCluster.js
@@ -170,8 +170,7 @@ const MarkerCluster = ({
   const onClusterItemClick = (unit) => {
     UnitHelper.unitElementClick(navigator, unit);
   };
-  // eslint-disable-next-line no-underscore-dangle
-  const showListOfUnits = () => (map._zoom > clusterPopupVisibility);
+  const showListOfUnits = () => (map.getZoom() > clusterPopupVisibility);
 
   // Cluster popup content
   const clusterPopupContent = (units) => {
@@ -300,6 +299,7 @@ const MarkerCluster = ({
       clusterMouseover,
       clusterMouseout,
       clusterAnimationEnd,
+      showListOfUnits,
     );
     // Add cluster to map
     map.addLayer(mcg);

--- a/src/views/MapView/components/MarkerCluster/MarkerCluster.js
+++ b/src/views/MapView/components/MarkerCluster/MarkerCluster.js
@@ -88,6 +88,7 @@ const MarkerCluster = ({
       getLocaleText,
       distance,
       intl,
+      isMobile,
     );
   };
 
@@ -349,6 +350,7 @@ const MarkerCluster = ({
           getLocaleText,
           distance,
           intl,
+          isMobile,
         );
         const tooltipPermanent = highlightedUnit
           && (highlightedUnit.id === unit.id && UnitHelper.isUnitPage());
@@ -366,8 +368,16 @@ const MarkerCluster = ({
           popupOptions(),
         );
 
+        if (isMobile) {
+          markerElem.on('popupopen', (e) => {
+            // Bind click event to popup when popup is opened
+            e.popup.getElement().addEventListener('click',
+              () => UnitHelper.unitElementClick(navigator, unit));
+          });
+        }
+
         // If not highlighted marker add tooltip
-        if (!tooltipPermanent) {
+        if (!tooltipPermanent && !isMobile) {
           markerElem.bindTooltip(
             tooltipContent,
             tooltipOptions(false, classes),
@@ -401,7 +411,7 @@ const MarkerCluster = ({
       // Remove marker interaction when using measuring tool
       if (measuringMode) item.classList.remove('leaflet-interactive');
     });
-  }, [cluster, data, measuringMode]);
+  }, [cluster, data, isMobile, measuringMode]);
 
   const removeMarkerInteraction = useCallback(() => {
     /* Remove interactions from markers during measuring mode.

--- a/src/views/MapView/components/MarkerCluster/MarkerCluster.js
+++ b/src/views/MapView/components/MarkerCluster/MarkerCluster.js
@@ -26,7 +26,7 @@ const popupOptions = () => ({
   closeOnClick: false,
   direction: 'top',
   opacity: 1,
-  offset: [0, -20],
+  offset: [2, -20],
 });
 
 // Cluster icon size handler
@@ -143,12 +143,21 @@ const MarkerCluster = ({
 
   // Remove popup from old marker and set new highligted marker
   const setNewHighlightedMarker = (marker) => {
-    // Close popup for highlighterMarker if it exists
-    if (clusterData.highlightedMarker) {
-      clusterData.highlightedMarker.closePopup();
+    if (!marker) return;
+    const { highlightedMarker } = clusterData;
+    // Open popoup on marker click even if it is already highlighted unit.
+    if (marker.options.customUnitData.id === highlightedMarker?.options.customUnitData.id) {
+      if (marker.isPopupOpen()) {
+        marker.openPopup();
+      }
+    } else {
+      // Close popup for highlighterMarker if it exists
+      if (highlightedMarker) {
+        highlightedMarker.closePopup();
+      }
+      // Set this marker as highligtedMarker
+      clusterData.highlightedMarker = marker;
     }
-    // Set this marker as highligtedMarker
-    clusterData.highlightedMarker = marker;
   };
 
 
@@ -276,7 +285,7 @@ const MarkerCluster = ({
     if (!highlightedUnit) {
       return;
     }
-    if (highlightedUnit && currentPage === 'search') {
+    if (highlightedUnit && currentPage === 'search' && !isMobile) {
       map.closePopup();
       return;
     }

--- a/src/views/MapView/components/MarkerCluster/MarkerCluster.js
+++ b/src/views/MapView/components/MarkerCluster/MarkerCluster.js
@@ -9,6 +9,7 @@ import { createMarkerClusterLayer, createTooltipContent, createPopupContent } fr
 import { mapTypes } from '../../config/mapConfig';
 import { keyboardHandler } from '../../../../utils';
 import UnitHelper from '../../../../utils/unitHelper';
+import useMobileStatus from '../../../../utils/isMobile';
 
 const tooltipOptions = (permanent, classes) => ({
   className: classes.unitTooltipContainer,
@@ -54,6 +55,7 @@ const MarkerCluster = ({
 }) => {
   const useContrast = theme === 'dark';
   const embeded = isEmbed();
+  const isMobile = useMobileStatus();
   const intl = useIntl();
   const [cluster, setCluster] = useState(null);
 
@@ -369,7 +371,9 @@ const MarkerCluster = ({
         if (unitListFiltered.length > 1 || embeded) {
           markerElem.on('click', () => {
             setNewHighlightedMarker(markerElem);
-            UnitHelper.unitElementClick(navigator, unit);
+            if (!isMobile) {
+              UnitHelper.unitElementClick(navigator, unit);
+            }
           });
         }
 

--- a/src/views/MapView/components/MarkerCluster/clusterUtils.js
+++ b/src/views/MapView/components/MarkerCluster/clusterUtils.js
@@ -9,6 +9,7 @@ export const createMarkerClusterLayer = (
   clusterMouseover,
   clusterMouseout,
   clusterAnimationend,
+  showListOfUnits,
 ) => {
   if (!isClient()) {
     return null;
@@ -32,8 +33,14 @@ export const createMarkerClusterLayer = (
     clusterLayer.on('clustermouseover', (a) => {
       if (clusterMouseover) clusterMouseover(a);
     });
+    // Add click events as alternative way to trigger hover events on mobile
+    clusterLayer.on('clusterclick', (a) => {
+      if (clusterMouseover && showListOfUnits()) {
+        clusterMouseover(a);
+      }
+    });
   } else {
-    // Add cluster click only when embeded
+    // Add cluster click when embeded
     clusterLayer.on('clusterclick', () => {
       window.open(window.location.href.replace('/embed', ''));
     });

--- a/src/views/MapView/components/MarkerCluster/clusterUtils.js
+++ b/src/views/MapView/components/MarkerCluster/clusterUtils.js
@@ -86,7 +86,7 @@ export const createTooltipContent = (unit, classes, getLocaleText, distance) => 
 );
 
 
-export const createPopupContent = (unit, classes, getLocaleText, distance, intl) => (
+export const createPopupContent = (unit, classes, getLocaleText, distance, intl, isMobile) => (
   ReactDOMServer.renderToStaticMarkup(
     <div className={classes.unitTooltipWrapper}>
       <p className={classes.unitTooltipTitle}>{unit.name && getLocaleText(unit.name)}</p>
@@ -109,6 +109,11 @@ export const createPopupContent = (unit, classes, getLocaleText, distance, intl)
           )
         }
       </div>
+      {isMobile && (
+        <p className={classes.unitTooltipLink}>
+          {intl.formatMessage({ id: 'unit.showInformation' })}
+        </p>
+      )}
     </div>,
   )
 );

--- a/src/views/MapView/styles.js
+++ b/src/views/MapView/styles.js
@@ -152,6 +152,12 @@ const styles = theme => ({
     ...theme.typography.body2,
     margin: theme.spacing(0, 1),
   },
+  unitTooltipLink: {
+    ...theme.typography.body2,
+    paddingTop: theme.spacing(1),
+    textAlign: 'center',
+    color: theme.palette.primary.main,
+  },
   unitTooltipWrapper: {
     padding: theme.spacing(2),
   },


### PR DESCRIPTION
- Added tap={false} to map to "fix" [safari double click problem](https://github.com/Leaflet/Leaflet/issues/7255). This option doesn't seem to break anything
- Changed mobile version marker click handling: now opens popup with link instead of navigating straight to unit page. 