### PR TITLE
Fix map test geometry check using data that doesn't exist anymore

### DIFF
--- a/browserTests/mapTest.js
+++ b/browserTests/mapTest.js
@@ -20,7 +20,7 @@ test('Unit geometry is drawn on map', async (t) => {
 });
 
 fixture`Unit page geometry test`
-  .page`http://${server.address}:${server.port}/fi/unit/54039`
+  .page`http://${server.address}:${server.port}/fi/unit/56544`
   .beforeEach(async () => {
     await waitForReact();
   });


### PR DESCRIPTION
Update mapTest geometry check to use existing data