### PR TITLE
Fix/school service list

### DIFF
--- a/src/components/Lists/ResultList/styles.js
+++ b/src/components/Lists/ResultList/styles.js
@@ -22,6 +22,7 @@ export default theme => ({
     ...theme.typography.body2,
     textTransform: 'uppercase',
     fontWeight: 'bold',
+    textAlign: 'left',
   },
   left: {
     float: 'left',
@@ -30,6 +31,7 @@ export default theme => ({
   right: {
     float: 'right',
     margin: theme.spacing(1),
+    whiteSpace: 'nowrap',
   },
   list: {
     maxHeight: '100%',

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -396,9 +396,9 @@ const translations = {
     one {# service}
     other {# services}
   }`,
-  'unit.semesters': 'The unit’s services per school year.',
-  'unit.semesters.description': 'School year {semester}',
-  'unit.semesters.more': 'Show more services ({count})',
+  'unit.educationServices': 'The unit’s services per school year',
+  'unit.educationServices.description': 'School year {semester}',
+  'unit.educationServices.more': 'Show more services ({count})',
   'unit.route': 'Look at the route to this place',
   'unit.route.extra': '(New tab. The HSL Journey Planner is not an accessible service)',
   'unit.socialMedia.title': 'The service point on social media',

--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -398,9 +398,9 @@ const translations = {
     one {# palvelu}
     other {# palvelua}
   }`,
-  'unit.semesters': 'Toimipisteen lukuvuosikohtaiset palvelut.', // TODO: verify
-  'unit.semesters.description': 'Lukuvuosi {semester}', // TODO: verify
-  'unit.semesters.more': 'Näytä lisää palveluja ({count})',
+  'unit.educationServices': 'Toimipisteen lukuvuosikohtaiset palvelut',
+  'unit.educationServices.description': 'Lukuvuosi {semester}',
+  'unit.educationServices.more': 'Näytä lisää palveluja ({count})',
   'unit.route': 'Katso reitti tänne',
   'unit.route.extra': '(Uusi välilehti. HSL-reittiopas ei ole saavutettava palvelu)',
   'unit.socialMedia.title': 'Toimipiste sosiaalisessa mediassa',

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -396,9 +396,9 @@ const translations = {
     one {# tjänst}
     other {# tjänster}
   }`,
-  'unit.semesters': 'Verksamhetsställets tjänster per läsår.',
-  'unit.semesters.description': 'Läsåret {semester}',
-  'unit.semesters.more': 'Visa fler tjänster ({count})',
+  'unit.educationServices': 'Verksamhetsställets tjänster per läsår',
+  'unit.educationServices.description': 'Läsåret {semester}',
+  'unit.educationServices.more': 'Visa fler tjänster ({count})',
   'unit.route': 'Se vägen till det här stället',
   'unit.route.extra': '(Ny flik. HRT-reseplaneraren är inte en tillgänglig tjänst)',
   'unit.socialMedia.title': 'Verksamhetsstället på sociala medier',

--- a/src/layouts/components/ViewRouter/ViewRouter.js
+++ b/src/layouts/components/ViewRouter/ViewRouter.js
@@ -81,6 +81,13 @@ const UnitServices = () => (
     </PageWrapper>
   </TitleWrapper>
 );
+const UnitEducationServices = () => (
+  <TitleWrapper messageId="general.pageTitles.unit.services">
+    <PageWrapper headMsgId="general.pageTitles.unit.services" page="unit">
+      <ExtendedData type="educationServices" />
+    </PageWrapper>
+  </TitleWrapper>
+);
 const UnitEvents = () => (
   <TitleWrapper messageId="general.pageTitles.unit.events">
     <PageWrapper headMsgId="general.pageTitles.unit.events" page="unit">
@@ -173,6 +180,7 @@ class ViewRouter extends React.Component {
         <Route exact path="/:lng/unit/:unit/events" component={UnitEvents} />
         <Route exact path="/:lng/unit/:unit/reservations" component={UnitReservations} />
         <Route exact path="/:lng/unit/:unit/services" component={UnitServices} />
+        <Route exact path="/:lng/unit/:unit/educationServices" component={UnitEducationServices} />
         <Route exact path="/:lng/unit/:unit" component={Unit} />
         <Route path="/:lng/search" component={Search} />
         <Route path="/:lng/services" component={ServiceTree} />

--- a/src/views/UnitView/components/ExtendedData/ExtendedData.js
+++ b/src/views/UnitView/components/ExtendedData/ExtendedData.js
@@ -89,6 +89,29 @@ const ExtendedData = ({
     );
   };
 
+  const renderEducationServices = () => {
+    const data = selectedUnit.services.filter(unit => unit.period);
+    const titleText = intl.formatMessage({ id: 'unit.educationServices' });
+    const srTitle = `${title} ${titleText}`;
+    return (
+      <div>
+        {
+          renderTitleBar('unit.educationServices')
+        }
+        <PaginatedList
+          id="educationServices"
+          data={data || []}
+          customComponent={service => (
+            <ServiceItem key={service.id} service={service} link={false} />
+          )}
+          srTitle={srTitle}
+          title={titleText}
+          titleComponent="h3"
+        />
+      </div>
+    );
+  };
+
   const renderEvents = () => {
     const { data } = events;
     const titleText = intl.formatMessage({ id: 'unit.events' });
@@ -143,6 +166,8 @@ const ExtendedData = ({
   switch (type) {
     case 'services':
       return renderServices();
+    case 'educationServices':
+      return renderEducationServices();
     case 'events':
       return renderEvents();
     case 'reservations':

--- a/src/views/UnitView/components/UnitDataList/UnitDataList.js
+++ b/src/views/UnitView/components/UnitDataList/UnitDataList.js
@@ -49,7 +49,7 @@ const UnitDataList = ({
         ))
       );
     }
-    if (type === 'services' || type === 'semesters') {
+    if (type === 'services' || type === 'educationServices') {
       return (
         shownData.map((item, i) => (
           <ServiceItem

--- a/src/views/UnitView/components/UnitDataList/UnitDataList.js
+++ b/src/views/UnitView/components/UnitDataList/UnitDataList.js
@@ -21,7 +21,7 @@ const UnitDataList = ({
   if (!dataItems) {
     return null;
   }
-  const endIndex = listLength > dataItems.length || listLength;
+  const endIndex = listLength > dataItems.length ? dataItems.length : listLength;
   const shownData = dataItems.length ? dataItems.slice(0, endIndex) : null;
   const showButton = fullDataLength > listLength;
 

--- a/src/views/UnitView/components/UnitsServicesList/UnitsServicesList.js
+++ b/src/views/UnitView/components/UnitsServicesList/UnitsServicesList.js
@@ -72,7 +72,7 @@ const UnitsServicesList = ({ unit, listLength, navigator }) => {
         key={`period-${period}`}
         listLength={listLength}
         data={{ data: subjectList, max: subjectList.length }}
-        type="semesters"
+        type="educationServices"
         semester={period}
         disableTitle={i !== 0}
         navigator={navigator}


### PR DESCRIPTION
New unit page show more buttons didn't work with school service lists, because extended data page for these wasn't implemented (https://palvelukartta.hel.fi/fi/unit/32303?p=1&t=services). Created extended data page for education services.

Also fixed a bug with unit data list slicing, that would always slice lists with less than 5 items to 1.