### PR TITLE
Exclude user marker from print markers

### DIFF
--- a/src/views/MapView/components/UserMarker/UserMarker.js
+++ b/src/views/MapView/components/UserMarker/UserMarker.js
@@ -17,6 +17,7 @@ const UserMarker = ({ position, classes, onClick }) => {
 
   return (
     <Marker
+      id="userMarker"
       onClick={onClick}
       position={position}
       icon={icon}

--- a/src/views/PrintView/PrintView.js
+++ b/src/views/PrintView/PrintView.js
@@ -185,7 +185,7 @@ const PrintView = ({
     Object.keys(markers).forEach((key) => {
       if (Object.prototype.hasOwnProperty.call(markers, key)) {
         const marker = markers[key];
-        if (!mapBounds.contains(marker.getLatLng())) {
+        if (marker.options.id === 'userMarker' || !mapBounds.contains(marker.getLatLng())) {
           return;
         }
         if (isUnitPage() && isInvalidUnitPageMarker(marker)) {


### PR DESCRIPTION
If user location is available, location icon crashes print view.