### PR TITLE
Use district area list on rescue area service list

### DIFF
--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -51,6 +51,7 @@ const translations = {
   'area.services.nearby.rescue_district': 'Civil defence sections in nearby areas as a list',
   'area.services.nearby.rescue_sub_district': 'Civil defence subsections in nearby areas as a list',
   'area.services.all': 'Locations as a list',
+  'area.services.all.rescue_area': 'Civil defence districts as a list',
   'area.services.all.rescue_district': 'Civil defence sections as a list',
   'area.services.all.rescue_sub_district': 'Civil defence subsections as a list',
   'area.info': 'Choose an area, whose services you want information about. Writing your home address in the search field opens a map, and the areas and districts that you belong to are shown under the Services in the area tab.',

--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -51,6 +51,7 @@ const translations = {
   'area.services.nearby.rescue_district': 'Lähialueiden suojelulohkot listana',
   'area.services.nearby.rescue_sub_district': 'Lähialueiden suojelualalohkot listana',
   'area.services.all': 'Toimipisteet listana',
+  'area.services.all.rescue_area': 'Suojelupiirit listana',
   'area.services.all.rescue_district': 'Suojelulohkot listana',
   'area.services.all.rescue_sub_district': 'Suojelualalohkot listana',
   'area.info': 'Valitse alue, jonka palveluista haluat tietoa. Kirjoittamalla alla olevaan hakukenttään kotiosoitteesi saat näkyville karttaan ja Alueen palvelut -välilehdelle alueet ja piirit, joihin kuulut',

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -51,6 +51,7 @@ const translations = {
   'area.services.nearby.rescue_district': 'Lista över skyddsavsnitten i närområden',
   'area.services.nearby.rescue_sub_district': 'Lista över skyddsunderavsnitten i närområden',
   'area.services.all': 'Lista över verksamhetsställen',
+  'area.services.all.rescue_area': 'Lista över skyddsdistrikten',
   'area.services.all.rescue_district': 'Lista över skyddsavsnitten',
   'area.services.all.rescue_sub_district': 'Lista över skyddsunderavsnitten',
   'area.info': 'Välj ett område, vars tjänster du vill ha information om. Genom att skriva din hemadress i sökfältet öppnas en karta och under fliken Tjänster i området visas de områden och distrikt som du hör till',

--- a/src/views/AreaView/AreaView.js
+++ b/src/views/AreaView/AreaView.js
@@ -181,7 +181,7 @@ const AreaView = ({
 
   useEffect(() => {
     if (map && !focusTo && !localAddressData.length && selectedDistrictGeometry) {
-      focusDistricts(map.leafletElement, selectedDistrictData);
+      focusDistricts(map, selectedDistrictData);
     }
   }, [selectedDistrictGeometry]);
 

--- a/src/views/AreaView/components/DistrictAreaList/DistrictAreaList.js
+++ b/src/views/AreaView/components/DistrictAreaList/DistrictAreaList.js
@@ -21,7 +21,8 @@ export const DistrictAreaList = ({
   const districtsWithoutUnits = district.data.filter(d => (
     !d.unit
     && (
-      d.type === 'rescue_district'
+      d.type === 'rescue_area'
+      || d.type === 'rescue_district'
       || d.type === 'rescue_sub_district'
     )
   ));

--- a/src/views/AreaView/components/ServiceTab/ServiceTab.js
+++ b/src/views/AreaView/components/ServiceTab/ServiceTab.js
@@ -64,7 +64,7 @@ const ServiceTab = (props) => {
 
 
   const renderDistrictList = (districList) => {
-    const listDistrictAreas = ['rescue_district', 'rescue_sub_district'].includes(selectedDistrictType);
+    const listDistrictAreas = ['rescue_area', 'rescue_district', 'rescue_sub_district'].includes(selectedDistrictType);
     const DistrictList = listDistrictAreas ? DistrictAreaList : DistrictUnitList;
     return (
       <List disablePadding>


### PR DESCRIPTION
Units will be removed from rescue areas. Replace service unit list with area list (same as rescue districts and rescue sub districts).

Fix area focus error