### PR TITLE
Fix duplicate period services

### DIFF
--- a/config/paths.js
+++ b/config/paths.js
@@ -13,7 +13,7 @@ const paths = {
     regex: /\/[a-zA-Z]{2}\/search/
   },
   unit: {
-    generate: data => `/unit/${data.id || ''}${data.type ? '/' + data.type : ''}`,
+    generate: data => `/unit/${data.id || ''}${data.type ? '/' + data.type : ''}${data.period ? '/' + data.period : ''}`,
     regex: /\/[a-zA-Z]{2}\/unit\/([0-9]+)/
   },
   service: {

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -448,7 +448,7 @@ const translations = {
     other {# services}
   }`,
   'unit.educationServices': 'The unit’s services per school year',
-  'unit.educationServices.description': 'School year {semester}',
+  'unit.educationServices.description': 'School year {period}',
   'unit.educationServices.more': 'Show more services ({count})',
   'unit.route': 'Look at the route to this place',
   'unit.route.extra': '(New tab. The HSL Journey Planner is not an accessible service)',

--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -450,7 +450,7 @@ const translations = {
     other {# palvelua}
   }`,
   'unit.educationServices': 'Toimipisteen lukuvuosikohtaiset palvelut',
-  'unit.educationServices.description': 'Lukuvuosi {semester}',
+  'unit.educationServices.description': 'Lukuvuosi {period}',
   'unit.educationServices.more': 'Näytä lisää palveluja ({count})',
   'unit.route': 'Katso reitti tänne',
   'unit.route.extra': '(Uusi välilehti. HSL-reittiopas ei ole saavutettava palvelu)',

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -449,7 +449,7 @@ const translations = {
     other {# tjänster}
   }`,
   'unit.educationServices': 'Verksamhetsställets tjänster per läsår',
-  'unit.educationServices.description': 'Läsåret {semester}',
+  'unit.educationServices.description': 'Läsåret {period}',
   'unit.educationServices.more': 'Visa fler tjänster ({count})',
   'unit.route': 'Se vägen till det här stället',
   'unit.route.extra': '(Ny flik. HRT-reseplaneraren är inte en tillgänglig tjänst)',

--- a/src/layouts/components/ViewRouter/ViewRouter.js
+++ b/src/layouts/components/ViewRouter/ViewRouter.js
@@ -183,7 +183,7 @@ class ViewRouter extends React.Component {
         <Route exact path="/:lng/unit/:unit/events" component={UnitEvents} />
         <Route exact path="/:lng/unit/:unit/reservations" component={UnitReservations} />
         <Route exact path="/:lng/unit/:unit/services" component={UnitServices} />
-        <Route exact path="/:lng/unit/:unit/educationServices" component={UnitEducationServices} />
+        <Route exact path="/:lng/unit/:unit/educationServices/:period?" component={UnitEducationServices} />
         <Route exact path="/:lng/unit/:unit" component={Unit} />
         <Route path="/:lng/search" component={Search} />
         <Route path="/:lng/services" component={ServiceTree} />

--- a/src/views/UnitView/components/ExtendedData/ExtendedData.js
+++ b/src/views/UnitView/components/ExtendedData/ExtendedData.js
@@ -23,7 +23,7 @@ const ExtendedData = ({
   const getLocaleText = useLocaleText();
   const selectedUnit = useSelector(state => state.selectedUnit?.unit?.data);
   const intl = useIntl();
-  const { unit } = useParams();
+  const { unit, period } = useParams();
   const title = currentUnit && currentUnit.name ? getLocaleText(currentUnit.name) : '';
 
   useEffect(() => {
@@ -90,7 +90,15 @@ const ExtendedData = ({
   };
 
   const renderEducationServices = () => {
-    const data = selectedUnit.services.filter(unit => unit.period);
+    const data = selectedUnit.services.filter((unit) => {
+      if (unit.period) {
+        // Show only units that have correct period data
+        const unitPeriod = `${unit.period[0]}–${unit.period[1]}`;
+        if (period && period === unitPeriod) return true;
+      }
+      return false;
+    });
+
     const titleText = intl.formatMessage({ id: 'unit.educationServices' });
     const srTitle = `${title} ${titleText}`;
     return (

--- a/src/views/UnitView/components/UnitDataList/UnitDataList.js
+++ b/src/views/UnitView/components/UnitDataList/UnitDataList.js
@@ -9,13 +9,13 @@ import ReservationItem from '../../../../components/ListItems/ReservationItem';
 import ServiceItem from '../../../../components/ListItems/ServiceItem';
 
 const UnitDataList = ({
-  data, listLength, type, semester, disableTitle, navigator,
+  data, listLength, type, period, disableTitle, navigator,
 }) => {
   const location = useLocation();
   const unit = useSelector(state => state.selectedUnit.unit.data);
 
   const dataItems = data.data;
-  const fullDataLength = data.max;
+  const fullDataLength = data.data.length;
   const { isFetching } = data;
 
   if (!dataItems) {
@@ -31,7 +31,7 @@ const UnitDataList = ({
         ...location,
         hash: `Unit${type}Button`,
       });
-      navigator.push('unit', { id: unit.id, type });
+      navigator.push('unit', { id: unit.id, type, period });
     }
   };
 
@@ -69,7 +69,7 @@ const UnitDataList = ({
       <div>
         <TitledList
           title={!disableTitle ? <FormattedMessage id={`unit.${type}`} /> : null}
-          description={<FormattedMessage id={`unit.${type}.description`} values={semester ? { semester } : null} />}
+          description={<FormattedMessage id={`unit.${type}.description`} values={period ? { period } : null} />}
           detailedTitle
           divider={false}
           titleComponent="h4"
@@ -93,7 +93,7 @@ UnitDataList.propTypes = {
   listLength: PropTypes.number,
   type: PropTypes.string.isRequired,
   navigator: PropTypes.objectOf(PropTypes.any),
-  semester: PropTypes.string,
+  period: PropTypes.string,
   disableTitle: PropTypes.bool,
 };
 
@@ -101,7 +101,7 @@ UnitDataList.defaultProps = {
   data: null,
   listLength: 5,
   navigator: null,
-  semester: null,
+  period: null,
   disableTitle: false,
 };
 

--- a/src/views/UnitView/components/UnitDataList/UnitDataList.js
+++ b/src/views/UnitView/components/UnitDataList/UnitDataList.js
@@ -15,7 +15,7 @@ const UnitDataList = ({
   const unit = useSelector(state => state.selectedUnit.unit.data);
 
   const dataItems = data.data;
-  const fullDataLength = data.data.length;
+  const fullDataLength = dataItems?.length || data.max;
   const { isFetching } = data;
 
   if (!dataItems) {

--- a/src/views/UnitView/components/UnitsServicesList/UnitsServicesList.js
+++ b/src/views/UnitView/components/UnitsServicesList/UnitsServicesList.js
@@ -77,7 +77,7 @@ const UnitsServicesList = ({ unit, listLength, navigator }) => {
         listLength={listLength}
         data={{ data: filterDataByYear(period), max: subjectList.length }}
         type="educationServices"
-        semester={period}
+        period={period}
         disableTitle={i !== 0}
         navigator={navigator}
       />


### PR DESCRIPTION
Bug: school service list showed duplicate services. Example: https://palvelukartta.hel.fi/fi/unit/6926/educationServices
The extended list showed the services for both periods in the same list. 

Fixed this by adding period to url to define which period services should be shown (example url: unit/6926/educationServices/2022–2023)