### PR TITLE
Add option for multiple unit embedding

### DIFF
--- a/src/components/SearchBar/SearchBarComponent.js
+++ b/src/components/SearchBar/SearchBarComponent.js
@@ -35,7 +35,7 @@ const SearchBarComponent = ({
   const blurDelay = 150;
   const rootClass = 'SearchBar';
   const ps = previousSearch
-    && !(previousSearch.includes('service_node:') || previousSearch.includes('events:')) ? previousSearch : null;
+    && !(previousSearch.includes('service_node:') || previousSearch.includes('events:') || previousSearch.includes('id:')) ? previousSearch : null;
 
   const intl = useIntl();
 

--- a/src/views/SearchView/SearchView.js
+++ b/src/views/SearchView/SearchView.js
@@ -158,6 +158,7 @@ class SearchView extends React.Component {
       service_node,
       search_language,
       events,
+      units,
     } = searchParams;
 
     const options = {};
@@ -179,6 +180,10 @@ class SearchView extends React.Component {
 
       if (events) {
         options.events = events;
+      }
+
+      if (units) {
+        options.id = units;
       }
 
       if (category) {
@@ -240,7 +245,7 @@ class SearchView extends React.Component {
       }
     } else {
       // Should fetch if no previous searches but search parameters exist
-      return !!(data.q || data.service || data.service_node || data.events);
+      return !!(data.q || data.service || data.service_node || data.events || data.id);
     }
     return false;
   }


### PR DESCRIPTION
Adding parameter "units" with list of id:s to search page url will show only the selected units.
Example url: https://palvelukartta.hel.fi/fi/embed/search?units=8215,51342