### PR TITLE
Add concurrent search to embedded multiple services fetch

### DIFF
--- a/src/redux/actions/services.js
+++ b/src/redux/actions/services.js
@@ -36,7 +36,7 @@ export const fetchServiceUnits = serviceIdList => async (dispatch, getState) => 
 
     // Handle fetch
     const smAPI = new ServiceMapAPI();
-    const serviceUnits = await smAPI.services(serviceIdList, options);
+    const serviceUnits = await smAPI.serviceUnits(serviceIdList, options);
 
     // Filter out duplicate units
     const distinctData = Array.from(new Set(serviceUnits.map(x => x.id))).map((id) => {

--- a/src/redux/actions/services.js
+++ b/src/redux/actions/services.js
@@ -1,55 +1,54 @@
-import { serviceFetch, unitsFetch } from '../../utils/fetch';
+import { serviceFetch } from '../../utils/fetch';
 import { service } from './fetchDataActions';
 import { addSearchParametersToObject } from '../../utils';
 import SettingsUtility from '../../utils/settings';
+import ServiceMapAPI from '../../utils/newFetch/ServiceMapAPI';
 
 // Actions
 const {
   fetchError, isFetching, fetchSuccess, fetchProgressUpdate, setNewCurrent,
 } = service;
 
-// Thunk fetch
-export const fetchServiceUnits = serviceId => async (dispatch, getState) => {
-  const onStart = () => dispatch(isFetching());
-  const onSuccess = (data) => {
+// New fetch implementation. TODO: add progress update info
+export const fetchServiceUnits = serviceIdList => async (dispatch, getState) => {
+  dispatch(isFetching());
+
+  try {
+    let municipality;
+    if (global.window) {
+      const search = new URLSearchParams(window.location.search);
+      municipality = search.get('municipality') || search.get('city');
+    }
+
+    if (!municipality) {
+      const citySettings = SettingsUtility.getActiveCitySettings(getState());
+      municipality = citySettings.join(',');
+    }
+
+    let options = {};
+
+    if (municipality) {
+      options.municipality = municipality;
+    }
+
+    // Add search parameters to options
+    options = addSearchParametersToObject(options, ['city']);
+
+    // Handle fetch
+    const smAPI = new ServiceMapAPI();
+    const serviceUnits = await smAPI.services(serviceIdList, options);
+
     // Filter out duplicate units
-    const distinctData = Array.from(new Set(data.map(x => x.id))).map((id) => {
-      const obj = data.find(s => id === s.id);
+    const distinctData = Array.from(new Set(serviceUnits.map(x => x.id))).map((id) => {
+      const obj = serviceUnits.find(s => id === s.id);
       obj.object_type = 'unit';
       return obj;
     });
+
     dispatch(fetchSuccess(distinctData));
-  };
-  const onError = e => dispatch(fetchError(e.message));
-  const onNext = (resultTotal, response) => {
-    dispatch(fetchProgressUpdate(resultTotal.length, response.count));
-  };
-  let municipality;
-  if (global.window) {
-    const search = new URLSearchParams(window.location.search);
-    municipality = search.get('municipality') || search.get('city');
+  } catch (e) {
+    dispatch(fetchError(e.message));
   }
-
-  if (!municipality) {
-    const citySettings = SettingsUtility.getActiveCitySettings(getState());
-    municipality = citySettings.join(',');
-  }
-
-  let options = {
-    service: serviceId,
-    page_size: 50,
-    only: 'street_address,name,accessibility_shortcoming_count,location,municipality,contract_type',
-  };
-
-  if (municipality) {
-    options.municipality = municipality;
-  }
-
-  // Add search parameters to options
-  options = addSearchParametersToObject(options, ['city']);
-
-  // Fetch data
-  unitsFetch(options, onStart, onSuccess, onError, onNext);
 };
 
 export const fetchService = serviceId => async (dispatch) => {
@@ -68,6 +67,6 @@ export const fetchService = serviceId => async (dispatch) => {
 export const setNewCurrentService = service => async (dispatch) => {
   if (service) {
     dispatch(setNewCurrent(service));
-    dispatch(fetchServiceUnits(service.id, []));
+    dispatch(fetchServiceUnits(service.id));
   }
 };

--- a/src/utils/newFetch/ServiceMapAPI.js
+++ b/src/utils/newFetch/ServiceMapAPI.js
@@ -28,6 +28,22 @@ export default class ServiceMapAPI extends HttpClient {
     return this.get('search', options);
   }
 
+  // Fetch multiple services concurrently
+  services = async (idList, additionalOptions) => {
+    if (typeof idList !== 'string' && typeof idList !== 'number') {
+      throw new APIFetchError('Invalid idList string provided to ServiceMapAPI services method');
+    }
+
+    const options = {
+      service: idList,
+      page_size: 200,
+      only: 'street_address,name,accessibility_shortcoming_count,location,municipality,contract_type',
+      ...additionalOptions,
+    };
+
+    return this.getConcurrent('unit', options);
+  }
+
   serviceNames = async (idList) => {
     if (typeof idList !== 'string') {
       throw new APIFetchError('Invalid idList string provided to ServiceMapAPI serviceNames method');

--- a/src/utils/newFetch/ServiceMapAPI.js
+++ b/src/utils/newFetch/ServiceMapAPI.js
@@ -28,8 +28,8 @@ export default class ServiceMapAPI extends HttpClient {
     return this.get('search', options);
   }
 
-  // Fetch multiple services concurrently
-  services = async (idList, additionalOptions) => {
+  // Fetch units of multiple services concurrently
+  serviceUnits = async (idList, additionalOptions) => {
     if (typeof idList !== 'string' && typeof idList !== 'number') {
       throw new APIFetchError('Invalid idList string provided to ServiceMapAPI services method');
     }


### PR DESCRIPTION
Problem: this multiple service fetch is taking too long. https://palvelukartta.hel.fi/fi/embed/unit/68398?services=155,239,254,311,312,344,345,389,917,399,400,401,410,415,916,961,912,577,672,767,786,791,813,819&distance=50

Fixed it by concurrently searching the service unit result pages, instead of searching the pages one after another.