### PR TITLE
Fix/accessibility test

### DIFF
--- a/browserTests/focusIndicatorTest.js
+++ b/browserTests/focusIndicatorTest.js
@@ -53,9 +53,10 @@ export default () => {
       const button = buttons.nth(i);
       const disabled = await button.getAttribute('disabled');
       const tabindex = await button.getAttribute('tabindex');
+      const size = await button.boundingClientRect;
 
       if (await button.getAttribute('data-rs-container') !== "readspeaker_button1") { // Ignore readspeaker button. TODO: better implementation  
-        if ((disabled === undefined || disabled === false) && tabindex !== '-1') {
+        if ((disabled === undefined || disabled === false) && tabindex !== '-1' && size.height !== 0) {
           const focusElement = ClientFunction(() => {
             button().focus();
           }, {

--- a/src/redux/actions/user.js
+++ b/src/redux/actions/user.js
@@ -49,6 +49,10 @@ export const changeTheme = theme => async (dispatch) => {
 };
 
 export const findUserLocation = () => async (dispatch) => {
+  // Disable user location during browser tests.
+  if (window.navigator.webdriver) {
+    return;
+  }
   const success = (position) => {
     if (position.coords.accuracy < 1000) {
       fetchAddress({ lat: position.coords.latitude, lng: position.coords.longitude })


### PR DESCRIPTION
Changes to unit view tab rendering caused focus border test to test buttons that are on a different tab (thus not visible).
Also disable location dialog from tests.