### PR TITLE
Fix/area view unit fetch limit

### DIFF
--- a/src/redux/actions/district.js
+++ b/src/redux/actions/district.js
@@ -1,4 +1,5 @@
-import { districtFetch, unitsFetch } from '../../utils/fetch';
+import { districtFetch } from '../../utils/fetch';
+import ServiceMapAPI from '../../utils/newFetch/ServiceMapAPI';
 import {
   dataStructure,
   geographicalDistricts,
@@ -145,14 +146,10 @@ export const fetchAllDistricts = selected => (
 export const fetchDistrictUnitList = nodeID => (
   async (dispatch) => {
     dispatch(startUnitFetch(nodeID));
-    const options = {
-      page: 1,
-      page_size: 1000,
-      division: nodeID,
-    };
     try {
-      const data = await unitsFetch(options);
-      const units = data.results;
+      // TODO: Add progress bar update to here with onNext
+      const smAPI = new ServiceMapAPI();
+      const units = await smAPI.areaUnits(nodeID);
       units.forEach((unit) => {
         unit.object_type = 'unit';
         unit.division_id = nodeID;

--- a/src/utils/newFetch/ServiceMapAPI.js
+++ b/src/utils/newFetch/ServiceMapAPI.js
@@ -39,4 +39,20 @@ export default class ServiceMapAPI extends HttpClient {
     };
     return this.get('service_node', options);
   }
+
+  areaUnits = async (nodeID) => {
+    if (typeof nodeID !== 'string') {
+      throw new APIFetchError('Invalid query string provided to ServiceMapAPI area unit fetch method');
+    }
+
+    const options = {
+      page: 1,
+      page_size: 200,
+      division: nodeID,
+      only: 'street_address,location,name,municipality,accessibility_shortcoming_count,service_nodes,contract_type',
+      include: 'services',
+    };
+
+    return this.get('unit', options);
+  }
 }

--- a/src/views/AreaView/components/GeographicalTab/GeographicalTab.js
+++ b/src/views/AreaView/components/GeographicalTab/GeographicalTab.js
@@ -84,7 +84,7 @@ const GeographicalTab = ({
   };
 
   useEffect(() => {
-    if (!selectedDistrictType || geographicalDistricts.includes(selectedDistrictType)) {
+    if (!selectedDistrictType || !geographicalDistricts.includes(selectedDistrictType)) {
       dispatch(setSelectedSubdistricts([]));
       dispatch(setSelectedDistrictServices([]));
       setOpenCategory(null);


### PR DESCRIPTION
Updated area view unit fetch to use new fetching functionality to handle next page fetching. Previously it fetched only one page, limiting results to 1000 units.
Fixed operator error that cleared selected district when returning to area view