### PR TITLE
Fix/drawer menu accessibility

### DIFF
--- a/src/components/TopBar/DrawerMenu/DrawerMenu.js
+++ b/src/components/TopBar/DrawerMenu/DrawerMenu.js
@@ -96,30 +96,32 @@ const DrawerMenu = (props) => {
       open={isOpen}
       classes={{ paper: pageType === 'mobile' ? classes.drawerContainerMobile : classes.drawerContainer }}
     >
-      {menuContent.map((item) => {
-        if (item.type === 'settings') {
+      <div className={classes.scrollContainer}>
+        {menuContent.map((item) => {
+          if (item.type === 'settings') {
+            return (
+              <DrawerSettings
+                key={item.type}
+                onClick={item.clickEvent}
+              />
+            );
+          }
+
           return (
-            <DrawerSettings
-              key={item.type}
+            <DrawerButton
+              key={item.name}
+              active={item.active}
+              disabled={item.disabled}
+              disableRipple
+              icon={item.icon}
+              isOpen={isOpen}
+              text={item.name}
               onClick={item.clickEvent}
+              subText={item.subText}
             />
           );
-        }
-        
-        return (
-          <DrawerButton
-            key={item.name}
-            active={item.active}
-            disabled={item.disabled}
-            disableRipple
-            icon={item.icon}
-            isOpen={isOpen}
-            text={item.name}
-            onClick={item.clickEvent}
-            subText={item.subText}
-          />
-        );
-      })}
+        })}
+      </div>
     </Drawer>
   // </ClickAwayListener>
   );

--- a/src/components/TopBar/DrawerMenu/__tests__/__snapshots__/DrawerButton.test.js.snap
+++ b/src/components/TopBar/DrawerMenu/__tests__/__snapshots__/DrawerButton.test.js.snap
@@ -15,15 +15,16 @@ exports[`<DrawerButton /> should work 1`] = `
     active={false}
     classes={
       Object {
-        "disabled": "DrawerButton-disabled-8",
-        "drawerButton": "DrawerButton-drawerButton-3",
-        "drawerButtonActive": "DrawerButton-drawerButtonActive-4",
-        "drawerButtonText": "DrawerButton-drawerButtonText-5",
+        "disabled": "DrawerButton-disabled-9",
+        "drawerButton": "DrawerButton-drawerButton-4",
+        "drawerButtonActive": "DrawerButton-drawerButtonActive-5",
+        "drawerButtonText": "DrawerButton-drawerButtonText-6",
         "drawerContainer": "DrawerButton-drawerContainer-1",
-        "drawerContainerMobile": "DrawerButton-drawerContainerMobile-2",
-        "drawerIcon": "DrawerButton-drawerIcon-6",
-        "drawerIconActive": "DrawerButton-drawerIconActive-7",
-        "itemFocus": "DrawerButton-itemFocus-9",
+        "drawerContainerMobile": "DrawerButton-drawerContainerMobile-3",
+        "drawerIcon": "DrawerButton-drawerIcon-7",
+        "drawerIconActive": "DrawerButton-drawerIconActive-8",
+        "itemFocus": "DrawerButton-itemFocus-10",
+        "scrollContainer": "DrawerButton-scrollContainer-2",
       }
     }
     disableRipple={true}
@@ -37,9 +38,9 @@ exports[`<DrawerButton /> should work 1`] = `
     <WithStyles(ForwardRef(ButtonBase))
       aria-hidden={true}
       aria-label="Drawer button text"
-      className="DrawerButton-drawerButton-3 "
+      className="DrawerButton-drawerButton-4 "
       disableRipple={true}
-      focusVisibleClassName="DrawerButton-itemFocus-9"
+      focusVisibleClassName="DrawerButton-itemFocus-10"
       key="Drawer button text"
       onClick={[Function]}
       role="link"
@@ -48,7 +49,7 @@ exports[`<DrawerButton /> should work 1`] = `
       <ForwardRef(ButtonBase)
         aria-hidden={true}
         aria-label="Drawer button text"
-        className="DrawerButton-drawerButton-3 "
+        className="DrawerButton-drawerButton-4 "
         classes={
           Object {
             "disabled": "Mui-disabled",
@@ -57,7 +58,7 @@ exports[`<DrawerButton /> should work 1`] = `
           }
         }
         disableRipple={true}
-        focusVisibleClassName="DrawerButton-itemFocus-9"
+        focusVisibleClassName="DrawerButton-itemFocus-10"
         onClick={[Function]}
         role="link"
         tabIndex={-1}
@@ -65,7 +66,7 @@ exports[`<DrawerButton /> should work 1`] = `
         <button
           aria-hidden={true}
           aria-label="Drawer button text"
-          className="MuiButtonBase-root DrawerButton-drawerButton-3 "
+          className="MuiButtonBase-root DrawerButton-drawerButton-4 "
           disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
@@ -84,7 +85,7 @@ exports[`<DrawerButton /> should work 1`] = `
           type="button"
         >
           <div
-            className="DrawerButton-drawerIcon-6  "
+            className="DrawerButton-drawerIcon-7  "
           >
             <ForwardRef>
               <WithStyles(ForwardRef(SvgIcon))>
@@ -121,11 +122,11 @@ exports[`<DrawerButton /> should work 1`] = `
             aria-hidden={true}
           >
             <WithStyles(ForwardRef(Typography))
-              className="DrawerButton-drawerButtonText-5 "
+              className="DrawerButton-drawerButtonText-6 "
               variant="body1"
             >
               <ForwardRef(Typography)
-                className="DrawerButton-drawerButtonText-5 "
+                className="DrawerButton-drawerButtonText-6 "
                 classes={
                   Object {
                     "alignCenter": "MuiTypography-alignCenter",
@@ -163,7 +164,7 @@ exports[`<DrawerButton /> should work 1`] = `
                 variant="body1"
               >
                 <p
-                  className="MuiTypography-root DrawerButton-drawerButtonText-5  MuiTypography-body1"
+                  className="MuiTypography-root DrawerButton-drawerButtonText-6  MuiTypography-body1"
                 >
                   Drawer button text
                 </p>

--- a/src/components/TopBar/DrawerMenu/styles.js
+++ b/src/components/TopBar/DrawerMenu/styles.js
@@ -9,6 +9,11 @@ const styles = () => ({
     backgroundColor: '#353638',
     maxWidth: 350,
     padding: 2,
+    overflow: 'visible',
+  },
+  scrollContainer: {
+    height: `calc(100vh - ${config.topBarHeight}px)`,
+    overflowY: 'auto',
   },
   drawerContainerMobile: {
     color: '#fff',
@@ -16,6 +21,7 @@ const styles = () => ({
     backgroundColor: '#353638',
     maxWidth: 350,
     padding: 2,
+    overflow: 'visible',
   },
   drawerButton: {
     color: 'inherit',
@@ -26,6 +32,7 @@ const styles = () => ({
     paddingLeft: 25,
     paddingRight: 25,
     borderBottom: '1px solid rgba(255, 255, 255, 0.24)',
+    width: '100%',
   },
   drawerButtonActive: {
     backgroundColor: '#141823',

--- a/src/components/TopBar/MenuButton/MenuButton.js
+++ b/src/components/TopBar/MenuButton/MenuButton.js
@@ -2,42 +2,45 @@ import { Button, Typography } from '@material-ui/core';
 import PropTypes from 'prop-types';
 import { Close, Menu } from '@material-ui/icons';
 import React from 'react';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 
 const MenuButton = ({
-  classes, intl, drawerOpen, pageType, toggleDrawerMenu,
-}) => (
-  <Button
-    id="MenuButton"
-    aria-label={intl.formatMessage({ id: 'general.menu' })}
-    aria-expanded={drawerOpen}
-    aria-haspopup="true"
-    className={`${drawerOpen ? classes.toolbarButtonPressed : classes.toolbarButton} ${pageType !== 'mobile' ? classes.largeButton : ''}`}
-    classes={{ label: classes.buttonLabel }}
-    onClick={() => toggleDrawerMenu()}
-  >
-    {drawerOpen ? (
-      <>
-        <Close />
-        <Typography color="inherit" variant="body2">
-          <FormattedMessage id="general.close" />
-        </Typography>
-      </>
-    ) : (
-      <>
-        <Menu />
-        <Typography color="inherit" variant="body2">
-          <FormattedMessage id="general.menu" />
-        </Typography>
-      </>
-    )}
-  </Button>
-);
+  classes, drawerOpen, pageType, toggleDrawerMenu,
+}) => {
+  const intl = useIntl();
+
+  return (
+    <Button
+      id="MenuButton"
+      aria-label={intl.formatMessage({ id: 'general.menu' })}
+      aria-expanded={drawerOpen}
+      aria-haspopup="true"
+      className={`${drawerOpen ? classes.toolbarButtonPressed : classes.toolbarButton} ${pageType !== 'mobile' ? classes.largeButton : ''}`}
+      classes={{ label: classes.buttonLabel }}
+      onClick={() => toggleDrawerMenu()}
+    >
+      {drawerOpen ? (
+        <>
+          <Close />
+          <Typography color="inherit" variant="body2">
+            <FormattedMessage id="general.close" />
+          </Typography>
+        </>
+      ) : (
+        <>
+          <Menu />
+          <Typography color="inherit" variant="body2">
+            <FormattedMessage id="general.menu" />
+          </Typography>
+        </>
+      )}
+    </Button>
+  );
+};
 
 MenuButton.propTypes = {
   classes: PropTypes.objectOf(PropTypes.any).isRequired,
-  intl: PropTypes.objectOf(PropTypes.any).isRequired,
   drawerOpen: PropTypes.bool.isRequired,
   pageType: PropTypes.string,
   toggleDrawerMenu: PropTypes.func.isRequired,

--- a/src/components/TopBar/MenuButton/MenuButton.js
+++ b/src/components/TopBar/MenuButton/MenuButton.js
@@ -1,0 +1,50 @@
+import { Button, Typography } from '@material-ui/core';
+import PropTypes from 'prop-types';
+import { Close, Menu } from '@material-ui/icons';
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+
+
+const MenuButton = ({
+  classes, intl, drawerOpen, pageType, toggleDrawerMenu,
+}) => (
+  <Button
+    id="MenuButton"
+    aria-label={intl.formatMessage({ id: 'general.menu' })}
+    aria-expanded={drawerOpen}
+    aria-haspopup="true"
+    className={`${drawerOpen ? classes.toolbarButtonPressed : classes.toolbarButton} ${pageType !== 'mobile' ? classes.largeButton : ''}`}
+    classes={{ label: classes.buttonLabel }}
+    onClick={() => toggleDrawerMenu()}
+  >
+    {drawerOpen ? (
+      <>
+        <Close />
+        <Typography color="inherit" variant="body2">
+          <FormattedMessage id="general.close" />
+        </Typography>
+      </>
+    ) : (
+      <>
+        <Menu />
+        <Typography color="inherit" variant="body2">
+          <FormattedMessage id="general.menu" />
+        </Typography>
+      </>
+    )}
+  </Button>
+);
+
+MenuButton.propTypes = {
+  classes: PropTypes.objectOf(PropTypes.any).isRequired,
+  intl: PropTypes.objectOf(PropTypes.any).isRequired,
+  drawerOpen: PropTypes.bool.isRequired,
+  pageType: PropTypes.string,
+  toggleDrawerMenu: PropTypes.func.isRequired,
+};
+
+MenuButton.defaultProps = {
+  pageType: null,
+};
+
+export default MenuButton;

--- a/src/components/TopBar/MenuButton/__tests__/MenuButton.test.js
+++ b/src/components/TopBar/MenuButton/__tests__/MenuButton.test.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import { createMount } from '@material-ui/core/test-utils';
+import { MuiThemeProvider } from '@material-ui/core';
+import { IntlProvider } from 'react-intl';
+import themes from '../../../../themes';
+import MenuButton from '../MenuButton';
+
+
+const mockProps = {
+  classes: {},
+  drawerOpen: false,
+  toggleDrawerMenu: () => {},
+};
+
+const intlMock = {
+  locale: 'en',
+  messages: {
+    'general.menu': 'Valikko',
+  },
+};
+
+// eslint-disable-next-line react/prop-types
+const Providers = ({ children }) => (
+  <IntlProvider {...intlMock}>
+    <MuiThemeProvider theme={themes.SMTheme}>
+      {children}
+    </MuiThemeProvider>
+  </IntlProvider>
+);
+
+
+describe('<MenuButton />', () => {
+  let mount;
+
+  beforeEach(() => {
+    // Use mount since intl.formatMessage does not work with shallow
+    mount = createMount({ wrappingComponent: Providers });
+  });
+
+  afterEach(() => {
+    mount.cleanUp();
+  });
+
+  it('should work', () => {
+    const component = mount(<MenuButton {...mockProps} />);
+    expect(component).toMatchSnapshot();
+  });
+
+  it('does use correct aria arrtibutes', () => {
+    const component = mount(<MenuButton {...mockProps} />);
+    const button = component.find('ForwardRef(Button)');
+    /*
+      The following aria-attributes are based on the accessibility testing report from 26.4.2021
+    */
+    // Expect button aria-haspopup value to be true
+    expect(button.props()['aria-haspopup']).toEqual('true');
+    // Expect button aria-label value to be Valikko
+    expect(button.props()['aria-label']).toEqual('Valikko');
+    // Expect button aria-expanded value to be same as from props
+    expect(button.props()['aria-expanded']).toEqual(mockProps.drawerOpen);
+  });
+});

--- a/src/components/TopBar/MenuButton/__tests__/__snapshots__/MenuButton.test.js.snap
+++ b/src/components/TopBar/MenuButton/__tests__/__snapshots__/MenuButton.test.js.snap
@@ -1,0 +1,216 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<MenuButton /> should work 1`] = `
+<MenuButton
+  classes={Object {}}
+  drawerOpen={false}
+  pageType={null}
+  toggleDrawerMenu={[Function]}
+>
+  <WithStyles(ForwardRef(Button))
+    aria-expanded={false}
+    aria-haspopup="true"
+    aria-label="Valikko"
+    className="undefined undefined"
+    classes={
+      Object {
+        "label": undefined,
+      }
+    }
+    id="MenuButton"
+    onClick={[Function]}
+  >
+    <ForwardRef(Button)
+      aria-expanded={false}
+      aria-haspopup="true"
+      aria-label="Valikko"
+      className="undefined undefined"
+      classes={
+        Object {
+          "colorInherit": "MuiButton-colorInherit",
+          "contained": "MuiButton-contained",
+          "containedPrimary": "MuiButton-containedPrimary",
+          "containedSecondary": "MuiButton-containedSecondary",
+          "containedSizeLarge": "MuiButton-containedSizeLarge",
+          "containedSizeSmall": "MuiButton-containedSizeSmall",
+          "disableElevation": "MuiButton-disableElevation",
+          "disabled": "Mui-disabled",
+          "endIcon": "MuiButton-endIcon",
+          "focusVisible": "Mui-focusVisible",
+          "fullWidth": "MuiButton-fullWidth",
+          "iconSizeLarge": "MuiButton-iconSizeLarge",
+          "iconSizeMedium": "MuiButton-iconSizeMedium",
+          "iconSizeSmall": "MuiButton-iconSizeSmall",
+          "label": "MuiButton-label",
+          "outlined": "MuiButton-outlined",
+          "outlinedPrimary": "MuiButton-outlinedPrimary",
+          "outlinedSecondary": "MuiButton-outlinedSecondary",
+          "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
+          "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
+          "root": "MuiButton-root",
+          "sizeLarge": "MuiButton-sizeLarge",
+          "sizeSmall": "MuiButton-sizeSmall",
+          "startIcon": "MuiButton-startIcon",
+          "text": "MuiButton-text",
+          "textPrimary": "MuiButton-textPrimary",
+          "textSecondary": "MuiButton-textSecondary",
+          "textSizeLarge": "MuiButton-textSizeLarge",
+          "textSizeSmall": "MuiButton-textSizeSmall",
+        }
+      }
+      disableFocusRipple={true}
+      disableRipple={true}
+      id="MenuButton"
+      onClick={[Function]}
+    >
+      <WithStyles(ForwardRef(ButtonBase))
+        aria-expanded={false}
+        aria-haspopup="true"
+        aria-label="Valikko"
+        className="MuiButton-root MuiButton-text undefined undefined"
+        component="button"
+        disableRipple={true}
+        disabled={false}
+        focusRipple={false}
+        focusVisibleClassName="Mui-focusVisible"
+        id="MenuButton"
+        onClick={[Function]}
+        type="button"
+      >
+        <ForwardRef(ButtonBase)
+          aria-expanded={false}
+          aria-haspopup="true"
+          aria-label="Valikko"
+          className="MuiButton-root MuiButton-text undefined undefined"
+          classes={
+            Object {
+              "disabled": "Mui-disabled",
+              "focusVisible": "Mui-focusVisible",
+              "root": "MuiButtonBase-root",
+            }
+          }
+          component="button"
+          disableRipple={true}
+          disabled={false}
+          focusRipple={false}
+          focusVisibleClassName="Mui-focusVisible"
+          id="MenuButton"
+          onClick={[Function]}
+          type="button"
+        >
+          <button
+            aria-expanded={false}
+            aria-haspopup="true"
+            aria-label="Valikko"
+            className="MuiButtonBase-root MuiButton-root MuiButton-text undefined undefined"
+            disabled={false}
+            id="MenuButton"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={0}
+            type="button"
+          >
+            <span
+              className="MuiButton-label"
+            >
+              <ForwardRef>
+                <WithStyles(ForwardRef(SvgIcon))>
+                  <ForwardRef(SvgIcon)
+                    classes={
+                      Object {
+                        "colorAction": "MuiSvgIcon-colorAction",
+                        "colorDisabled": "MuiSvgIcon-colorDisabled",
+                        "colorError": "MuiSvgIcon-colorError",
+                        "colorPrimary": "MuiSvgIcon-colorPrimary",
+                        "colorSecondary": "MuiSvgIcon-colorSecondary",
+                        "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
+                        "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
+                        "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
+                        "root": "MuiSvgIcon-root",
+                      }
+                    }
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="MuiSvgIcon-root"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"
+                      />
+                    </svg>
+                  </ForwardRef(SvgIcon)>
+                </WithStyles(ForwardRef(SvgIcon))>
+              </ForwardRef>
+              <WithStyles(ForwardRef(Typography))
+                color="inherit"
+                variant="body2"
+              >
+                <ForwardRef(Typography)
+                  classes={
+                    Object {
+                      "alignCenter": "MuiTypography-alignCenter",
+                      "alignJustify": "MuiTypography-alignJustify",
+                      "alignLeft": "MuiTypography-alignLeft",
+                      "alignRight": "MuiTypography-alignRight",
+                      "body1": "MuiTypography-body1",
+                      "body2": "MuiTypography-body2",
+                      "button": "MuiTypography-button",
+                      "caption": "MuiTypography-caption",
+                      "colorError": "MuiTypography-colorError",
+                      "colorInherit": "MuiTypography-colorInherit",
+                      "colorPrimary": "MuiTypography-colorPrimary",
+                      "colorSecondary": "MuiTypography-colorSecondary",
+                      "colorTextPrimary": "MuiTypography-colorTextPrimary",
+                      "colorTextSecondary": "MuiTypography-colorTextSecondary",
+                      "displayBlock": "MuiTypography-displayBlock",
+                      "displayInline": "MuiTypography-displayInline",
+                      "gutterBottom": "MuiTypography-gutterBottom",
+                      "h1": "MuiTypography-h1",
+                      "h2": "MuiTypography-h2",
+                      "h3": "MuiTypography-h3",
+                      "h4": "MuiTypography-h4",
+                      "h5": "MuiTypography-h5",
+                      "h6": "MuiTypography-h6",
+                      "noWrap": "MuiTypography-noWrap",
+                      "overline": "MuiTypography-overline",
+                      "paragraph": "MuiTypography-paragraph",
+                      "root": "MuiTypography-root",
+                      "srOnly": "MuiTypography-srOnly",
+                      "subtitle1": "MuiTypography-subtitle1",
+                      "subtitle2": "MuiTypography-subtitle2",
+                    }
+                  }
+                  color="inherit"
+                  variant="body2"
+                >
+                  <p
+                    className="MuiTypography-root MuiTypography-body2 MuiTypography-colorInherit"
+                  >
+                    <FormattedMessage
+                      id="general.menu"
+                    >
+                      Valikko
+                    </FormattedMessage>
+                  </p>
+                </ForwardRef(Typography)>
+              </WithStyles(ForwardRef(Typography))>
+            </span>
+          </button>
+        </ForwardRef(ButtonBase)>
+      </WithStyles(ForwardRef(ButtonBase))>
+    </ForwardRef(Button)>
+  </WithStyles(ForwardRef(Button))>
+</MenuButton>
+`;

--- a/src/components/TopBar/MenuButton/index.js
+++ b/src/components/TopBar/MenuButton/index.js
@@ -1,0 +1,6 @@
+import { withStyles } from '@material-ui/core';
+import { injectIntl } from 'react-intl';
+import MenuButton from './MenuButton';
+import styles from '../styles';
+
+export default injectIntl(withStyles(styles)(MenuButton));

--- a/src/components/TopBar/MenuButton/index.js
+++ b/src/components/TopBar/MenuButton/index.js
@@ -1,6 +1,5 @@
 import { withStyles } from '@material-ui/core';
-import { injectIntl } from 'react-intl';
 import MenuButton from './MenuButton';
 import styles from '../styles';
 
-export default injectIntl(withStyles(styles)(MenuButton));
+export default withStyles(styles)(MenuButton);

--- a/src/components/TopBar/TopBar.js
+++ b/src/components/TopBar/TopBar.js
@@ -104,8 +104,9 @@ const TopBar = (props) => {
   const renderMenuButton = pageType => (
     <Button
       id="MenuButton"
-      aria-label={intl.formatMessage({ id: drawerOpen ? 'general.menu.close' : 'general.menu.open' })}
-      aria-pressed={drawerOpen}
+      aria-label={intl.formatMessage({ id: 'general.menu' })}
+      aria-expanded={drawerOpen}
+      aria-haspopup="true"
       className={`${drawerOpen ? classes.toolbarButtonPressed : classes.toolbarButton} ${pageType !== 'mobile' ? classes.largeButton : ''}`}
       classes={{ label: classes.buttonLabel }}
       onClick={() => toggleDrawerMenu()}

--- a/src/components/TopBar/TopBar.js
+++ b/src/components/TopBar/TopBar.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import {
   Button, Typography, AppBar, Toolbar, ButtonBase, NoSsr,
 } from '@material-ui/core';
-import { Map, Menu, Close } from '@material-ui/icons';
+import { Map } from '@material-ui/icons';
 import { FormattedMessage } from 'react-intl';
 import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom/cjs/react-router-dom.min';
@@ -16,6 +16,7 @@ import { focusToViewTitle } from '../../utils/accessibility';
 import LocaleUtility from '../../utils/locale';
 import { useNavigationParams } from '../../utils/address';
 import SettingsButton from './SettingsButton';
+import MenuButton from './MenuButton';
 
 const TopBar = (props) => {
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -28,7 +29,6 @@ const TopBar = (props) => {
     classes,
     toggleSettings,
     breadcrumb,
-    intl,
     changeTheme,
     theme,
     setMapType,
@@ -102,31 +102,11 @@ const TopBar = (props) => {
   };
 
   const renderMenuButton = pageType => (
-    <Button
-      id="MenuButton"
-      aria-label={intl.formatMessage({ id: 'general.menu' })}
-      aria-expanded={drawerOpen}
-      aria-haspopup="true"
-      className={`${drawerOpen ? classes.toolbarButtonPressed : classes.toolbarButton} ${pageType !== 'mobile' ? classes.largeButton : ''}`}
-      classes={{ label: classes.buttonLabel }}
-      onClick={() => toggleDrawerMenu()}
-    >
-      {drawerOpen ? (
-        <>
-          <Close />
-          <Typography color="inherit" variant="body2">
-            <FormattedMessage id="general.close" />
-          </Typography>
-        </>
-      ) : (
-        <>
-          <Menu />
-          <Typography color="inherit" variant="body2">
-            <FormattedMessage id="general.menu" />
-          </Typography>
-        </>
-      )}
-    </Button>
+    <MenuButton
+      pageType={pageType}
+      drawerOpen={drawerOpen}
+      toggleDrawerMenu={() => toggleDrawerMenu()}
+    />
   );
 
   const renderLanguages = (pageType) => {
@@ -313,7 +293,6 @@ TopBar.propTypes = {
   changeTheme: PropTypes.func.isRequired,
   classes: PropTypes.objectOf(PropTypes.any).isRequired,
   currentPage: PropTypes.string.isRequired,
-  intl: PropTypes.objectOf(PropTypes.any).isRequired,
   navigator: PropTypes.objectOf(PropTypes.any),
   setMapType: PropTypes.func.isRequired,
   settingsOpen: PropTypes.string,

--- a/src/components/TopBar/TopBar.js
+++ b/src/components/TopBar/TopBar.js
@@ -101,12 +101,12 @@ const TopBar = (props) => {
     }, 1);
   };
 
-  const renderMenuButton = () => (
+  const renderMenuButton = pageType => (
     <Button
       id="MenuButton"
       aria-label={intl.formatMessage({ id: drawerOpen ? 'general.menu.close' : 'general.menu.open' })}
       aria-pressed={drawerOpen}
-      className={drawerOpen ? classes.toolbarButtonPressed : classes.toolbarButton}
+      className={`${drawerOpen ? classes.toolbarButtonPressed : classes.toolbarButton} ${pageType !== 'mobile' ? classes.largeButton : ''}`}
       classes={{ label: classes.buttonLabel }}
       onClick={() => toggleDrawerMenu()}
     >
@@ -257,7 +257,7 @@ const TopBar = (props) => {
             <MobileComponent>
               <div className={classes.mobileButtonContainer}>
                 {renderMapButton()}
-                {renderMenuButton()}
+                {renderMenuButton(pageType)}
               </div>
               {renderDrawerMenu(pageType)}
             </MobileComponent>
@@ -316,7 +316,6 @@ TopBar.propTypes = {
   navigator: PropTypes.objectOf(PropTypes.any),
   setMapType: PropTypes.func.isRequired,
   settingsOpen: PropTypes.string,
-  settings: PropTypes.objectOf(PropTypes.any).isRequired,
   smallScreen: PropTypes.bool.isRequired,
   theme: PropTypes.string.isRequired,
   toggleSettings: PropTypes.func.isRequired,

--- a/src/components/TopBar/index.js
+++ b/src/components/TopBar/index.js
@@ -1,6 +1,5 @@
 import { connect } from 'react-redux';
 import { withStyles } from '@material-ui/core';
-import { injectIntl } from 'react-intl';
 import styles from './styles';
 import TopBar from './TopBar';
 import { setMapType, toggleSettings } from '../../redux/actions/settings';
@@ -20,7 +19,7 @@ const mapStateToProps = (state) => {
   };
 };
 
-export default injectIntl(withStyles(styles)(connect(
+export default withStyles(styles)(connect(
   mapStateToProps,
   { changeTheme, setMapType, toggleSettings },
-)(TopBar)));
+)(TopBar));

--- a/src/components/TopBar/styles.js
+++ b/src/components/TopBar/styles.js
@@ -72,7 +72,7 @@ const styles = theme => ({
       textAlign: 'left',
     },
     maxWidth: 350,
-    maxHeight: 58 ,
+    maxHeight: 58,
     flex: '0 1 auto',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
@@ -120,6 +120,9 @@ const styles = theme => ({
     color: '#000',
     marginLeft: 4,
     borderRadius: 0,
+  },
+  largeButton: {
+    height: 66,
   },
   iconTextContainer: {
     display: 'flex',

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -180,8 +180,6 @@ const translations = {
   'general.frontPage': 'Front page',
   'general.contrast': 'Contrast',
   'general.menu': 'Menu',
-  'general.menu.open': 'Open menu',
-  'general.menu.close': 'Close menu',
   'general.back': 'Back',
   'general.back.area': 'Back to area page',
   'general.back.address': 'Back to address page',

--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -180,8 +180,6 @@ const translations = {
   'general.frontPage': 'Etusivu',
   'general.contrast': 'Kontrasti',
   'general.menu': 'Valikko',
-  'general.menu.open': 'Avaa valikko',
-  'general.menu.close': 'Sulje valikko',
   'general.back': 'Palaa',
   'general.back.address': 'Palaa osoitesivulle',
   'general.back.area': 'Palaa aluesivulle',

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -180,8 +180,6 @@ const translations = {
   'general.frontPage': 'Framsidan',
   'general.contrast': 'Kontrast',
   'general.menu': 'Meny',
-  'general.menu.open': 'Öppna menyn',
-  'general.menu.close': 'Stäng menyn',
   'general.back': 'Tillbaka',
   'general.back.address': 'Gå tillbaka till adressidan',
   'general.back.area': 'Gå tillbaka till områdessidan',


### PR DESCRIPTION
From the accessibility report:
- Made drawer menu scrollable (2.3) 
- Fixed menu button roles and descriptions (3.3)
Also made close menu button larger on devices that use larger desktop topbar (Tablet devices)