### PR TITLE
Fix/map clicks

### DIFF
--- a/src/views/MapView/MapView.js
+++ b/src/views/MapView/MapView.js
@@ -312,7 +312,7 @@ const MapView = (props) => {
         <MapContainer
           tap={false} // This should fix leaflet safari double click bug
           preferCanvas
-          className={`${classes.map} ${measuringMode ? classes.measuringCursor : ''} ${embedded || sidebarHidden ? classes.mapNoSidebar : ''} `}
+          className={`${classes.map} ${embedded ? classes.mapNoSidebar : ''} `}
           key={mapObject.options.name}
           zoomControl={false}
           doubleClickZoom={false}

--- a/src/views/MapView/components/DistanceMeasure/DistanceMeasure.js
+++ b/src/views/MapView/components/DistanceMeasure/DistanceMeasure.js
@@ -15,13 +15,23 @@ const DistanceMeasure = (props) => {
   } = global.rL;
 
   const theme = useTheme();
-
-  const [clickedPoint, setClickedPoint] = useState(null);
   const [icon, setIcon] = useState(null);
 
   useMapEvents({
     click(e) {
-      setClickedPoint(e.latlng);
+      setMarkerArray([...markerArray, e.latlng]);
+      setLineArray([...lineArray, e.latlng]);
+    },
+    zoom() {
+      // Distance markers lose interactive status after zooming. Add it back manually
+      setTimeout(() => {
+        const measureMarkers = document.getElementsByClassName('leaflet-marker-draggable');
+        if (measureMarkers.length) {
+          measureMarkers.forEach((marker) => {
+            marker.classList.add('leaflet-interactive');
+          });
+        }
+      }, 500);
     },
   });
 
@@ -45,13 +55,6 @@ const DistanceMeasure = (props) => {
     setLineArray([...updateArray]);
   };
 
-  useEffect(() => {
-    // When the map is clicked, add new marker and update line between markers
-    if (clickedPoint) {
-      setMarkerArray([...markerArray, clickedPoint]);
-      setLineArray([...lineArray, clickedPoint]);
-    }
-  }, [clickedPoint]);
 
   useEffect(() => {
     const mapElement = document.getElementsByClassName('leaflet-container')[0];

--- a/src/views/MapView/components/DistanceMeasure/DistanceMeasure.js
+++ b/src/views/MapView/components/DistanceMeasure/DistanceMeasure.js
@@ -54,7 +54,12 @@ const DistanceMeasure = (props) => {
   }, [clickedPoint]);
 
   useEffect(() => {
+    const mapElement = document.getElementsByClassName('leaflet-container')[0];
+    mapElement.style.cursor = 'crosshair';
     setMarkerArray(lineArray);
+    return () => {
+      mapElement.style.cursor = 'grab';
+    };
   }, []);
 
 

--- a/src/views/MapView/components/Districts/Districts.js
+++ b/src/views/MapView/components/Districts/Districts.js
@@ -89,11 +89,14 @@ const Districts = ({
               ]}
               icon={drawMarkerIcon(useContrast)}
               keyboard={false}
-              onClick={() => {
-                if (navigator) {
-                  UnitHelper.unitElementClick(navigator, district.unit);
-                }
-              }}
+              eventHandlers={{
+                click: () => {
+                  if (navigator) {
+                    UnitHelper.unitElementClick(navigator, district.unit);
+                  }
+                },
+              }
+              }
             >
               <Tooltip
                 direction="top"

--- a/src/views/MapView/styles.js
+++ b/src/views/MapView/styles.js
@@ -114,9 +114,6 @@ const styles = theme => ({
   showLocationIcon: {
     color: '#fff',
   },
-  measuringCursor: {
-    cursor: 'crosshair',
-  },
   colorInherit: {
     color: 'inherit',
   },


### PR DESCRIPTION
- New MapContainer component is immutable, so classNames cannot be updated. This is why measuring mode cursor changes needed to be moved to measuring component.
- Measuring mode had a bug that made the measuring markers lose interactive status after map zoom (cannot be clicked or dragged). Added interactive class manually after each zoom. This bug is present on current production version.
- Area markers used old click functionality that does not work anymore on newer react-leaflet version. Changed to new