### PR TITLE
Create sitemap only when SERVER_TYPE is production

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -10,7 +10,7 @@ import thunk from 'redux-thunk';
 import config from '../config';
 import rootReducer from '../src/redux/rootReducer';
 import App from '../src/App';
-import { makeLanguageHandler, languageSubdomainRedirect, unitRedirect, parseInitialMapPositionFromHostname, getRequestFullUrl } from './utils';
+import { makeLanguageHandler, languageSubdomainRedirect, unitRedirect, parseInitialMapPositionFromHostname, getRequestFullUrl, sitemapActive } from './utils';
 import { setLocale } from '../src/redux/actions/user';
 import { Helmet } from 'react-helmet';
 import { ServerStyleSheets } from '@material-ui/core/styles';
@@ -51,7 +51,7 @@ const setupTests = () => {
 setupTests();
 
 // Handle sitemap creation
-if (config.production && process.env.DOMAIN) {
+  if (sitemapActive()) {
   // Generate sitemap on start
   generateSitemap();
   // Update sitemap every monday

--- a/server/sitemapMiddlewares.js
+++ b/server/sitemapMiddlewares.js
@@ -2,6 +2,7 @@ import config from '../config';
 import { SitemapStream, streamToPromise } from 'sitemap'
 import { createGzip } from 'zlib'
 import { fetchIDs } from './dataFetcher';
+import { sitemapActive } from './utils';
 
 const fs = require('fs');
 const supportedLanguages = config.supportedLanguages;
@@ -24,11 +25,11 @@ export const getRobotsFile = (req, res, next) => {
   // Returns robots.txt file that points to sitemap location
   if (process.env.DOMAIN) {
     res.type('text/plain');
-    if (process.env.SERVER_TYPE === 'staging') {
+    if (sitemapActive()) {
+      res.send(`User-agent: *\nAllow: /\n\nSitemap: ${process.env.DOMAIN}/sitemap.xml`);
+    } else {
       // Disable crawling if on staging server
       res.send(`User-agent: *\nDisallow: /`);
-    } else {
-      res.send(`User-agent: *\nAllow: /\n\nSitemap: ${process.env.DOMAIN}/sitemap.xml`);
     }
   } else {
     next();

--- a/server/utils.js
+++ b/server/utils.js
@@ -1,3 +1,5 @@
+import config from '../config';
+
 const redirectables = [
   {
     check: /^\/(fi|sv|en)(|\/embed)\/unit\?(.+)=/,
@@ -130,3 +132,10 @@ export const parseInitialMapPositionFromHostname = (req, Sentry) => {
 }
 
 export const getRequestFullUrl = (req) => req.protocol + '://' + req.get('host') + req.originalUrl;
+
+export const sitemapActive = () => {
+  return config.production
+    && process.env.DOMAIN
+    && process.env.NODE_ENV === 'production'
+    && process.env.SERVER_TYPE === 'production';
+};


### PR DESCRIPTION
Rather than only disabling sitemap when SERVER_TYPE is staging change sitemap to be disabled by default. Changed to sitemap creation to check if SERVER_TYPE is production and NODE_ENV is production. This makes sure sitemap is not created in development mode or in staging server.

This requires changing environment variables in production server. Need to add SERVER_TYPE=production into envrionment variables