### PR TITLE
Fix/multiple popups

### DIFF
--- a/src/views/MapView/components/MarkerCluster/MarkerCluster.js
+++ b/src/views/MapView/components/MarkerCluster/MarkerCluster.js
@@ -98,6 +98,10 @@ const MarkerCluster = ({
     const highlightedMarker = getHighlightedMarker(mapLayers);
     if (highlightedMarker && UnitHelper.isUnitPage()) {
       const tooltipContent = getUnitPopupContent(clusterData.highlightedUnit);
+      // Close all open popups
+      map.eachLayer((layer) => {
+        layer.closePopup();
+      });
       if (highlightedMarker instanceof global.L.MarkerCluster) {
         highlightedMarker.bindPopup(tooltipContent, popupOptions()).openPopup();
       } else {

--- a/src/views/MapView/components/MarkerCluster/MarkerCluster.js
+++ b/src/views/MapView/components/MarkerCluster/MarkerCluster.js
@@ -212,10 +212,10 @@ const MarkerCluster = ({
         const listItem = document.createElement('li');
         // Create span for interactive list item content
         const span = document.createElement('span');
-        span.setAttribute('tabindex', '0');
-        span.setAttribute('role', 'link');
-        span.onkeydown = keyboardHandler(() => onClusterItemClick(unit), ['enter', 'space']);
-        span.onclick = () => {
+        listItem.setAttribute('tabindex', '0');
+        listItem.setAttribute('role', 'link');
+        listItem.onkeydown = keyboardHandler(() => onClusterItemClick(unit), ['enter', 'space']);
+        listItem.onclick = () => {
           if (onClusterItemClick) {
             onClusterItemClick(unit);
           }

--- a/src/views/MapView/styles.js
+++ b/src/views/MapView/styles.js
@@ -201,6 +201,9 @@ const styles = theme => ({
         cursor: 'pointer',
         backgroundColor: theme.palette.white.light,
       },
+      '&:focus': {
+        backgroundColor: theme.palette.white.light,
+      },
     },
     '& .popup-divider': {
       cursor: 'unset',


### PR DESCRIPTION
- Fix multiple popup problem when choosing different units from marker cluster list.
- Move marker cluster unit list click from span to li. Previously click event would not trigger when clicking the edge of the list item