### PR TITLE
Fix/unit price links

### DIFF
--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -527,7 +527,7 @@ const translations = {
   'service.plural': 'Services',
   'service.nearby': 'Nearby services',
   'service.units.empty': 'Service does not have service points',
-  'service.tab': 'Services and events',
+  'service.tab': 'Services',
   'service.description': 'View locations and contact information of services',
 
   // Service tree

--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -530,7 +530,7 @@ const translations = {
   'service.plural': 'Palvelut',
   'service.nearby': 'Palvelut täällä asuville',
   'service.units.empty': 'Palvelulla ei ole toimipisteitä',
-  'service.tab': 'Palvelut ja tapahtumat',
+  'service.tab': 'Palvelut',
   'service.description': 'Katso palveluiden sijainnit ja yhteystiedot',
 
   // Service tree

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -528,7 +528,7 @@ const translations = {
   'service.plural': 'Tjänster',
   'service.nearby': 'Närtjänster',
   'service.units.empty': 'Tjänsten har inga verksamhetsställen',
-  'service.tab': 'Tjänster och evenemang',
+  'service.tab': 'Tjänster',
   'service.description': 'Se tjänsternas lägen och kontaktuppgifter',
 
   // Service tree

--- a/src/views/UnitView/components/PriceInfo/PriceInfo.js
+++ b/src/views/UnitView/components/PriceInfo/PriceInfo.js
@@ -1,29 +1,56 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
+import { Link, Typography } from '@material-ui/core';
 import unitSectionFilter from '../../utils/unitSectionFilter';
 import DescriptionText from '../../../../components/DescriptionText';
 import useLocaleText from '../../../../utils/useLocaleText';
 
-const PriceInfo = ({ unit }) => {
+const PriceInfo = ({ unit, classes }) => {
   const getLocaleText = useLocaleText();
 
   const data = unitSectionFilter(unit.connections, 'PRICE');
-  let text = '';
 
-  // Combine all price info to one text
-  data.forEach((item) => {
-    if (item.value?.name) {
-      text += `${getLocaleText(item.value?.name)}\n\n`;
-    }
-  });
+  const renderLink = link => (
+    <>
+      <Typography
+        key={link.id}
+        variant="body2"
+      >
+        <Link className={classes.link} href={getLocaleText(link.value.www)} target="_blank">
+          {getLocaleText(link.value.name)}
+          {' '}
+          <FormattedMessage id="unit.opens.new.tab" />
+        </Link>
+      </Typography>
+      <br />
+    </>
+  );
 
-  if (!text.length) return null;
+
+  const getTextContent = () => (
+    <>
+      {data.map((item) => {
+        if (item.value?.www) return renderLink(item);
+        if (item.value?.name) {
+          return (
+            <>
+              <Typography>{`${getLocaleText(item.value?.name)}`}</Typography>
+              <br />
+            </>
+          );
+        }
+        return null;
+      })}
+    </>
+  );
+
+  if (!data.length) return null;
 
   return (
     <div>
       <DescriptionText
-        description={text}
+        description={getTextContent()}
         title={<FormattedMessage id="unit.price" />}
         titleComponent="h4"
       />
@@ -33,6 +60,7 @@ const PriceInfo = ({ unit }) => {
 
 PriceInfo.propTypes = {
   unit: PropTypes.objectOf(PropTypes.any).isRequired,
+  classes: PropTypes.objectOf(PropTypes.any).isRequired,
 };
 
 export default PriceInfo;

--- a/src/views/UnitView/components/PriceInfo/index.js
+++ b/src/views/UnitView/components/PriceInfo/index.js
@@ -1,3 +1,5 @@
+import { withStyles } from '@material-ui/core';
 import PriceInfo from './PriceInfo';
+import styles from '../../styles/styles';
 
-export default PriceInfo;
+export default withStyles(styles)(PriceInfo);


### PR DESCRIPTION
- Units with link price data (www data) did not render as links. Added missing link elements to unit price info
- Removed the text "events" from unit view third tab, since events have been moved to first tab