### PR TITLE
Check that description has units

### DIFF
--- a/src/views/PrintView/PrintView.js
+++ b/src/views/PrintView/PrintView.js
@@ -82,10 +82,19 @@ const PrintView = ({
         return;
       }
       const current = layers[key];
+      const cl = current?._icon?.classList; // Class list for icon
 
       if (
-        current instanceof global.L.MarkerCluster
-        || current instanceof global.L.Marker
+        ( 
+          current instanceof global.L.MarkerCluster
+          || current instanceof global.L.Marker
+        )
+        // Only unit markers and clusters
+        && cl
+        && (
+          cl.contains('unitMarker')
+          || cl.contains('unitClusterMarker')
+        )
       ) {
         markers.push(current);
       }
@@ -293,7 +302,7 @@ const PrintView = ({
               <TableBody>
                 {
                   descriptions.map((description) => {
-                    if (!description?.units) {
+                    if (!description?.units || !description.units[0]) {
                       return null;
                     }
                     const { name, street_address: address } = description.units[0];


### PR DESCRIPTION
Only add markers that are unit markers or clusters. 

Print view was crashing because it was fetching any leaflet marker including transit stops. Changed marker fetching to only get markers that have icons with class `unitMarker` or `unitClusterMarker`. Also added check that confirms description has existing first unit.