### PR TITLE
Add dynamic aria-label for contrast change button

### DIFF
--- a/src/components/TopBar/TopBar.js
+++ b/src/components/TopBar/TopBar.js
@@ -208,6 +208,7 @@ const TopBar = (props) => {
     } ${
       pageType === 'mobile' ? classes.toolbarBlackMobile : ''
     }`;
+    const contrastAriaLabel = intl.formatMessage({ id: `general.contrast.ariaLabel.${theme === 'dark' ? 'off' : 'on'}` })
     return (
       <>
         <AppBar className={classes.appBar}>
@@ -222,7 +223,7 @@ const TopBar = (props) => {
               <Typography aria-hidden color="inherit">|</Typography>
               {renderLanguages(pageType)}
               <Typography aria-hidden color="inherit">|</Typography>
-              <ButtonBase role="button" onClick={() => handleContrastChange()} focusVisibleClassName={classes.topButtonFocused}>
+              <ButtonBase role="button" onClick={() => handleContrastChange()} focusVisibleClassName={classes.topButtonFocused} aria-label={contrastAriaLabel}>
                 <Typography className={fontClass} color="inherit" variant="body2"><FormattedMessage id="general.contrast" /></Typography>
               </ButtonBase>
             </div>

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -180,6 +180,8 @@ const translations = {
   // General
   'general.frontPage': 'Front page',
   'general.contrast': 'Contrast',
+  'general.contrast.ariaLabel.on': 'Turn on the high contrast mode',
+  'general.contrast.ariaLabel.off': 'Go back to the standard contrast mode',
   'general.menu': 'Menu',
   'general.back': 'Back',
   'general.back.area': 'Back to area page',

--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -180,6 +180,8 @@ const translations = {
   // General
   'general.frontPage': 'Etusivu',
   'general.contrast': 'Kontrasti',
+  'general.contrast.ariaLabel.on': 'Siirry suurikontrastiseen tilaan',
+  'general.contrast.ariaLabel.off': 'Palaa normaalikontrastiseen tilaan',
   'general.menu': 'Valikko',
   'general.back': 'Palaa',
   'general.back.address': 'Palaa osoitesivulle',

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -180,6 +180,8 @@ const translations = {
   // General
   'general.frontPage': 'Framsidan',
   'general.contrast': 'Kontrast',
+  'general.contrast.ariaLabel.on': 'Aktivera högkontrastläge',
+  'general.contrast.ariaLabel.off': 'Gå tillbaka till standardkontrastläge',
   'general.menu': 'Meny',
   'general.back': 'Tillbaka',
   'general.back.address': 'Gå tillbaka till adressidan',


### PR DESCRIPTION
Accessibility report 4.1. Add more descriptive aria-label for contrast button because for users who can't see the change button seem to do nothing