### PR TITLE
Fix/duplicate area data

### DIFF
--- a/src/redux/actions/district.js
+++ b/src/redux/actions/district.js
@@ -21,9 +21,10 @@ const setDistrictData = data => ({
   data,
 });
 
-const updateDistrictData = (type, data) => ({
+const updateDistrictData = (type, data, period) => ({
   type: 'UPDATE_DISTRICT_DATA',
   districtType: type,
+  period,
   data,
 });
 
@@ -89,7 +90,7 @@ const endDistrictFetch = districtType => ({
 });
 
 
-export const fetchDistrictGeometry = type => (
+export const fetchDistrictGeometry = (type, period) => (
   async (dispatch) => {
     const options = {
       page: 1,
@@ -103,8 +104,17 @@ export const fetchDistrictGeometry = type => (
     };
     const onNext = () => {};
     const onSuccess = (results) => {
-      const filteredData = parseDistrictGeometry(results);
-      dispatch(updateDistrictData(type, filteredData));
+      let filteredData = parseDistrictGeometry(results);
+      if (period) {
+        // Filter with start and end year
+        const start = period.slice(0, 4);
+        const end = period.slice(-4);
+        const yearFilteredData = filteredData.filter(item => (
+          item.start.slice(0, 4) === start && item.end.slice(0, 4) === end
+        ));
+        filteredData = yearFilteredData;
+      }
+      dispatch(updateDistrictData(type, filteredData, period));
       dispatch(endDistrictFetch(type));
     };
     districtFetch(options, onStart, onSuccess, null, onNext);

--- a/src/redux/reducers/district.js
+++ b/src/redux/reducers/district.js
@@ -49,9 +49,10 @@ export default (state = initialState, action) => {
     case 'UPDATE_DISTRICT_DATA':
       return {
         ...state,
-        districtData: state.districtData.map(obj => (obj.name === action.districtType
-          ? { ...obj, data: action.data }
-          : obj)),
+        districtData: state.districtData.map(obj => (
+          obj.name === action.districtType && obj.period === action.period
+            ? { ...obj, data: action.data }
+            : obj)),
       };
 
     case 'SET_DISTRICT_ADDRESS_DATA':

--- a/src/views/AreaView/components/ServiceTab/ServiceTab.js
+++ b/src/views/AreaView/components/ServiceTab/ServiceTab.js
@@ -4,7 +4,6 @@ import {
   List,
   ListItem,
   Typography,
-  RadioGroup,
   Divider,
 } from '@material-ui/core';
 import { FormattedMessage } from 'react-intl';
@@ -34,7 +33,7 @@ const ServiceTab = (props) => {
       dispatch(setSelectedDistrictType(null));
     } else {
       if (!district.data.some(obj => obj.boundary)) {
-        dispatch(fetchDistrictGeometry(district.name));
+        dispatch(fetchDistrictGeometry(district.name, district.period));
       }
       dispatch(setSelectedDistrictType(district.id));
     }

--- a/src/views/AreaView/utils/districtDataHelper.js
+++ b/src/views/AreaView/utils/districtDataHelper.js
@@ -86,7 +86,7 @@ export const groupDistrictData = (data) => {
   const groupedData = data.reduce((acc, cur) => {
   // Group data by district type and period
     const { start, end } = cur;
-    if (start?.includes(2019)) {
+    if (start?.includes(2020)) {
     // FIXME: temporary solution to hide older school years
       return acc;
     }


### PR DESCRIPTION
Problem was that fetching school area types of certain school year updated all years with the new data. For example school year 2021-2022 also got year 2020-2021 data, causing duplicate data.

Also removed old school year data