### PR TITLE
Remove marker cluster embedded functionality

### DIFF
--- a/src/views/MapView/components/MarkerCluster/MarkerCluster.js
+++ b/src/views/MapView/components/MarkerCluster/MarkerCluster.js
@@ -411,7 +411,7 @@ const MarkerCluster = ({
           setNewHighlightedMarker(markerElem);
         }
 
-        if (unitListFiltered.length > 1 || embeded) {
+        if (unitListFiltered.length > 1) {
           markerElem.on('click', () => {
             setNewHighlightedMarker(markerElem);
             if (!isMobile) {

--- a/src/views/MapView/components/MarkerCluster/clusterUtils.js
+++ b/src/views/MapView/components/MarkerCluster/clusterUtils.js
@@ -1,7 +1,6 @@
 import ReactDOMServer from 'react-dom/server';
 import React from 'react';
 import isClient from '../../../../utils';
-import { isEmbed } from '../../../../utils/path';
 import { getAddressFromUnit } from '../../../../utils/address';
 import formatEventDate from '../../../../utils/events';
 
@@ -15,10 +14,6 @@ export const createMarkerClusterLayer = (
   if (!isClient()) {
     return null;
   }
-  let embeded = false;
-  if (global.window) {
-    embeded = isEmbed();
-  }
 
   const clusterLayer = global.L.markerClusterGroup({
     animate: true,
@@ -27,25 +22,18 @@ export const createMarkerClusterLayer = (
     iconCreateFunction: createClusterCustomIcon,
     maxClusterRadius: 40,
     removeOutsideVisibleBounds: true,
-    zoomToBoundsOnClick: !embeded,
+    zoomToBoundsOnClick: true,
   });
 
-  if (!embeded) {
-    clusterLayer.on('clustermouseover', (a) => {
-      if (clusterMouseover) clusterMouseover(a);
-    });
-    // Add click events as alternative way to trigger hover events on mobile
-    clusterLayer.on('clusterclick', (a) => {
-      if (clusterMouseover && showListOfUnits()) {
-        clusterMouseover(a);
-      }
-    });
-  } else {
-    // Add cluster click when embeded
-    clusterLayer.on('clusterclick', () => {
-      window.open(window.location.href.replace('/embed', ''));
-    });
-  }
+  clusterLayer.on('clustermouseover', (a) => {
+    if (clusterMouseover) clusterMouseover(a);
+  });
+  // Add click events as alternative way to trigger hover events on mobile
+  clusterLayer.on('clusterclick', (a) => {
+    if (clusterMouseover && showListOfUnits()) {
+      clusterMouseover(a);
+    }
+  });
 
   // Hide clusters and markers from keyboard after clustering animations are done
   clusterLayer.on('animationend', (a) => {


### PR DESCRIPTION
It was decided that marker clusters should work the same way in embedder view as in Servicemap itself. Removed previous click functionality that would take users to Servicemap on cluster click.