### PR TITLE
Fix/optimize getLocaleText

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "abortcontroller-polyfill": "^1.5.0",
     "core-js": "^3.7.0",
     "dotenv": "^8.2.0",
+    "eslint-plugin-react-hooks": "^4.2.0",
     "express": "^4.17.1",
     "intl": "^1.2.5",
     "isomorphic-style-loader": "^5.1.0",

--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -1,5 +1,5 @@
 {
-    "extends": ["airbnb"],
+    "extends": ["airbnb", "plugin:react-hooks/recommended"],
     "rules": {
         "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
         "no-shadow": 0,

--- a/src/components/AddressSearchBar/AddressSearchBar.js
+++ b/src/components/AddressSearchBar/AddressSearchBar.js
@@ -5,23 +5,26 @@ import {
   InputBase, IconButton, Paper, List, ListItem, Typography, Divider,
 } from '@material-ui/core';
 import { Clear, Search } from '@material-ui/icons';
+import { useDispatch, useSelector } from 'react-redux';
+import { setOrder, setDirection } from '../../redux/actions/sort';
 import config from '../../../config';
 import { keyboardHandler, uppercaseFirst } from '../../utils';
 import useMobileStatus from '../../utils/isMobile';
+import useLocaleText from '../../utils/useLocaleText';
 
 const AddressSearchBar = ({
   defaultAddress,
   handleAddressChange,
   title,
-  locale,
   containerClassName,
   inputClassName,
-  setOrder,
-  setDirection,
-  getLocaleText,
   classes,
   intl,
 }) => {
+  const getLocaleText = useLocaleText();
+  const dispatch = useDispatch();
+  const locale = useSelector(state => state.user.locale);
+
   const formAddressString = address => (address
     ? `${getLocaleText(address.street.name)} ${address.number}${address.number_end ? address.number_end : ''}${address.letter ? address.letter : ''}, ${uppercaseFirst(address.street.municipality)}`
     : '');
@@ -43,8 +46,8 @@ const AddressSearchBar = ({
     inputRef.current.value = formAddressString(address);
     setAddressResults([]);
     setCurrentLocation(formAddressString(address));
-    setDirection('asc');
-    setOrder('distance');
+    dispatch(setDirection('asc'));
+    dispatch(setOrder('distance'));
     handleAddressChange(address);
   };
 
@@ -192,13 +195,9 @@ AddressSearchBar.propTypes = {
   intl: PropTypes.objectOf(PropTypes.any).isRequired,
   defaultAddress: PropTypes.objectOf(PropTypes.any),
   handleAddressChange: PropTypes.func.isRequired,
-  setOrder: PropTypes.func.isRequired,
-  setDirection: PropTypes.func.isRequired,
   title: PropTypes.objectOf(PropTypes.any),
-  locale: PropTypes.string.isRequired,
   containerClassName: PropTypes.string,
   inputClassName: PropTypes.string,
-  getLocaleText: PropTypes.func.isRequired,
 };
 
 AddressSearchBar.defaultProps = {

--- a/src/components/AddressSearchBar/index.js
+++ b/src/components/AddressSearchBar/index.js
@@ -1,21 +1,7 @@
 import { withStyles } from '@material-ui/core';
-import { connect } from 'react-redux';
 import { injectIntl } from 'react-intl';
 import AddressSearchBar from './AddressSearchBar';
 import styles from './styles';
-import { getLocaleString } from '../../redux/selectors/locale';
-import { setOrder, setDirection } from '../../redux/actions/sort';
 
-const mapStateToProps = (state) => {
-  const { locale } = state.user;
-  const getLocaleText = textObject => getLocaleString(state, textObject);
-  return {
-    locale,
-    getLocaleText,
-  };
-};
 
-export default injectIntl(withStyles(styles)(connect(
-  mapStateToProps,
-  { setOrder, setDirection },
-)(AddressSearchBar)));
+export default withStyles(styles)(injectIntl(AddressSearchBar));

--- a/src/components/AlertBox/AlertBox.js
+++ b/src/components/AlertBox/AlertBox.js
@@ -5,13 +5,16 @@ import { FormattedMessage } from 'react-intl';
 import { getIcon } from '../SMIcon';
 import LocalStorageUtility from '../../utils/localStorage';
 import { focusToViewTitle } from '../../utils/accessibility';
+import useLocaleText from '../../utils/useLocaleText';
 
 // LocalStorage key for alert message
 const lsKey = 'alertMessage';
 
 const AlertBox = ({
-  classes, getLocaleText, intl, errors, news,
+  classes, intl, errors, news,
 }) => {
+  const getLocaleText = useLocaleText();
+
   const [visible, setVisible] = useState(true);
   const isErrorMessage = !!errors.length;
   const abData = isErrorMessage ? errors : news;
@@ -90,7 +93,6 @@ AlertBox.propTypes = {
       fi: PropTypes.string,
     }),
   })).isRequired,
-  getLocaleText: PropTypes.func.isRequired,
   news: PropTypes.arrayOf(PropTypes.shape({
     lead_paragraph: PropTypes.shape({
       fi: PropTypes.string,

--- a/src/components/AlertBox/index.js
+++ b/src/components/AlertBox/index.js
@@ -1,7 +1,6 @@
 import { withStyles } from '@material-ui/core';
 import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
-import { getLocaleString } from '../../redux/selectors/locale';
 import AlertBox from './AlertBox';
 import styles from './styles';
 
@@ -9,11 +8,9 @@ import styles from './styles';
 const mapStateToProps = (state) => {
   const { alerts } = state;
   const { errors, news } = alerts;
-  const getLocaleText = textObject => getLocaleString(state, textObject);
 
   return {
     errors: errors.data || [],
-    getLocaleText,
     news: news.data || [],
   };
 };

--- a/src/components/Dialog/DownloadDialog/DownloadDialog.js
+++ b/src/components/Dialog/DownloadDialog/DownloadDialog.js
@@ -17,13 +17,14 @@ import SMButton from '../../ServiceMapButton';
 import useDownloadData from '../../../utils/downloadData';
 import { getIcon } from '../../SMIcon';
 import { fetchServiceNames } from './utils';
+import useLocaleText from '../../../utils/useLocaleText';
 
 const DownloadDialog = ({
   classes,
-  getLocaleText,
   open,
   ...rest
 }) => {
+  const getLocaleText = useLocaleText();
   const downloadData = useDownloadData();
   const page = useSelector(state => state.user.page);
   const selectedUnit = useSelector(state => state.selectedUnit.unit.data);
@@ -234,10 +235,10 @@ DownloadDialog.propTypes = {
     downloadIcon: PropTypes.string,
     formControlGroup: PropTypes.string,
     formControlLabel: PropTypes.string,
+    icon: PropTypes.string,
     topMargin: PropTypes.string,
     unitCount: PropTypes.string,
   }).isRequired,
-  getLocaleText: PropTypes.func.isRequired,
   open: PropTypes.bool.isRequired,
 };
 

--- a/src/components/Dialog/DownloadDialog/index.js
+++ b/src/components/Dialog/DownloadDialog/index.js
@@ -1,16 +1,6 @@
-import { connect } from 'react-redux';
 import { withStyles } from '@material-ui/styles';
 import DownloadDialog from './DownloadDialog';
-import { getLocaleString } from '../../../redux/selectors/locale';
 import styles from './styles';
 
-const mapStateToProps = (state) => {
-  const getLocaleText = textObject => getLocaleString(state, textObject);
 
-  return {
-    getLocaleText,
-  };
-};
-
-
-export default withStyles(styles)(connect(mapStateToProps)(DownloadDialog));
+export default withStyles(styles)(DownloadDialog);

--- a/src/components/DrawerMenu/DrawerMenu.js
+++ b/src/components/DrawerMenu/DrawerMenu.js
@@ -6,6 +6,7 @@ import {
 import { Map } from '@material-ui/icons';
 import { getIcon } from '../SMIcon';
 import DrawerButton from './DrawerButton';
+import useLocaleText from '../../utils/useLocaleText';
 
 const DrawerMenu = (props) => {
   const {
@@ -20,8 +21,8 @@ const DrawerMenu = (props) => {
     isOpen,
     toggleDrawerMenu,
     handleNavigation,
-    getLocaleText,
   } = props;
+  const getLocaleText = useLocaleText();
 
   const menuContent = [
     { // Nearby services button
@@ -126,7 +127,6 @@ DrawerMenu.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   toggleDrawerMenu: PropTypes.func.isRequired,
   handleNavigation: PropTypes.func.isRequired,
-  getLocaleText: PropTypes.func.isRequired,
 };
 
 DrawerMenu.defaultProps = {

--- a/src/components/DrawerMenu/index.js
+++ b/src/components/DrawerMenu/index.js
@@ -4,15 +4,12 @@ import { withStyles } from '@material-ui/core';
 import DrawerMenu from './DrawerMenu';
 import { findUserLocation } from '../../redux/actions/user';
 import styles from './styles';
-import { getLocaleString } from '../../redux/selectors/locale';
 
 const mapStateToProps = (state) => {
   const { user } = state;
-  const getLocaleText = textObject => getLocaleString(state, textObject);
   return {
     currentPage: user.page,
     userLocation: user.position,
-    getLocaleText,
   };
 };
 

--- a/src/components/ListItems/AddressItem/AddressItem.js
+++ b/src/components/ListItems/AddressItem/AddressItem.js
@@ -4,11 +4,11 @@ import { uppercaseFirst } from '../../../utils';
 import SimpleListItem from '../SimpleListItem';
 import { AddressIcon } from '../../SMIcon';
 import { getAddressText } from '../../../utils/address';
+import useLocaleText from '../../../utils/useLocaleText';
 
 const AddressItem = (props) => {
   const {
     getAddressNavigatorParams,
-    getLocaleText,
     navigator,
     address,
     classes,
@@ -18,6 +18,7 @@ const AddressItem = (props) => {
     role,
     id,
   } = props;
+  const getLocaleText = useLocaleText();
 
   const text = getAddressText(address, getLocaleText, showPostalCode);
 
@@ -47,7 +48,6 @@ export default AddressItem;
 AddressItem.propTypes = {
   classes: PropTypes.objectOf(PropTypes.any).isRequired,
   getAddressNavigatorParams: PropTypes.func.isRequired,
-  getLocaleText: PropTypes.func.isRequired,
   navigator: PropTypes.objectOf(PropTypes.any),
   address: PropTypes.objectOf(PropTypes.any).isRequired,
   selected: PropTypes.bool,

--- a/src/components/ListItems/AddressItem/index.js
+++ b/src/components/ListItems/AddressItem/index.js
@@ -10,11 +10,12 @@ const mapStateToProps = (state) => {
   const { current } = state.service;
   const getLocaleText = textObject => getLocaleString(state, textObject);
   const { navigator, user } = state;
+  /* TODO: create custom hook for getAddressNavigatorParams to prevent
+  re-rendering on every state change */
   const getAddressNavigatorParams = getAddressNavigatorParamsConnector(getLocaleText, user.locale);
   return {
     getAddressNavigatorParams,
     currentService: current,
-    getLocaleText,
     navigator,
   };
 };

--- a/src/components/ListItems/DivisionItem/DivisionItem.js
+++ b/src/components/ListItems/DivisionItem/DivisionItem.js
@@ -7,6 +7,7 @@ import { FormattedMessage } from 'react-intl';
 import UnitIcon from '../../SMIcon/UnitIcon';
 import SMLink from '../../Link';
 import { getAddressFromUnit } from '../../../utils/address';
+import useLocaleText from '../../../utils/useLocaleText';
 
 const DivisionItem = ({
   classes,
@@ -14,10 +15,10 @@ const DivisionItem = ({
   distance,
   divider,
   className,
-  getLocaleText,
   intl,
   navigator,
 }) => {
+  const getLocaleText = useLocaleText();
   const { area } = data;
   const aStart = area && area.start ? new Date(area.start).getFullYear() : null;
   const aEnd = area && area.end ? new Date(area.end).getFullYear() : null;
@@ -206,7 +207,6 @@ DivisionItem.propTypes = {
     text: PropTypes.string,
   }),
   divider: PropTypes.bool.isRequired,
-  getLocaleText: PropTypes.func.isRequired,
   navigator: PropTypes.objectOf(PropTypes.any).isRequired,
   intl: PropTypes.shape({
     formatMessage: PropTypes.func,

--- a/src/components/ListItems/DivisionItem/index.js
+++ b/src/components/ListItems/DivisionItem/index.js
@@ -3,15 +3,12 @@ import { withStyles } from '@material-ui/core';
 import { injectIntl } from 'react-intl';
 import styles from './styles';
 import DivisionItem from './DivisionItem';
-import { getLocaleString } from '../../../redux/selectors/locale';
 
 const mapStateToProps = (state) => {
-  const getLocaleText = textObject => getLocaleString(state, textObject);
   const { navigator, user } = state;
   const { locale } = user;
 
   return {
-    getLocaleText,
     locale,
     navigator,
   };

--- a/src/components/ListItems/EventItem/EventItem.js
+++ b/src/components/ListItems/EventItem/EventItem.js
@@ -3,6 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Event } from '@material-ui/icons';
 import ResultItem from '../ResultItem';
+import useLocaleText from '../../../utils/useLocaleText';
 
 const formatEventDate = (event, intl) => {
   const timeString = intl.formatMessage({ id: 'general.time.short' });
@@ -32,10 +33,10 @@ const formatEventDate = (event, intl) => {
 const EventItem = ({
   changeSelectedEvent,
   event,
-  getLocaleText,
   intl,
   navigator,
 }) => {
+  const getLocaleText = useLocaleText();
   const dateString = formatEventDate(event, intl);
   return (
     <ResultItem
@@ -62,7 +63,6 @@ export default EventItem;
 EventItem.propTypes = {
   changeSelectedEvent: PropTypes.func.isRequired,
   event: PropTypes.objectOf(PropTypes.any).isRequired,
-  getLocaleText: PropTypes.func.isRequired,
   intl: PropTypes.objectOf(PropTypes.any).isRequired,
   navigator: PropTypes.objectOf(PropTypes.any),
 };

--- a/src/components/ListItems/EventItem/index.js
+++ b/src/components/ListItems/EventItem/index.js
@@ -2,17 +2,14 @@
 import { connect } from 'react-redux';
 import { injectIntl } from 'react-intl';
 import EventItem from './EventItem';
-import { getLocaleString } from '../../../redux/selectors/locale';
 import { changeSelectedEvent } from '../../../redux/actions/event';
 
 // Listen to redux state
 const mapStateToProps = (state) => {
-  const getLocaleText = textObject => getLocaleString(state, textObject);
   const {
     navigator,
   } = state;
   return {
-    getLocaleText,
     navigator,
   };
 };

--- a/src/components/ListItems/ReservationItem/ReservationItem.js
+++ b/src/components/ListItems/ReservationItem/ReservationItem.js
@@ -2,22 +2,25 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { EventAvailable } from '@material-ui/icons';
 import SimpleListItem from '../SimpleListItem';
+import useLocaleText from '../../../utils/useLocaleText';
 
-const ReservationItem = ({ getLocaleText, reservation, intl }) => (
-  <SimpleListItem
-    key={reservation.id}
-    icon={<EventAvailable />}
-    link
-    text={`${getLocaleText(reservation.name)} ${intl.formatMessage({ id: 'unit.opens.new.tab' })}`}
-    divider
-    handleItemClick={() => {
-      window.open(`https://varaamo.hel.fi/resources/${reservation.id}`);
-    }}
-  />
-);
+const ReservationItem = ({ reservation, intl }) => {
+  const getLocaleText = useLocaleText();
+  return (
+    <SimpleListItem
+      key={reservation.id}
+      icon={<EventAvailable />}
+      link
+      text={`${getLocaleText(reservation.name)} ${intl.formatMessage({ id: 'unit.opens.new.tab' })}`}
+      divider
+      handleItemClick={() => {
+        window.open(`https://varaamo.hel.fi/resources/${reservation.id}`);
+      }}
+    />
+  );
+};
 
 ReservationItem.propTypes = {
-  getLocaleText: PropTypes.func.isRequired,
   intl: PropTypes.objectOf(PropTypes.any).isRequired,
   reservation: PropTypes.shape({
     id: PropTypes.string,

--- a/src/components/ListItems/ReservationItem/index.js
+++ b/src/components/ListItems/ReservationItem/index.js
@@ -1,13 +1,5 @@
-import { connect } from 'react-redux';
 import { injectIntl } from 'react-intl';
 import ReservationItem from './ReservationItem';
-import { getLocaleString } from '../../../redux/selectors/locale';
 
-const mapStateToProps = (state) => {
-  const getLocaleText = textObject => getLocaleString(state, textObject);
-  return {
-    getLocaleText,
-  };
-};
 
-export default injectIntl(connect(mapStateToProps)(ReservationItem));
+export default injectIntl(ReservationItem);

--- a/src/components/ListItems/ServiceItem/index.js
+++ b/src/components/ListItems/ServiceItem/index.js
@@ -8,6 +8,7 @@ import styles from './styles';
 // Listen to redux state
 const mapStateToProps = (state) => {
   const { current } = state.service;
+  // TODO: replace this with useLocaleText when the component is converted to function component
   const getLocaleText = textObject => getLocaleString(state, textObject);
   const { navigator } = state;
   return {

--- a/src/components/ListItems/UnitItem/UnitItem.js
+++ b/src/components/ListItems/UnitItem/UnitItem.js
@@ -10,13 +10,13 @@ import locationIcon from '../../../assets/icons/LocationDefault.svg';
 import locationIconHover from '../../../assets/icons/LocationHover.svg';
 import locationIconContrast from '../../../assets/icons/LocationDefaultContrast.svg';
 import locationIconContrastHover from '../../../assets/icons/LocationHoverContrast.svg';
+import useLocaleText from '../../../utils/useLocaleText';
 
 const UnitItem = ({
   classes,
   distance,
   unit,
   onClick,
-  getLocaleText,
   intl,
   padded,
   divider,
@@ -24,10 +24,7 @@ const UnitItem = ({
   settings,
   theme,
 }) => {
-  // Don't render if not valid unit
-  if (!UnitHelper.isValidUnit(unit)) {
-    return null;
-  }
+  const getLocaleText = useLocaleText();
 
   const parseAccessibilityText = () => {
     const accessSettingsSet = SettingsUtility.hasActiveAccessibilitySettings(settings);
@@ -88,6 +85,12 @@ const UnitItem = ({
     resetMarkerHighlight();
   };
 
+
+  // Don't render if not valid unit
+  if (!UnitHelper.isValidUnit(unit)) {
+    return null;
+  }
+
   // Accessibility text and color
   const accessData = isClient() ? parseAccessibilityText() : 0;
   const accessText = accessData.text;
@@ -145,7 +148,6 @@ UnitItem.propTypes = {
     text: PropTypes.string,
   }),
   unit: PropTypes.objectOf(PropTypes.any),
-  getLocaleText: PropTypes.func.isRequired,
   onClick: PropTypes.func,
   intl: PropTypes.objectOf(PropTypes.any).isRequired,
   navigator: PropTypes.objectOf(PropTypes.any),

--- a/src/components/ListItems/UnitItem/index.js
+++ b/src/components/ListItems/UnitItem/index.js
@@ -3,7 +3,6 @@ import { connect } from 'react-redux';
 import { injectIntl } from 'react-intl';
 import { withStyles } from '@material-ui/core';
 import UnitItem from './UnitItem';
-import { getLocaleString } from '../../../redux/selectors/locale';
 import { changeSelectedUnit } from '../../../redux/actions/selectedUnit';
 import styles from './styles';
 import { calculateDistance, getCurrentlyUsedPosition } from '../../../redux/selectors/unit';
@@ -14,13 +13,11 @@ const mapStateToProps = (state, props) => {
   const {
     intl, unit,
   } = props;
-  const getLocaleText = textObject => getLocaleString(state, textObject);
   const {
     navigator, settings, user,
   } = state;
   return {
     distance: formatDistanceObject(intl, calculateDistance(unit, getCurrentlyUsedPosition(state))),
-    getLocaleText,
     navigator,
     settings,
     theme: user.theme,

--- a/src/components/NewsInfo/components/NewsItem/NewsItem.js
+++ b/src/components/NewsInfo/components/NewsItem/NewsItem.js
@@ -1,14 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import { withStyles } from '@material-ui/styles';
 import { Link, Paper, Typography } from '@material-ui/core';
-import { FormattedMessage } from 'react-intl';
 import { getIcon } from '../../../SMIcon';
 import styles from './styles';
-import { getLocaleString } from '../../../../redux/selectors/locale';
+import useLocaleText from '../../../../utils/useLocaleText';
 
-const NewsItem = ({ classes, item, getLocaleText }) => {
+const NewsItem = ({ classes, item }) => {
+  const getLocaleText = useLocaleText();
   if (!item || !item.title) {
     return null;
   }
@@ -77,7 +76,6 @@ NewsItem.propTypes = {
     titleContainer: PropTypes.string,
     subtitle: PropTypes.string,
   }).isRequired,
-  getLocaleText: PropTypes.func.isRequired,
   item: PropTypes.shape({
     lead_paragraph: PropTypes.shape({
       fi: PropTypes.string,
@@ -95,13 +93,5 @@ NewsItem.propTypes = {
   }).isRequired,
 };
 
-// Listen to redux state
-const mapStateToProps = (state) => {
-  const getLocaleText = textObject => getLocaleString(state, textObject);
 
-  return {
-    getLocaleText,
-  };
-};
-
-export default withStyles(styles)(connect(mapStateToProps)(NewsItem));
+export default withStyles(styles)(NewsItem);

--- a/src/components/TopBar/index.js
+++ b/src/components/TopBar/index.js
@@ -14,7 +14,10 @@ const mapStateToProps = (state) => {
   const {
     navigator, user, breadcrumb, settings,
   } = state;
+  // TODO: replace this with useLocaleText when the component is converted to function component
   const getLocaleText = textObject => getLocaleString(state, textObject);
+  /* TODO: create custom hook for getAddressNavigatorParams to prevent
+  re-rendering on every state change */
   const getAddressNavigatorParams = getAddressNavigatorParamsConnector(getLocaleText, user.locale);
   return {
     getAddressNavigatorParams,

--- a/src/layouts/components/PageHandler/index.js
+++ b/src/layouts/components/PageHandler/index.js
@@ -6,6 +6,7 @@ import PageHandler from './PageHandler';
 
 const mapStateToProps = (state) => {
   const { selectedUnit, service, event } = state;
+  // TODO: replace this with useLocaleText when the component is converted to function component
   const getLocaleText = textObject => getLocaleString(state, textObject);
   return {
     unit: selectedUnit.unit.data,

--- a/src/redux/selectors/locale.js
+++ b/src/redux/selectors/locale.js
@@ -1,7 +1,8 @@
 
 const getLocale = store => store.user.locale;
 
-// This returns correct string according to locale
+// NOTE: this is used only on old class components. useLocaleText should be used instead
+// TODO: remove this once class components are replaced with function components
 const getLocaleString = (state, obj) => {
   let locale;
   if (typeof state === 'string') {

--- a/src/utils/useLocaleText.js
+++ b/src/utils/useLocaleText.js
@@ -1,0 +1,21 @@
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+
+// This returns correct string from text object according to locale
+const getLocaleString = (locale, obj) => {
+  // Default rerturned string is the first one listed (probably always finnish)
+  let value = obj[Object.keys(obj)[0]];
+  Object.keys(obj).forEach((key) => {
+    if (key === locale) {
+      value = obj[key];
+    }
+  });
+  return value;
+};
+
+const useLocaleText = () => {
+  const locale = useSelector(state => state.user.locale);
+  return useCallback(obj => getLocaleString(locale, obj), [locale]);
+};
+
+export default useLocaleText;

--- a/src/views/AddressView/AddressView.js
+++ b/src/views/AddressView/AddressView.js
@@ -23,6 +23,7 @@ import MobileComponent from '../../components/MobileComponent';
 import DivisionItem from '../../components/ListItems/DivisionItem';
 import { parseSearchParams } from '../../utils';
 import config from '../../../config';
+import useLocaleText from '../../utils/useLocaleText';
 
 
 const hiddenDivisions = {
@@ -62,7 +63,6 @@ const AddressView = (props) => {
     match,
     getAddressNavigatorParams,
     getDistance,
-    getLocaleText,
     map,
     setAddressData,
     setAddressLocation,
@@ -74,6 +74,8 @@ const AddressView = (props) => {
     location,
     units,
   } = props;
+
+  const getLocaleText = useLocaleText();
 
   const fetchAddressDistricts = (lnglat) => {
     setAdminDistricts(null);
@@ -329,7 +331,6 @@ AddressView.propTypes = {
   navigator: PropTypes.objectOf(PropTypes.any),
   getAddressNavigatorParams: PropTypes.func.isRequired,
   getDistance: PropTypes.func.isRequired,
-  getLocaleText: PropTypes.func.isRequired,
   setAddressData: PropTypes.func.isRequired,
   setAddressLocation: PropTypes.func.isRequired,
   setAddressUnits: PropTypes.func.isRequired,

--- a/src/views/AddressView/index.js
+++ b/src/views/AddressView/index.js
@@ -26,6 +26,8 @@ const mapStateToProps = (state, props) => {
   } = state;
   const map = mapRef && mapRef.leafletElement;
   const getLocaleText = textObject => getLocaleString(state, textObject);
+  /* TODO: create custom hooks for getAddressNavigatorParams and getDistance
+  to prevent re-rendering on every state change */
   const getAddressNavigatorParams = getAddressNavigatorParamsConnector(getLocaleText, user.locale);
   const currentPosition = getCurrentlyUsedPosition(state);
   const getDistance = unit => formatDistanceObject(intl, calculateDistance(unit, currentPosition));
@@ -36,7 +38,6 @@ const mapStateToProps = (state, props) => {
     map,
     getAddressNavigatorParams,
     getDistance,
-    getLocaleText,
     navigator,
     units,
   };

--- a/src/views/AreaView/AreaView.js
+++ b/src/views/AreaView/AreaView.js
@@ -15,6 +15,7 @@ import AreaTab from './components/AreaTab';
 import { districtFetch } from '../../utils/fetch';
 import fetchAddress from '../MapView/utils/fetchAddress';
 import TitleBar from '../../components/TitleBar';
+import useLocaleText from '../../utils/useLocaleText';
 
 
 const fetchReducer = (state, action) => {
@@ -48,15 +49,10 @@ const AreaView = ({
   selectedDistrictServices,
   areaViewState,
   map,
-  getLocaleText,
   navigator,
   embed,
   intl,
 }) => {
-  if (!map || !map.leafletElement) {
-    return null;
-  }
-
   const dataStructure = [ // Categorized district data structure
     {
       id: 'health',
@@ -125,7 +121,7 @@ const AreaView = ({
       ],
     },
   ];
-
+  const getLocaleText = useLocaleText();
   const location = useLocation();
   const accordionStates = useRef(null);
 
@@ -429,6 +425,10 @@ const AreaView = ({
     }
   }, []);
 
+
+  if (!map || !map.leafletElement) {
+    return null;
+  }
 
   const renderAreaTab = () => (
     <AreaTab

--- a/src/views/AreaView/index.js
+++ b/src/views/AreaView/index.js
@@ -14,7 +14,6 @@ import {
   setAreaViewState,
 } from '../../redux/actions/district';
 import { getDistrictsByType, getAddressDistrict, getSubdistrictServices } from '../../redux/selectors/district';
-import { getLocaleString } from '../../redux/selectors/locale';
 
 const mapStateToProps = (state) => {
   const { navigator } = state;
@@ -32,7 +31,6 @@ const mapStateToProps = (state) => {
   const filteredSubdistrictUnits = getSubdistrictServices(state);
   const selectedDistrictData = getDistrictsByType(state);
   const addressDistrict = getAddressDistrict(state);
-  const getLocaleText = textObject => getLocaleString(state, textObject);
   return {
     districtData,
     selectedDistrictData,
@@ -45,7 +43,6 @@ const mapStateToProps = (state) => {
     selectedDistrictServices,
     unitsFetching,
     areaViewState,
-    getLocaleText,
     navigator,
     map,
   };

--- a/src/views/EmbedderView/EmbedderView.js
+++ b/src/views/EmbedderView/EmbedderView.js
@@ -17,6 +17,7 @@ import SMButton from '../../components/ServiceMapButton';
 import paths from '../../../config/paths';
 import embedderConfig from './embedderConfig';
 import SettingsUtility from '../../utils/settings';
+import useLocaleText from '../../utils/useLocaleText';
 
 
 const hideCitiesIn = [
@@ -40,14 +41,10 @@ const timeoutDelay = 1000;
 const EmbedderView = ({
   citySettings,
   classes,
-  getLocaleText,
   intl,
   mapType,
   navigator,
 }) => {
-  if (!isClient()) {
-    return null;
-  }
   // Verify url
   const data = isClient() ? smurl.verify(window.location.href) : {};
   let { url } = data;
@@ -81,6 +78,7 @@ const EmbedderView = ({
   const page = useSelector(state => state.user.page);
   const selectedUnit = useSelector(state => state.selectedUnit.unit.data);
   const currentService = useSelector(state => state.service.current);
+  const getLocaleText = useLocaleText();
 
   // States
   const [language, setLanguage] = useState(defaultLanguage);
@@ -478,6 +476,10 @@ const EmbedderView = ({
     </Helmet>
   );
 
+  if (!isClient()) {
+    return null;
+  }
+
   return (
     <div ref={dialogRef}>
       {
@@ -578,7 +580,6 @@ EmbedderView.propTypes = {
     title: PropTypes.string,
     titleContainer: PropTypes.string,
   }).isRequired,
-  getLocaleText: PropTypes.func.isRequired,
   location: PropTypes.shape({
     hash: PropTypes.string,
     pathname: PropTypes.string,

--- a/src/views/EmbedderView/index.js
+++ b/src/views/EmbedderView/index.js
@@ -2,7 +2,6 @@ import { withStyles } from '@material-ui/core';
 import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import { getLocaleString } from '../../redux/selectors/locale';
 import SettingsUtility from '../../utils/settings';
 import EmbedderView from './EmbedderView';
 import styles from './styles';
@@ -11,11 +10,9 @@ import styles from './styles';
 const mapStateToProps = (state) => {
   const { navigator, settings } = state;
   const { mapType } = settings;
-  const getLocaleText = textObject => getLocaleString(state, textObject);
 
   return {
     citySettings: SettingsUtility.getActiveCitySettings(state),
-    getLocaleText,
     mapType,
     navigator,
   };

--- a/src/views/EventDetailView/index.js
+++ b/src/views/EventDetailView/index.js
@@ -9,6 +9,7 @@ import { getLocaleString } from '../../redux/selectors/locale';
 import styles from './styles';
 
 const mapStateToProps = (state) => {
+  // TODO: replace this with useLocaleText when the component is converted to function component
   const getLocaleText = textObject => getLocaleString(state, textObject);
   const { event, mapRef, navigator } = state;
   const selectedUnit = state.selectedUnit.unit.data;

--- a/src/views/FeedbackView/FeedbackView.js
+++ b/src/views/FeedbackView/FeedbackView.js
@@ -11,10 +11,12 @@ import SMButton from '../../components/ServiceMapButton';
 import config from '../../../config';
 import DesktopComponent from '../../components/DesktopComponent';
 import { focusToViewTitle } from '../../utils/accessibility';
+import useLocaleText from '../../utils/useLocaleText';
 
 const FeedbackView = ({
-  classes, navigator, intl, location, selectedUnit, getLocaleText,
+  classes, navigator, intl, location, selectedUnit,
 }) => {
+  const getLocaleText = useLocaleText();
   // State
   const [email, setEmail] = useState(null);
   const [feedback, setFeedback] = useState(null);
@@ -252,7 +254,6 @@ FeedbackView.propTypes = {
   intl: PropTypes.objectOf(PropTypes.any).isRequired,
   location: PropTypes.objectOf(PropTypes.any).isRequired,
   selectedUnit: PropTypes.objectOf(PropTypes.any),
-  getLocaleText: PropTypes.func.isRequired,
 };
 
 FeedbackView.defaultProps = {

--- a/src/views/FeedbackView/index.js
+++ b/src/views/FeedbackView/index.js
@@ -3,17 +3,14 @@ import { withRouter } from 'react-router-dom';
 import { withStyles } from '@material-ui/core';
 import { injectIntl } from 'react-intl';
 import FeedbackView from './FeedbackView';
-import { getLocaleString } from '../../redux/selectors/locale';
 import styles from './styles';
 
 const mapStateToProps = (state) => {
   const { navigator } = state;
   const selectedUnit = state.selectedUnit.unit.data;
-  const getLocaleText = textObject => getLocaleString(state, textObject);
   return {
     navigator,
     selectedUnit,
-    getLocaleText,
   };
 };
 

--- a/src/views/HomeView/index.js
+++ b/src/views/HomeView/index.js
@@ -12,7 +12,10 @@ const mapStateToProps = (state) => {
   const {
     data, isFetching, count, max,
   } = units;
+  // TODO: replace this with useLocaleText when the component is converted to function component
   const getLocaleText = textObject => getLocaleString(state, textObject);
+  /* TODO: create custom hook for getAddressNavigatorParams to prevent
+  re-rendering on every state change */
   const getAddressNavigatorParams = getAddressNavigatorParamsConnector(getLocaleText, user.locale);
   return {
     unit: state.unit,

--- a/src/views/InfoView/index.js
+++ b/src/views/InfoView/index.js
@@ -1,17 +1,14 @@
 import { connect } from 'react-redux';
 import { withStyles } from '@material-ui/core';
 import { withRouter } from 'react-router-dom';
-import { getLocaleString } from '../../redux/selectors/locale';
 import InfoView from './InfoView';
 import styles from './styles';
 
 // Listen to redux state
 const mapStateToProps = (state) => {
   const { navigator } = state;
-  const getLocaleText = textObject => getLocaleString(state, textObject);
   const { locale } = state.user;
   return {
-    getLocaleText,
     navigator,
     locale,
   };

--- a/src/views/MapView/MapView.js
+++ b/src/views/MapView/MapView.js
@@ -26,6 +26,7 @@ import UnitGeometry from './components/UnitGeometry';
 import MapUtility from './utils/mapUtility';
 import HideSidebarButton from './components/HideSidebarButton';
 import CoordinateMarker from './components/CoordinateMarker';
+import useLocaleText from '../../utils/useLocaleText';
 
 if (global.window) {
   require('leaflet');
@@ -41,7 +42,6 @@ const MapView = (props) => {
     classes,
     currentPage,
     getAddressNavigatorParams,
-    getLocaleText,
     intl,
     location,
     settings,
@@ -64,8 +64,7 @@ const MapView = (props) => {
     toggleSidebar,
     sidebarHidden,
   } = props;
-
-
+  const getLocaleText = useLocaleText();
   const mapRef = useRef(null);
 
   // State
@@ -242,10 +241,10 @@ const MapView = (props) => {
       try {
         if (lat && lng) {
           const position = [usp.get('lon'), usp.get('lat')];
-          focusToPosition(mapRef.current.leafletElement, position); 
+          focusToPosition(mapRef.current.leafletElement, position);
         }
       } catch (e) {
-        console.error('Error while attemptin to focus on coordinate:', e)
+        console.error('Error while attemptin to focus on coordinate:', e);
       }
     }
   }, [mapRef.current]);
@@ -388,7 +387,6 @@ const MapView = (props) => {
             <AddressPopup
               mapClickPoint={mapClickPoint}
               getAddressNavigatorParams={getAddressNavigatorParams}
-              getLocaleText={getLocaleText}
               map={mapRef.current}
               setAddressLocation={setAddressLocation}
               navigator={navigator}
@@ -471,7 +469,6 @@ MapView.propTypes = {
   classes: PropTypes.objectOf(PropTypes.any).isRequired,
   currentPage: PropTypes.string.isRequired,
   getAddressNavigatorParams: PropTypes.func.isRequired,
-  getLocaleText: PropTypes.func.isRequired,
   hideUserMarker: PropTypes.bool,
   highlightedDistrict: PropTypes.objectOf(PropTypes.any),
   highlightedUnit: PropTypes.objectOf(PropTypes.any),

--- a/src/views/MapView/MapView.js
+++ b/src/views/MapView/MapView.js
@@ -64,7 +64,6 @@ const MapView = (props) => {
     toggleSidebar,
     sidebarHidden,
   } = props;
-  const getLocaleText = useLocaleText();
   const mapRef = useRef(null);
 
   // State
@@ -377,7 +376,6 @@ const MapView = (props) => {
           <Districts mapOptions={mapOptions} map={mapRef.current} embed={embeded} />
 
           <TransitStops
-            getLocaleText={getLocaleText}
             map={mapRef.current}
             mapObject={mapObject}
             isMobile={isMobile}

--- a/src/views/MapView/components/AddressMarker/AddressMarker.js
+++ b/src/views/MapView/components/AddressMarker/AddressMarker.js
@@ -3,14 +3,15 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { Typography } from '@material-ui/core';
 import PropTypes from 'prop-types';
 import { getAddressText } from '../../../../utils/address';
+import useLocaleText from '../../../../utils/useLocaleText';
 
 const AddressMarker = ({
   address,
   classes,
   embeded,
   position,
-  getLocaleText,
 }) => {
+  const getLocaleText = useLocaleText();
   if (!position && (!address || !address.addressCoordinates)) {
     return null;
   }
@@ -47,7 +48,7 @@ const AddressMarker = ({
           <Tooltip
             className={classes.unitTooltip}
             direction="top"
-            offset={[0, -36]}
+            offset={[0, -36]} // TODO: fix offset
             permanent
           >
             <Typography variant="body2">
@@ -65,7 +66,6 @@ AddressMarker.propTypes = {
   classes: PropTypes.objectOf(PropTypes.any).isRequired,
   position: PropTypes.arrayOf(PropTypes.number),
   embeded: PropTypes.bool,
-  getLocaleText: PropTypes.func.isRequired,
 };
 
 AddressMarker.defaultProps = {

--- a/src/views/MapView/components/AddressMarker/index.js
+++ b/src/views/MapView/components/AddressMarker/index.js
@@ -1,16 +1,13 @@
 import { withStyles } from '@material-ui/core';
 import { connect } from 'react-redux';
 import styles from '../../styles';
-import { getLocaleString } from '../../../../redux/selectors/locale';
 import AddressMarker from './AddressMarker';
 
 // Listen to redux state
 const mapStateToProps = (state) => {
   const { address } = state;
-  const getLocaleText = textObject => getLocaleString(state, textObject);
   return {
     address,
-    getLocaleText,
   };
 };
 

--- a/src/views/MapView/components/AddressPopup/AddressPopup.js
+++ b/src/views/MapView/components/AddressPopup/AddressPopup.js
@@ -5,16 +5,17 @@ import { useLocation } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import fetchAddress from '../../utils/fetchAddress';
 import { getAddressText } from '../../../../utils/address';
+import useLocaleText from '../../../../utils/useLocaleText';
 
 const AddressPopup = ({
   classes,
   mapClickPoint,
   getAddressNavigatorParams,
-  getLocaleText,
   map,
   navigator,
 }) => {
   const { Popup } = global.rL;
+  const getLocaleText = useLocaleText();
 
   const [address, setAddress] = useState(null);
   const [fetching, setFetching] = useState(null);
@@ -122,7 +123,6 @@ AddressPopup.propTypes = {
   classes: PropTypes.objectOf(PropTypes.any).isRequired,
   mapClickPoint: PropTypes.objectOf(PropTypes.any).isRequired,
   getAddressNavigatorParams: PropTypes.func.isRequired,
-  getLocaleText: PropTypes.func.isRequired,
   map: PropTypes.objectOf(PropTypes.any).isRequired,
   navigator: PropTypes.objectOf(PropTypes.any).isRequired,
 };

--- a/src/views/MapView/components/Districts/Districts.js
+++ b/src/views/MapView/components/Districts/Districts.js
@@ -10,6 +10,7 @@ import AddressMarker from '../AddressMarker';
 import useMobileStatus from '../../../../utils/isMobile';
 import { parseSearchParams } from '../../../../utils';
 import config from '../../../../../config';
+import useLocaleText from '../../../../utils/useLocaleText';
 
 
 const Districts = ({
@@ -17,7 +18,6 @@ const Districts = ({
   districtData,
   unitsFetching,
   addressDistrict,
-  getLocaleText,
   theme,
   mapOptions,
   currentPage,
@@ -37,6 +37,7 @@ const Districts = ({
   const useContrast = theme === 'dark';
   const isMobile = useMobileStatus();
   const location = useLocation();
+  const getLocaleText = useLocaleText();
   const citySettings = useSelector(state => state.settings.cities);
   const selectedDistrictType = useSelector(state => state.districts.selectedDistrictType);
   const [areaPopup, setAreaPopup] = useState(null);
@@ -262,7 +263,6 @@ const Districts = ({
 
 Districts.propTypes = {
   highlightedDistrict: PropTypes.objectOf(PropTypes.any),
-  getLocaleText: PropTypes.func.isRequired,
   mapOptions: PropTypes.objectOf(PropTypes.any).isRequired,
   currentPage: PropTypes.string.isRequired,
   measuringMode: PropTypes.bool.isRequired,

--- a/src/views/MapView/components/Districts/index.js
+++ b/src/views/MapView/components/Districts/index.js
@@ -5,7 +5,6 @@ import Districts from './Districts';
 import styles from '../../styles';
 import { getDistrictsByType, getAddressDistrict, getHighlightedDistrict } from '../../../../redux/selectors/district';
 import { setSelectedSubdistricts, setSelectedDistrictServices } from '../../../../redux/actions/district';
-import { getLocaleString } from '../../../../redux/selectors/locale';
 
 const mapStateToProps = (state) => {
   const { navigator, measuringMode } = state;
@@ -14,7 +13,6 @@ const mapStateToProps = (state) => {
   const districtData = getDistrictsByType(state);
   const addressDistrict = getAddressDistrict(state);
   const highlightedDistrict = getHighlightedDistrict(state);
-  const getLocaleText = textObject => getLocaleString(state, textObject);
   return {
     theme,
     navigator,
@@ -26,7 +24,6 @@ const mapStateToProps = (state) => {
     selectedAddress: districtAddressData.address,
     selectedSubdistricts,
     measuringMode,
-    getLocaleText,
   };
 };
 

--- a/src/views/MapView/components/MarkerCluster/MarkerCluster.js
+++ b/src/views/MapView/components/MarkerCluster/MarkerCluster.js
@@ -10,6 +10,7 @@ import { mapTypes } from '../../config/mapConfig';
 import { keyboardHandler } from '../../../../utils';
 import UnitHelper from '../../../../utils/unitHelper';
 import useMobileStatus from '../../../../utils/isMobile';
+import useLocaleText from '../../../../utils/useLocaleText';
 
 const tooltipOptions = (permanent, classes) => ({
   className: classes.unitTooltipContainer,
@@ -45,7 +46,6 @@ const MarkerCluster = ({
   currentPage,
   data,
   getDistance,
-  getLocaleText,
   highlightedUnit,
   map,
   navigator,
@@ -53,6 +53,7 @@ const MarkerCluster = ({
   theme,
   measuringMode,
 }) => {
+  const getLocaleText = useLocaleText();
   const useContrast = theme === 'dark';
   const embeded = isEmbed();
   const isMobile = useMobileStatus();

--- a/src/views/MapView/components/MarkerCluster/MarkerCluster.js
+++ b/src/views/MapView/components/MarkerCluster/MarkerCluster.js
@@ -444,7 +444,6 @@ MarkerCluster.propTypes = {
     }),
   ).isRequired,
   getDistance: PropTypes.func.isRequired,
-  getLocaleText: PropTypes.func.isRequired,
   map: PropTypes.objectOf(PropTypes.any).isRequired,
   navigator: PropTypes.objectOf(PropTypes.any).isRequired,
   settings: PropTypes.objectOf(PropTypes.any).isRequired,

--- a/src/views/MapView/components/MarkerCluster/index.js
+++ b/src/views/MapView/components/MarkerCluster/index.js
@@ -1,8 +1,6 @@
 import { connect } from 'react-redux';
 import { withStyles } from '@material-ui/styles';
 import MarkerCluster from './MarkerCluster';
-import { getLocaleString } from '../../../../redux/selectors/locale';
-import { generatePath } from '../../../../utils/path';
 import { formatDistanceObject } from '../../../../utils';
 import { calculateDistance, getCurrentlyUsedPosition } from '../../../../redux/selectors/unit';
 import styles from '../../styles';
@@ -11,10 +9,9 @@ import { getSelectedUnit } from '../../../../redux/selectors/selectedUnit';
 
 const mapStateToProps = (state) => {
   const { navigator, user, settings } = state;
-  const { locale, page, theme } = user;
-  const getLocaleText = textObject => getLocaleString(state, textObject);
-  const getPath = (id, data) => generatePath(id, locale, data);
+  const { page, theme } = user;
   const distanceCoordinates = getCurrentlyUsedPosition(state);
+  // TODO: optimization: memoize getDistance (move from mapStateToProps to custom hook)
   const getDistance = (unit, intl) => (
     formatDistanceObject(intl, calculateDistance(unit, distanceCoordinates))
   );
@@ -23,8 +20,6 @@ const mapStateToProps = (state) => {
   return {
     currentPage: page,
     getDistance,
-    getLocaleText,
-    getPath,
     highlightedUnit,
     navigator,
     settings,

--- a/src/views/MapView/components/TransitStops/TransitStopInfo/TransitStopInfo.js
+++ b/src/views/MapView/components/TransitStops/TransitStopInfo/TransitStopInfo.js
@@ -7,10 +7,10 @@ import { Typography, ButtonBase } from '@material-ui/core';
 import { Close } from '@material-ui/icons';
 import { fetchStopData } from '../../../utils/transitFetch';
 import { getIcon } from '../../../../../components/SMIcon';
+import useLocaleText from '../../../../../utils/useLocaleText';
 
-const TransitStopInfo = ({
-  stop, onCloseClick, classes, getLocaleText,
-}) => {
+const TransitStopInfo = ({ stop, onCloseClick, classes }) => {
+  const getLocaleText = useLocaleText();
   const [stopData, setStopData] = useState({ departureTimes: null, wheelchair: null });
 
   const getAccessibilityIcon = (value) => {
@@ -113,7 +113,6 @@ TransitStopInfo.propTypes = {
   stop: PropTypes.objectOf(PropTypes.any),
   onCloseClick: PropTypes.func.isRequired,
   classes: PropTypes.objectOf(PropTypes.any).isRequired,
-  getLocaleText: PropTypes.func.isRequired,
 };
 
 TransitStopInfo.defaultProps = {

--- a/src/views/MapView/components/TransitStops/TransitStops.js
+++ b/src/views/MapView/components/TransitStops/TransitStops.js
@@ -8,7 +8,6 @@ import { transitIconSize } from '../../config/mapConfig';
 import { isEmbed } from '../../../../utils/path';
 
 class TransitStops extends React.Component {
-  // TODO: convert this to function component and replace getLocaleText from parent component with useLocaText on this component
   constructor(props) {
     super(props);
     this.state = {
@@ -103,7 +102,6 @@ class TransitStops extends React.Component {
   }
 
   render() {
-    const { getLocaleText } = this.props;
     const { Marker, Popup } = global.rL;
     const { transitStops } = this.state;
 
@@ -121,7 +119,6 @@ class TransitStops extends React.Component {
               <TransitStopInfo
                 stop={stop}
                 onCloseClick={() => this.closePopup()}
-                getLocaleText={getLocaleText}
               />
             </Popup>
           </Marker>
@@ -132,7 +129,6 @@ class TransitStops extends React.Component {
 }
 
 TransitStops.propTypes = {
-  getLocaleText: PropTypes.func.isRequired,
   map: PropTypes.objectOf(PropTypes.any).isRequired,
   mapObject: PropTypes.objectOf(PropTypes.any).isRequired,
   classes: PropTypes.objectOf(PropTypes.any).isRequired,

--- a/src/views/MapView/components/TransitStops/TransitStops.js
+++ b/src/views/MapView/components/TransitStops/TransitStops.js
@@ -8,6 +8,7 @@ import { transitIconSize } from '../../config/mapConfig';
 import { isEmbed } from '../../../../utils/path';
 
 class TransitStops extends React.Component {
+  // TODO: convert this to function component and replace getLocaleText from parent component with useLocaText on this component
   constructor(props) {
     super(props);
     this.state = {

--- a/src/views/MapView/index.js
+++ b/src/views/MapView/index.js
@@ -29,6 +29,8 @@ const mapStateToProps = (state) => {
   const { adminDistricts, units, toRender } = address;
   const districtUnits = getFilteredSubdistrictUnits(state);
   const districtUnitsFetching = districts.unitsFetching;
+  /* TODO: create custom hook for getAddressNavigatorParams to prevent
+  re-rendering on every state change */
   const getAddressNavigatorParams = getAddressNavigatorParamsConnector(getLocaleText, locale);
   const userLocation = customPosition.coordinates || position.coordinates;
   return {
@@ -38,7 +40,6 @@ const mapStateToProps = (state) => {
     highlightedDistrict,
     highlightedUnit,
     getAddressNavigatorParams,
-    getLocaleText,
     unitList,
     serviceUnits,
     districtUnits,

--- a/src/views/PrintView/PrintView.js
+++ b/src/views/PrintView/PrintView.js
@@ -18,6 +18,7 @@ import { NumberCircleMaker } from '../MapView/utils/drawIcon';
 import CreateMap from '../MapView/utils/createMap';
 import SMButton from '../../components/ServiceMapButton';
 import paths from '../../../config/paths';
+import useLocaleText from '../../utils/useLocaleText';
 
 const StyledTableRow = withStyles(theme => ({
   root: {
@@ -35,11 +36,11 @@ const StyledTableCell = withStyles(theme => ({
 
 const PrintView = ({
   classes,
-  getLocaleText,
   map,
   togglePrintView,
 }) => {
   const intl = useIntl();
+  const getLocaleText = useLocaleText();
   const [descriptions, setDescriptions] = useState([]);
   const location = useLocation();
   const dialogRef = useRef();
@@ -68,8 +69,8 @@ const PrintView = ({
     map.keyboard.disable();
     if (map.tap) map.tap.disable();
     document.getElementById('print-map').style.cursor = 'default';
-    document.querySelector('.leaflet-control-zoom').style.display = 'none'
-    document.querySelector('.leaflet-control-attribution').style.display = 'none'
+    document.querySelector('.leaflet-control-zoom').style.display = 'none';
+    document.querySelector('.leaflet-control-attribution').style.display = 'none';
   };
 
   const getMarkers = () => {
@@ -365,11 +366,13 @@ PrintView.propTypes = {
     buttonContainer: PropTypes.string,
     container: PropTypes.string,
     map: PropTypes.string,
+    table: PropTypes.string,
     wrapper: PropTypes.string,
   }).isRequired,
-  getLocaleText: PropTypes.func.isRequired,
   map: PropTypes.shape({
     getBounds: PropTypes.func,
+    getCenter: PropTypes.func,
+    getZoom: PropTypes.func,
   }).isRequired,
   togglePrintView: PropTypes.func.isRequired,
 };

--- a/src/views/PrintView/index.js
+++ b/src/views/PrintView/index.js
@@ -2,15 +2,12 @@ import { withStyles } from '@material-ui/core';
 import { connect } from 'react-redux';
 import PrintView from './PrintView';
 import styles from './styles';
-import { getLocaleString } from '../../redux/selectors/locale';
 
 const mapStateToProps = (state) => {
   const { mapRef } = state;
   const map = mapRef?.leafletElement;
-  const getLocaleText = textObject => getLocaleString(state, textObject);
 
   return {
-    getLocaleText,
     map,
   };
 };

--- a/src/views/SearchView/index.js
+++ b/src/views/SearchView/index.js
@@ -19,6 +19,8 @@ const mapStateToProps = (state) => {
   } = units;
   const isRedirectFetching = redirectService.isFetching;
   const unitData = getOrderedData(state);
+  /* TODO: create custom hook for getAddressNavigatorParams to prevent
+  re-rendering on every state change */
   const getLocaleText = textObject => getLocaleString(state, textObject);
   const getAddressNavigatorParams = getAddressNavigatorParamsConnector(getLocaleText, user.locale);
 

--- a/src/views/ServiceTreeView/ServiceTreeView.js
+++ b/src/views/ServiceTreeView/ServiceTreeView.js
@@ -10,6 +10,7 @@ import { FormattedMessage } from 'react-intl';
 import config from '../../../config';
 import SMButton from '../../components/ServiceMapButton';
 import SMAccordion from '../../components/SMAccordion';
+import useLocaleText from '../../utils/useLocaleText';
 
 const ServiceTreeView = (props) => {
   const {
@@ -21,8 +22,8 @@ const ServiceTreeView = (props) => {
     prevSelected,
     prevOpened,
     settings,
-    getLocaleText,
   } = props;
+  const getLocaleText = useLocaleText();
 
   // State
   const [services, setServices] = useState(prevServices);
@@ -463,7 +464,6 @@ ServiceTreeView.propTypes = {
   prevSelected: PropTypes.arrayOf(PropTypes.any),
   prevOpened: PropTypes.arrayOf(PropTypes.any),
   settings: PropTypes.objectOf(PropTypes.any).isRequired,
-  getLocaleText: PropTypes.func.isRequired,
 };
 
 ServiceTreeView.defaultProps = {

--- a/src/views/ServiceTreeView/index.js
+++ b/src/views/ServiceTreeView/index.js
@@ -1,21 +1,18 @@
 import { connect } from 'react-redux';
 import { withStyles } from '@material-ui/core';
 import { injectIntl } from 'react-intl';
-import { getLocaleString } from '../../redux/selectors/locale';
 import setTreeState from '../../redux/actions/serviceTree';
 import ServiceTreeView from './ServiceTreeView';
 import styles from './styles';
 
 const mapStateToProps = (state) => {
   const { navigator, serviceTree, settings } = state;
-  const getLocaleText = textObject => getLocaleString(state, textObject);
   return {
     navigator,
     prevServices: (serviceTree && serviceTree.services) || [],
     prevSelected: (serviceTree && serviceTree.selected) || [],
     prevOpened: (serviceTree && serviceTree.opened) || [],
     settings,
-    getLocaleText,
   };
 };
 

--- a/src/views/ServiceView/index.js
+++ b/src/views/ServiceView/index.js
@@ -11,7 +11,7 @@ import styles from './styles';
 const mapStateToProps = (state) => {
   const { mapRef, service, user } = state;
   const { customPosition } = user;
-
+  // TODO: replace this with useLocaleText when the component is converted to function component
   const getLocaleText = textObject => getLocaleString(state, textObject);
   const map = mapRef && mapRef.leafletElement;
   const units = getServiceUnits(state);

--- a/src/views/UnitView/UnitView.js
+++ b/src/views/UnitView/UnitView.js
@@ -27,6 +27,7 @@ import ReadSpeakerButton from '../../components/ReadSpeakerButton';
 import config from '../../../config';
 import useMobileStatus from '../../utils/isMobile';
 import UnitHelper from '../../utils/unitHelper';
+import useLocaleText from '../../utils/useLocaleText';
 
 const UnitView = (props) => {
   const {
@@ -35,7 +36,6 @@ const UnitView = (props) => {
     intl,
     classes,
     embed,
-    getLocaleText,
     navigator,
     match,
     fetchSelectedUnit,
@@ -60,6 +60,8 @@ const UnitView = (props) => {
   const [unit, setUnit] = useState(checkCorrectUnit(stateUnit) ? stateUnit : null);
 
   const isMobile = useMobileStatus();
+
+  const getLocaleText = useLocaleText();
 
 
   const initializePTVAccessibilitySentences = () => {
@@ -140,11 +142,11 @@ const UnitView = (props) => {
     }
   }, [match.params.unit]);
 
-  if (config.usePtvAccessibilityApi) {
-    useEffect(() => {
+  useEffect(() => {
+    if (config.usePtvAccessibilityApi) {
       initializePTVAccessibilitySentences();
-    }, [unit]);
-  }
+    }
+  }, [unit]);
 
   if (embed) {
     return null;
@@ -426,7 +428,6 @@ UnitView.propTypes = {
   fetchUnitEvents: PropTypes.func.isRequired,
   match: PropTypes.objectOf(PropTypes.any),
   classes: PropTypes.objectOf(PropTypes.any).isRequired,
-  getLocaleText: PropTypes.func.isRequired,
   intl: PropTypes.objectOf(PropTypes.any).isRequired,
   navigator: PropTypes.objectOf(PropTypes.any),
   reservations: PropTypes.arrayOf(PropTypes.any),

--- a/src/views/UnitView/UnitView.js
+++ b/src/views/UnitView/UnitView.js
@@ -199,10 +199,10 @@ const UnitView = (props) => {
           </Container>
 
           {/* View Components */}
-          <ContactInfo unit={unit} userLocation={userLocation} getLocaleText={getLocaleText} />
-          <SocialMediaLinks unit={unit} getLocaleText={getLocaleText} />
-          <Highlights unit={unit} getLocaleText={getLocaleText} />
-          <Description unit={unit} getLocaleText={getLocaleText} />
+          <ContactInfo unit={unit} userLocation={userLocation} />
+          <SocialMediaLinks unit={unit} />
+          <Highlights unit={unit} />
+          <Description unit={unit} />
           <UnitLinks unit={unit} />
           <ElectronicServices unit={unit} />
           {!isMobile && feedbackButton()}

--- a/src/views/UnitView/components/AccessibilityInfo/index.js
+++ b/src/views/UnitView/components/AccessibilityInfo/index.js
@@ -7,6 +7,7 @@ import styles from './styles';
 const mapStateToProps = (state) => {
   const { selectedUnit, settings } = state;
   const { data } = selectedUnit.unit;
+  // TODO: replace this with useLocaleText when the component is converted to function component
   const getLocaleText = textObject => getLocaleString(state, textObject);
   const { accessibilitySentences } = selectedUnit;
   return {

--- a/src/views/UnitView/components/ContactInfo/ContactInfo.js
+++ b/src/views/UnitView/components/ContactInfo/ContactInfo.js
@@ -9,10 +9,13 @@ import config from '../../../../../config';
 import InfoList from '../InfoList';
 import unitSectionFilter from '../../utils/unitSectionFilter';
 import { getAddressFromUnit } from '../../../../utils/address';
+import useLocaleText from '../../../../utils/useLocaleText';
 
 const ContactInfo = ({
-  unit, userLocation, getLocaleText, intl, classes,
+  unit, userLocation, intl, classes,
 }) => {
+  const getLocaleText = useLocaleText();
+
   const address = {
     type: 'ADDRESS',
     value: unit.street_address ? getAddressFromUnit(unit, getLocaleText, intl) : intl.formatMessage({ id: 'unit.address.missing' }),
@@ -119,7 +122,6 @@ ContactInfo.propTypes = {
   unit: PropTypes.objectOf(PropTypes.any).isRequired,
   intl: PropTypes.objectOf(PropTypes.any).isRequired,
   classes: PropTypes.objectOf(PropTypes.any).isRequired,
-  getLocaleText: PropTypes.func.isRequired,
   userLocation: PropTypes.objectOf(PropTypes.any),
 };
 

--- a/src/views/UnitView/components/Description/Description.js
+++ b/src/views/UnitView/components/Description/Description.js
@@ -4,8 +4,11 @@ import { FormattedMessage } from 'react-intl';
 import { Typography, Link } from '@material-ui/core';
 import unitSectionFilter from '../../utils/unitSectionFilter';
 import DescriptionText from '../../../../components/DescriptionText';
+import useLocaleText from '../../../../utils/useLocaleText';
 
-const Description = ({ unit, getLocaleText, classes }) => {
+const Description = ({ unit, classes }) => {
+  const getLocaleText = useLocaleText();
+
   const additionalInfo = [
     ...unitSectionFilter(unit.connections, 'OTHER_INFO'),
     ...unitSectionFilter(unit.connections, 'TOPICAL'),
@@ -61,7 +64,6 @@ const Description = ({ unit, getLocaleText, classes }) => {
 Description.propTypes = {
   unit: PropTypes.objectOf(PropTypes.any).isRequired,
   classes: PropTypes.objectOf(PropTypes.any).isRequired,
-  getLocaleText: PropTypes.func.isRequired,
 };
 
 export default Description;

--- a/src/views/UnitView/components/Events/index.js
+++ b/src/views/UnitView/components/Events/index.js
@@ -1,15 +1,12 @@
 import { connect } from 'react-redux';
 import { fetchUnitEvents } from '../../../../redux/actions/selectedUnitEvents';
-import { getLocaleString } from '../../../../redux/selectors/locale';
 import Events from './Events';
 
 const mapStateToProps = (state) => {
   const unit = state.selectedUnit.unit.data;
-  const getLocaleText = textObject => getLocaleString(state, textObject);
   const { navigator } = state;
   return {
     unit,
-    getLocaleText,
     navigator,
   };
 };

--- a/src/views/UnitView/components/ExtendedData/ExtendedData.js
+++ b/src/views/UnitView/components/ExtendedData/ExtendedData.js
@@ -7,6 +7,7 @@ import PaginatedList from '../../../../components/Lists/PaginatedList';
 import TitleBar from '../../../../components/TitleBar';
 import Loading from '../../../../components/Loading';
 import ReservationItem from '../../../../components/ListItems/ReservationItem';
+import useLocaleText from '../../../../utils/useLocaleText';
 
 const ExtendedData = ({
   currentUnit,
@@ -14,10 +15,10 @@ const ExtendedData = ({
   fetchSelectedUnit,
   fetchReservations,
   fetchUnitEvents,
-  getLocaleText,
   reservations,
   type,
 }) => {
+  const getLocaleText = useLocaleText();
   const intl = useIntl();
   const { unit } = useParams();
   const title = currentUnit && currentUnit.name ? getLocaleText(currentUnit.name) : '';
@@ -125,9 +126,16 @@ const ExtendedData = ({
 
 ExtendedData.propTypes = {
   events: PropTypes.objectOf(PropTypes.any).isRequired,
+  currentUnit: PropTypes.objectOf(PropTypes.any),
+  fetchSelectedUnit: PropTypes.func.isRequired,
+  type: PropTypes.string.isRequired,
   fetchReservations: PropTypes.func.isRequired,
   fetchUnitEvents: PropTypes.func.isRequired,
   reservations: PropTypes.objectOf(PropTypes.any).isRequired,
+};
+
+ExtendedData.defaultProps = {
+  currentUnit: null,
 };
 
 export default ExtendedData;

--- a/src/views/UnitView/components/ExtendedData/index.js
+++ b/src/views/UnitView/components/ExtendedData/index.js
@@ -1,19 +1,15 @@
 import { connect } from 'react-redux';
-import { injectIntl } from 'react-intl';
 import { fetchReservations } from '../../../../redux/actions/selectedUnitReservations';
 import { fetchUnitEvents } from '../../../../redux/actions/selectedUnitEvents';
 import { fetchSelectedUnit } from '../../../../redux/actions/selectedUnit';
 
 import ExtendedData from './ExtendedData';
-import { getLocaleString } from '../../../../redux/selectors/locale';
 
 const mapStateToProps = (state) => {
   const { unit, events, reservations } = state.selectedUnit;
-  const getLocaleText = textObject => getLocaleString(state, textObject);
   return {
     currentUnit: unit.data,
     events,
-    getLocaleText,
     reservations,
   };
 };

--- a/src/views/UnitView/components/Highlights/Highlights.js
+++ b/src/views/UnitView/components/Highlights/Highlights.js
@@ -4,10 +4,10 @@ import { Typography, Link } from '@material-ui/core';
 import { FormattedMessage } from 'react-intl';
 import config from '../../../../../config';
 import unitSectionFilter from '../../utils/unitSectionFilter';
+import useLocaleText from '../../../../utils/useLocaleText';
 
-const Highlights = ({
-  unit, classes, getLocaleText, intl,
-}) => {
+const Highlights = ({ unit, classes, intl }) => {
+  const getLocaleText = useLocaleText();
   const connections = unitSectionFilter(unit.connections, 'HIGHLIGHT');
 
   // Add link to ulkoliikunta.fi as custom highligh to certain services
@@ -66,7 +66,6 @@ const Highlights = ({
 Highlights.propTypes = {
   unit: PropTypes.objectOf(PropTypes.any).isRequired,
   classes: PropTypes.objectOf(PropTypes.any).isRequired,
-  getLocaleText: PropTypes.func.isRequired,
   intl: PropTypes.objectOf(PropTypes.any).isRequired,
 };
 

--- a/src/views/UnitView/components/InfoList/index.js
+++ b/src/views/UnitView/components/InfoList/index.js
@@ -4,6 +4,7 @@ import { getLocaleString } from '../../../../redux/selectors/locale';
 import InfoList from './InfoList';
 
 const mapStateToProps = (state) => {
+  // TODO: replace this with useLocaleText when the component is converted to function component
   const getLocaleText = textObject => getLocaleString(state, textObject);
   return {
     getLocaleText,

--- a/src/views/UnitView/components/Services/Services.js
+++ b/src/views/UnitView/components/Services/Services.js
@@ -8,6 +8,7 @@ import ServiceItem from '../../../../components/ListItems/ServiceItem';
 const educationNode = 1087;
 
 class Services extends React.Component {
+  // TODO: replace getLocaleText with useLocaleText when the component is converted to function component
   serviceRef = null;
 
   periodRef = null;

--- a/src/views/UnitView/components/SocialMediaLinks/SocialMediaLinks.js
+++ b/src/views/UnitView/components/SocialMediaLinks/SocialMediaLinks.js
@@ -7,8 +7,10 @@ import DefaultIcon from '@material-ui/icons/Public';
 import { FormattedMessage } from 'react-intl';
 import unitSectionFilter from '../../utils/unitSectionFilter';
 import { getIcon } from '../../../../components/SMIcon';
+import useLocaleText from '../../../../utils/useLocaleText';
 
-const SocialMediaLinks = ({ unit, getLocaleText, classes }) => {
+const SocialMediaLinks = ({ unit, classes }) => {
+  const getLocaleText = useLocaleText();
   const links = unitSectionFilter(unit.connections, 'SOCIAL_MEDIA_LINK');
   const columns = 3;
 
@@ -52,7 +54,6 @@ const SocialMediaLinks = ({ unit, getLocaleText, classes }) => {
 
 SocialMediaLinks.propTypes = {
   unit: PropTypes.objectOf(PropTypes.any).isRequired,
-  getLocaleText: PropTypes.func.isRequired,
   classes: PropTypes.objectOf(PropTypes.any).isRequired,
 };
 

--- a/src/views/UnitView/index.js
+++ b/src/views/UnitView/index.js
@@ -7,7 +7,6 @@ import { fetchAccessibilitySentences } from '../../redux/actions/selectedUnitAcc
 import { fetchHearingMaps } from '../../redux/actions/selectedUnitHearingMaps';
 import { fetchUnitEvents } from '../../redux/actions/selectedUnitEvents';
 import { fetchReservations } from '../../redux/actions/selectedUnitReservations';
-import { getLocaleString } from '../../redux/selectors/locale';
 
 import UnitView from './UnitView';
 import styles from './styles/styles';
@@ -23,7 +22,6 @@ const mapStateToProps = (state, props) => {
   const {
     accessibilitySentences, events, reservations, hearingMaps,
   } = state.selectedUnit;
-  const getLocaleText = textObject => getLocaleString(state, textObject);
   const { navigator, user } = state;
 
   return {
@@ -32,7 +30,6 @@ const mapStateToProps = (state, props) => {
     stateUnit,
     unitFetching,
     eventsData: events,
-    getLocaleText,
     navigator,
     reservationsData: reservations,
     userLocation: user.position,


### PR DESCRIPTION
Noticed that getLocaleText triggers component re-render whenever any state in redux changes. This causes unwanted re-renders, for example: TopBar re-renders whenever a radio button is selected on Area view.

- Created new memoized useLocaleText hook
- Updated all function components that used getLocaleText
- Added new eslint plugin that checks that hooks are used correctly. Fixed some of the issues pointed out by this plugin

Further to do:
- New useLocaleText hook can't be used on class components. The remaining few class components should be updated.
- Also noticed some other functions in mapStateToProps which cause similar re-renders as getLocaleText. Added TODO comments to those. 

EDIT:  [useTraceUpdate](https://www.npmjs.com/package/use-trace-update) was used to find causes of re-rendering