### PR TITLE
Fix area view embedder crash

### DIFF
--- a/src/views/AreaView/AreaView.js
+++ b/src/views/AreaView/AreaView.js
@@ -81,7 +81,9 @@ const AreaView = ({
   );
 
   const focusMapToDistrict = (district) => {
-    focusDistrict(map.leafletElement, district.boundary.coordinates);
+    if (map?.leafletElement && district?.boundary) {
+      focusDistrict(map.leafletElement, district.boundary.coordinates);
+    }
   };
 
   const fetchAddressDistricts = async () => {


### PR DESCRIPTION
Area view: choosing an address and an area then opening embedder tool and closing it caused a crash.