### PR TITLE
New HTTPClient and ServiceMapAPI classes for imporved fetch handling

### DIFF
--- a/src/components/Dialog/DownloadDialog/utils.js
+++ b/src/components/Dialog/DownloadDialog/utils.js
@@ -1,4 +1,3 @@
-import config from '../../../../config';
 import ServiceMapAPI from '../../../utils/newFetch/ServiceMapAPI';
 
 const smAPI = new ServiceMapAPI();
@@ -8,10 +7,8 @@ export const fetchServiceNames = async (ids) => {
     return null;
   }
 
-  return await smAPI.serviceNames(ids)
-    .then((data) => {
-      return data?.map(v => v.name);
-    })
-}
+  return smAPI.serviceNames(ids)
+    .then(data => data?.map(v => v.name));
+};
 
 export default fetchServiceNames;

--- a/src/components/Dialog/DownloadDialog/utils.js
+++ b/src/components/Dialog/DownloadDialog/utils.js
@@ -1,19 +1,17 @@
 import config from '../../../../config';
+import ServiceMapAPI from '../../../utils/newFetch/ServiceMapAPI';
 
-// Fetch service names using givcen service_node id's
-export const fetchServiceNames = (ids) => {
+const smAPI = new ServiceMapAPI();
+
+export const fetchServiceNames = async (ids) => {
   if (!ids) {
     return null;
   }
 
-  return fetch(`${config.serviceMapAPI.root}/service_node/?id=${ids}&page=1&page_size=1000`)
-    .then(response => response.json())
+  return await smAPI.serviceNames(ids)
     .then((data) => {
-      const nameArray = data?.results?.map(v => v.name);
-      return nameArray;
-    }).catch((e) => {
-      console.error('Error while fetching service names', e);
-    });
-};
+      return data?.map(v => v.name);
+    })
+}
 
 export default fetchServiceNames;

--- a/src/utils/newFetch/HTTPClient.js
+++ b/src/utils/newFetch/HTTPClient.js
@@ -1,0 +1,138 @@
+import AbortController from 'abort-controller';
+import config from '../../../config';
+
+export class APIFetchError extends Error {
+  constructor(props) {
+    super(props);
+    // Maintains proper stack trace for where our error was thrown (only available on V8)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, APIFetchError)
+    }
+
+    this.name = 'APIFetchError'
+    // Custom debugging information
+    this.date = new Date()
+  }
+}
+
+export default class HttpClient {
+  timeoutTimer = config?.searchTimeout || 10000;
+  status = '';
+  abortController;
+  timeout;
+
+  constructor(baseURL) {
+    this.baseURL = baseURL;
+  }
+  
+  optionsToSearchParams = (options) => {
+    if (typeof options !== 'object') {
+      throw APIFetchError('Invalid options provided for HttpClient optionsToSearchParams method');
+    }
+
+    const params = new URLSearchParams();
+    Object.keys(options).forEach(key => {
+      if (Object.prototype.hasOwnProperty.call(options, key)) {
+        const value = options[key];
+        params.set(key, value);
+      }
+    });
+
+    return params.toString();
+  }
+
+  fetchNext = async (query, results) => {
+    const signal = this.abortController?.signal || null;
+    console.log('Fetching next:', query)
+    return await fetch(query, { signal })
+      .then(response => response.json())
+      .then(async data => {
+        if (data.next) {
+          return await this.fetchNext(data.next, [...results, data.results]);
+        }
+        return [...results, ...data.results];
+      });
+  }
+
+  handleResults = async (data) => {
+    console.log('Status in handleResults', this.status);
+    if (data.next) {
+      return await this.fetchNext(data.next, [...data.results]);
+    }
+    return data.results;
+  }
+
+  fetch = async (endpoint, options) => {
+    this.abortController = new AbortController();
+    this.status = 'fetching';
+
+    const signal = this.abortController?.signal || null;
+    let promise;
+
+    console.log('Fetching...', `${this.baseURL}/${endpoint}`);
+
+    // Since we do not send any POST data to server we expect all fetches to be GET
+    // and utilize search parameters for sending required data
+    if (typeof options !== 'string') {
+      this.throwAPIError(`Invalid options given to HTTPClient fetch method`);
+    }
+    // Create fetch promise
+    promise = fetch(`${this.baseURL}/${endpoint}?${options}`, { signal });
+
+    // Create timeout for aborting fetch
+    this.createTimeout();
+
+    // Preform fetch
+    return await promise
+      .then(response => response.json())
+      .then(async (data) => {
+        const results = await this.handleResults(data)
+        this.clearTimeout();
+        this.status = 'done';
+        console.log('Status before returning results', this.status);
+        return results;
+      })
+      .catch(e => {
+        if (e.name === 'AbortError') {
+          this.throwAPIError(`Error - ${endpoint} fetch aborted: Timeout after ${this.timeoutTimer / 1000} seconds`, e)
+        } else {
+          this.throwAPIError(`Error while fetching ${endpoint}:`, e)
+        }
+      });
+  }
+
+  get = async (endpoint, options) => {
+    console.log('Fetch is using GET');
+    return await this.fetch(endpoint, this.optionsToSearchParams(options))
+  }
+
+  throwAPIError = (msg, e) => {
+    this.status = 'error';
+    this.clearTimeout();
+    throw new APIFetchError(msg, e);
+  };
+
+  getStatus = () => {
+    return this.status;
+  }
+  
+  abort = () => {
+    if (!this.abortController?.abort) {
+      throw new APIFetchError(`Invalid AbortController when attempting to abort fetch`);
+    }
+    this.clearTimeout();
+    this.abortController.abort();
+  }
+
+  createTimeout = () => {
+    this.timeout = setTimeout(() => {
+      this.abort();
+    }, this.timeoutTimer);
+  }
+
+  clearTimeout = () => {
+    if (this.timeout) {
+      clearTimeout(this.timeout);
+    }
+  }
+}

--- a/src/utils/newFetch/HTTPClient.js
+++ b/src/utils/newFetch/HTTPClient.js
@@ -44,6 +44,10 @@ export default class HttpClient {
   fetchNext = async (query, results) => {
     const signal = this.abortController?.signal || null;
     console.log('Fetching next:', query)
+    // Clear old timeout
+    this.clearTimeout();
+    // Create new timeout for next fetch
+    this.createTimeout();
     console.log('Current results ', results)
 
     return await fetch(query, { signal })

--- a/src/utils/newFetch/HTTPClient.js
+++ b/src/utils/newFetch/HTTPClient.js
@@ -43,12 +43,10 @@ export default class HttpClient {
 
   fetchNext = async (query, results) => {
     const signal = this.abortController?.signal || null;
-    console.log('Fetching next:', query)
     // Clear old timeout
     this.clearTimeout();
     // Create new timeout for next fetch
     this.createTimeout();
-    console.log('Current results ', results)
 
     return await fetch(query, { signal })
       .then(response => response.json())
@@ -65,7 +63,6 @@ export default class HttpClient {
   }
 
   handleResults = async (response) => {
-    console.log('Status in handleResults', this.status);
     if (response.next) {
       if (this.onNext) {
         this.onNext(response.results.length, response.count)
@@ -82,12 +79,10 @@ export default class HttpClient {
     const signal = this.abortController?.signal || null;
     let promise;
 
-    console.log('Fetching...', `${this.baseURL}/${endpoint}`);
-
     // Since we do not send any POST data to server we expect all fetches to be GET
     // and utilize search parameters for sending required data
     if (typeof options !== 'string') {
-      this.throwAPIError(`Invalid options given to HTTPClient fetch method`);
+      this.throwAPIError(`Invalid options given to HTTPClient's fetch method`);
     }
     // Create fetch promise
     promise = fetch(`${this.baseURL}/${endpoint}?${options}`, { signal });
@@ -102,7 +97,6 @@ export default class HttpClient {
         const results = await this.handleResults(data)
         this.clearTimeout();
         this.status = 'done';
-        console.log('Status before returning results', this.status);
         return results;
       })
       .catch(e => {
@@ -115,16 +109,15 @@ export default class HttpClient {
   }
 
   get = async (endpoint, options) => {
-    console.log('Fetch is using GET');
     return await this.fetch(endpoint, this.optionsToSearchParams(options))
   }
 
   throwAPIError = (msg, e) => {
+    this.status = 'error';
+    this.clearTimeout();
     if (this.onError) {
       this.onError(e)
     }
-    this.status = 'error';
-    this.clearTimeout();
     throw new APIFetchError(msg, e);
   };
 
@@ -164,6 +157,9 @@ export default class HttpClient {
       throw new APIFetchError(`Invalid onError provided for HTTPClient`);
     }
     this.onError = onError;
+  }
 
+  isFetching = () => {
+    return this.status === 'fetching';
   }
 }

--- a/src/utils/newFetch/ServiceMapAPI.js
+++ b/src/utils/newFetch/ServiceMapAPI.js
@@ -3,7 +3,6 @@ import HttpClient, { APIFetchError } from './HTTPClient';
 
 export default class ServiceMapAPI extends HttpClient {
   constructor() {
-    console.log('ServiceMapAPI baseURL', config.serviceMapAPI.root)
     if (
       typeof config?.serviceMapAPI?.root === 'string'
       && config.serviceMapAPI.root.indexOf('undefined') !== -1
@@ -14,8 +13,9 @@ export default class ServiceMapAPI extends HttpClient {
   }
 
   search = async (query) => {
-    console.log('Search endpoint')
-
+    if (typeof query !== 'string') {
+      throw new APIFetchError('Invalid query string provided to ServiceMapAPI search method');
+    }
     const options = {
       page: 1,
       page_size: 200,
@@ -29,7 +29,6 @@ export default class ServiceMapAPI extends HttpClient {
   }
 
   serviceNames = async (idList) => {
-    console.log('Service node endpoint')
     if (typeof idList !== 'string') {
       throw new APIFetchError('Invalid idList string provided to ServiceMapAPI serviceNames method');
     }

--- a/src/utils/newFetch/ServiceMapAPI.js
+++ b/src/utils/newFetch/ServiceMapAPI.js
@@ -22,10 +22,10 @@ export default class ServiceMapAPI extends HttpClient {
       only: 'unit.street_address,unit.location,unit.name,unit.municipality,unit.accessibility_shortcoming_count,unit.contract_type',
       geometry: true,
       include: 'unit.department',
-      q: query
+      q: query,
     };
 
-    return await this.get('search', options);
+    return this.get('search', options);
   }
 
   serviceNames = async (idList) => {
@@ -36,7 +36,7 @@ export default class ServiceMapAPI extends HttpClient {
       id: idList,
       page: '1',
       page_size: '1000',
-    }
+    };
     return this.get('service_node', options);
   }
 }

--- a/src/utils/newFetch/ServiceMapAPI.js
+++ b/src/utils/newFetch/ServiceMapAPI.js
@@ -1,0 +1,43 @@
+import config from '../../../config';
+import HttpClient, { APIFetchError } from './HTTPClient';
+
+export default class ServiceMapAPI extends HttpClient {
+  constructor() {
+    console.log('ServiceMapAPI baseURL', config.serviceMapAPI.root)
+    if (
+      typeof config?.serviceMapAPI?.root === 'string'
+      && config.serviceMapAPI.root.indexOf('undefined') !== -1
+    ) {
+      throw new APIFetchError('ServicemapAPI baseURL missing');
+    }
+    super(config.serviceMapAPI.root);
+  }
+
+  search = async (query) => {
+    console.log('Search endpoint')
+
+    const options = {
+      page: 1,
+      page_size: 200,
+      only: 'unit.street_address,unit.location,unit.name,unit.municipality,unit.accessibility_shortcoming_count,unit.contract_type',
+      geometry: true,
+      include: 'unit.department',
+      q: query
+    };
+
+    return await this.get('search', options);
+  }
+
+  serviceNames = async (idList) => {
+    console.log('Service node endpoint')
+    if (typeof idList !== 'string') {
+      throw new APIFetchError('Invalid idList string provided to ServiceMapAPI serviceNames method');
+    }
+    const options = {
+      id: idList,
+      page: '1',
+      page_size: '1000',
+    }
+    return this.get('service_node', options);
+  }
+}


### PR DESCRIPTION
New HttpClient and ServiceMapAPI classes for better API fetching.

HttpClient has in-built abort handling and next fetching logic.
ServiceMapAPI extends HttpClient and contains all required fetch data in individual methods that better describe what is being fetched from Servicemap API.

This way we can get rid of the constants file and messy fetch logic used in previous solution.