### PR TITLE
Add option for adding services to unit view map

### DIFF
--- a/server/dataFetcher.js
+++ b/server/dataFetcher.js
@@ -124,7 +124,7 @@ export const fetchSelectedUnitData = (req, res, next) => {
       }
       data.complete = true;
       store.dispatch(changeSelectedUnit(data));
-      if (data.keywords.fi.includes('kuuluvuuskartta')) {
+      if (data.keywords.fi?.includes('kuuluvuuskartta')) {
         hearingMapsFetch(null, null, hearingMapsFetchEnd, fetchOnError, null, id, controller);
       }
       response();

--- a/src/views/UnitView/UnitView.js
+++ b/src/views/UnitView/UnitView.js
@@ -7,7 +7,7 @@ import {
   Map, Mail, Hearing, Share,
 } from '@material-ui/icons';
 import { Helmet } from 'react-helmet';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { SearchBar, AcceptSettingsDialog, LinkSettingsDialog } from '../../components';
 import TitleBar from '../../components/TitleBar';
 import Container from '../../components/Container';
@@ -33,6 +33,8 @@ import SettingsUtility from '../../utils/settings';
 import UnitDataList from './components/UnitDataList';
 import UnitsServicesList from './components/UnitsServicesList';
 import PriceInfo from './components/PriceInfo';
+import { parseSearchParams } from '../../utils';
+import { fetchServiceUnits } from '../../redux/actions/services';
 
 const UnitView = (props) => {
   const {
@@ -65,6 +67,7 @@ const UnitView = (props) => {
   const [openAcceptSettingsDialog, setOpenAcceptSettingsDialog] = useState(false);
   const [openLinkDialog, setOpenLinkDialog] = useState(false);
   const getLocaleText = useLocaleText();
+  const dispatch = useDispatch();
 
   const map = useSelector(state => state.mapRef);
 
@@ -125,6 +128,14 @@ const UnitView = (props) => {
     }
   };
 
+  const handleServiceFetch = () => {
+    // Fetch additional data based on URL parameters
+    const searchParams = parseSearchParams(location.search);
+    if (searchParams.services) {
+      dispatch(fetchServiceUnits(searchParams.services));
+    }
+  };
+
   const handleFeedbackClick = () => {
     const URLs = config.additionalFeedbackURLs;
     if (unit.municipality === 'espoo') {
@@ -162,6 +173,7 @@ const UnitView = (props) => {
 
   useEffect(() => { // On mount
     intializeUnitData();
+    handleServiceFetch();
     saveMapPosition();
     return () => { // On unmount
       // Return map to previous position if returning to search page or service page


### PR DESCRIPTION
Some embedded units with areas needed to also show nearby units of certain service. Now extra services with distance filter can be added with url parameters: /embed/unit/68398?services=819&distance=500