### PR TITLE
Move cookie consent check to tracking function

### DIFF
--- a/src/components/Navigator/Navigator.js
+++ b/src/components/Navigator/Navigator.js
@@ -54,23 +54,24 @@ class Navigator extends React.Component {
 
   trackPageView = (settings) => {
     const { mobility, senses } = settings;
-
-    if (matomoTracker) {
-      setTimeout(() => {
-        matomoTracker.trackPageView({
-          documentTitle: document.title,
-          customDimensions: [
-            {
-              id: config.matomoMobilityDimensionID,
-              value: mobility || '',
-            },
-            {
-              id: config.matomoSensesDimensionID,
-              value: senses.join(','),
-            },
-          ],
-        });
-      }, 400);
+    if (typeof window !== 'undefined' && window?.cookiehub?.hasConsented('analytics')) {
+      if (matomoTracker) {
+        setTimeout(() => {
+          matomoTracker.trackPageView({
+            documentTitle: document.title,
+            customDimensions: [
+              {
+                id: config.matomoMobilityDimensionID,
+                value: mobility || '',
+              },
+              {
+                id: config.matomoSensesDimensionID,
+                value: senses.join(','),
+              },
+            ],
+          });
+        }, 400);
+      }
     }
   }
 

--- a/src/utils/tracking.js
+++ b/src/utils/tracking.js
@@ -1,17 +1,13 @@
 import MatomoTracker from '@datapunt/matomo-tracker-js';
 import config from '../../config';
 
-const matomoTracker = (
-  typeof window !== 'undefined'
-  && config.matomoSiteId
-  && config.matomoUrl
-  && window?.cookiehub?.hasConsented('analytics'))
+const matomoTracker = (config.matomoSiteId && config.matomoUrl)
   ? new MatomoTracker({
     urlBase: `https://${config.matomoUrl}`,
     siteId: config.matomoSiteId,
     trackerUrl: `https://${config.matomoUrl}/tracker.php`, // optional, default value: `${urlBase}matomo.php`
     srcUrl: `https://${config.matomoUrl}/piwik.min.js`, // optional, default value: `${urlBase}matomo.js`
-    disabled: !window?.cookiehub?.hasConsented('analytics'), // optional, false by default. Makes all tracking calls no-ops if set to true.
+    disabled: false, // optional, false by default. Makes all tracking calls no-ops if set to true.
     linkTracking: false, // optional, default value: true
   }) : null;
 


### PR DESCRIPTION
Previously Matomo was not working even if user allowed cookies. Moved cookie consent check to tracking function