### PR TITLE
Feature/concurrent fetch

### DIFF
--- a/src/utils/newFetch/ServiceMapAPI.js
+++ b/src/utils/newFetch/ServiceMapAPI.js
@@ -53,6 +53,6 @@ export default class ServiceMapAPI extends HttpClient {
       include: 'services',
     };
 
-    return this.get('unit', options);
+    return this.getConcurrent('unit', options);
   }
 }

--- a/src/views/AreaView/components/GeographicalDistrictList/GeographicalDistrictList.js
+++ b/src/views/AreaView/components/GeographicalDistrictList/GeographicalDistrictList.js
@@ -30,7 +30,7 @@ const GeographicalDistrictList = ({ district, classes }) => {
       );
       const coordinateArray = districtsToFocus.map(district => district.boundary.coordinates);
       if (districtsToFocus.length === 1) {
-        map.leafletElement.fitBounds(coordinateArray[0]);
+        map.fitBounds(coordinateArray[0]);
       } else {
         panViewToBounds(map, district.boundary, coordinateArray);
       }


### PR DESCRIPTION
Some area view major districts (on geographical tab) fetched over 3000 units causing a long wait time and loading screen. Created new search functionality to fetch all result pages concurrently, minimizing wait time. This new search functionality could be used on other fetches as well (for example: basic search, service tree fetch, address view unit fetch). 