### PR TITLE
Focus map to selected area

### DIFF
--- a/src/views/AreaView/AreaView.js
+++ b/src/views/AreaView/AreaView.js
@@ -52,6 +52,7 @@ const AreaView = ({
   const districtsFetching = useSelector(state => state.districts.districtsFetching);
   const getLocaleText = useLocaleText();
   const openItems = useSelector(state => state.districts.openItems);
+  const selectedDistrictGeometry = selectedDistrictData[0]?.boundary;
 
   const searchParams = parseSearchParams(location.search);
   const selectedArea = searchParams.selected;
@@ -162,12 +163,12 @@ const AreaView = ({
     // If pending district focus, focus to districts when distitct data is loaded
     if (focusTo && selectedDistrictData.length) {
       if (focusTo === 'districts') {
-        if (selectedDistrictData[0]?.boundary) {
+        if (selectedDistrictGeometry) {
           setFocusTo(null);
           focusDistricts(map.leafletElement, selectedDistrictData);
         }
       } else if (focusTo === 'subdistricts') {
-        if (selectedDistrictData[0]?.boundary) {
+        if (selectedDistrictGeometry) {
           const filtetedDistricts = selectedDistrictData.filter(
             i => selectedSubdistricts.includes(i.ocd_id),
           );
@@ -177,6 +178,12 @@ const AreaView = ({
       }
     }
   }, [selectedDistrictData, focusTo]);
+
+  useEffect(() => {
+    if (map && !focusTo && !localAddressData.length && selectedDistrictGeometry) {
+      focusDistricts(map.leafletElement, selectedDistrictData);
+    }
+  }, [selectedDistrictGeometry]);
 
 
   useEffect(() => {
@@ -208,8 +215,6 @@ const AreaView = ({
       if (searchParams.districts) {
         setSelectedSubdistricts(searchParams.districts.split(','));
         setFocusTo('subdistricts');
-      } else {
-        setFocusTo('districts');
       }
 
       // Set selected geographical services from url parameters

--- a/src/views/AreaView/components/GeographicalDistrictList/GeographicalDistrictList.js
+++ b/src/views/AreaView/components/GeographicalDistrictList/GeographicalDistrictList.js
@@ -29,7 +29,11 @@ const GeographicalDistrictList = ({ district, classes }) => {
         district => newArray.includes(district.ocd_id),
       );
       const coordinateArray = districtsToFocus.map(district => district.boundary.coordinates);
-      panViewToBounds(map, district.boundary, coordinateArray);
+      if (districtsToFocus.length === 1) {
+        map.leafletElement.fitBounds(coordinateArray[0]);
+      } else {
+        panViewToBounds(map, district.boundary, coordinateArray);
+      }
     } else {
       newArray = selectedSubdistricts.filter(i => i !== district.ocd_id);
     }


### PR DESCRIPTION
Selecting an area type in area view now zooms out or in to fit the areas to the map. Selecting the first geographical subdistrict (single neighborhood for example) will also zoom the map instead of just panning.