### PR TITLE
Prevent vertical overflow being hidden when not in mobile

### DIFF
--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -347,7 +347,7 @@ class SearchBar extends React.Component {
     }  ${
       className
     }`;
-    const wrapperClasses = `${isActive ? classes.mobileWrapper : classes.wrapper}`;
+    const wrapperClasses = `${isActive ? classes.mobileWrapperActive : classes.mobileWrapper}`;
     const stickyStyles = typeof isSticky === 'number' ? { top: isSticky } : null;
 
     return (

--- a/src/components/SearchBar/components/SuggestionBox/SuggestionBox.js
+++ b/src/components/SearchBar/components/SuggestionBox/SuggestionBox.js
@@ -246,7 +246,9 @@ const SuggestionBox = (props) => {
     const sidebar = document.getElementsByClassName('SidebarWrapper')[0];
     const app = document.getElementsByClassName('App')[0];
     if (visible) {
-      sidebar.style.overflow = 'hidden';
+      if (isMobile) {
+        sidebar.style.overflow = 'hidden';
+      }
       if (app) {
         app.style.height = '100%';
       }

--- a/src/components/SearchBar/components/SuggestionBox/styles.js
+++ b/src/components/SearchBar/components/SuggestionBox/styles.js
@@ -1,4 +1,3 @@
-import config from '../../../../../config';
 
 export default theme => ({
   minimizeLink: {
@@ -15,16 +14,15 @@ export default theme => ({
     },
   },
   suggestionArea: {
+    width: '100%',
     position: 'absolute',
-    right: theme.spacing(3),
-    left: theme.spacing(3),
     zIndex: theme.zIndex.infront,
     backgroundColor: '#fff',
     overflow: 'auto',
     borderRadius: 0,
     borderBottomLeftRadius: theme.spacing(0.5),
     borderBottomRightRadius: theme.spacing(0.5),
-    maxHeight: `calc(80vh - ${config.topBarHeight}px)`,
+    overflowX: 'hidden',
   },
   suggestionAreaMobile: {
     right: 0,
@@ -40,6 +38,7 @@ export default theme => ({
     display: 'flex',
     flexDirection: 'column',
     boxShadow: 'none',
+    overflowX: 'hidden',
   },
   infoText: {
     padding: theme.spacing(1),

--- a/src/components/SearchBar/styles.js
+++ b/src/components/SearchBar/styles.js
@@ -24,10 +24,15 @@ export default theme => ({
     overflow: 'auto',
   },
   wrapper: {
+    position: 'relative',
     flex: '0 1 auto',
     borderRadius: 4,
   },
   mobileWrapper: {
+    flex: '0 1 auto',
+    borderRadius: 4,
+  },
+  mobileWrapperActive: {
     flex: '0 1 auto',
     display: 'flex',
     flexDirection: 'column',


### PR DESCRIPTION
There was an issue with suggestion box overflowing out of sidebar wrapper when wrapper has `overflow hidden`. This was caused by suggestion box setting overflow hidden. For solution I changed overflow hidden only to appear in mobile widths.

Suggestion box also had horizontal overflow scroll being shown. This is caused by list item dividers having margins that take it out of parent bounds. I've added `overflow-x: hidden` for suggestion container.

Removed `max-height` from suggestion area because it doesn't seem to do anything because it is not responsive to different heights.

Changed searchbar wrapper to relative position so suggestion area can be set width 100% based on wrapper. This saves us from having to worry about having correct `left` and `right` attributes for suggestion area because width will be always in relation to wrapper.