### PR TITLE
Add focus indicator to map

### DIFF
--- a/src/views/MapView/styles.js
+++ b/src/views/MapView/styles.js
@@ -13,6 +13,12 @@ const styles = theme => ({
         color: '#347865 !important',
       },
     },
+    '&:focus': {
+      margin: '4px 4px 4px 0px',
+      height: 'calc(100% - 8px)',
+      outline: '2px solid transparent',
+      boxShadow: `0 0 0 4px ${theme.palette.focusBorder.main}`,
+    }
   },
   addressLink: {
     color: theme.palette.primary.main,


### PR DESCRIPTION
Accessibility report 3.7: Focus indicator moves to "invisible" element. Focus moved to map without focus indicator. Added focus indicator for map to show user where they currently are.