### PR TITLE
Mobile embedded view fixes

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -74,7 +74,13 @@ input[type="search"]::-webkit-search-cancel-button{
   color: #4A4A4C !important;
 }
 
+/* This allows clicks to go through control background to the map. Control buttons need style: pointer-events: auto */
+.leaflet-control {
+  pointer-events: none; 
+}
+
 .leaflet-control-attribution {
   background: #fff !important;
+  pointer-events: auto;
 }
 

--- a/src/layouts/EmbedLayout.js
+++ b/src/layouts/EmbedLayout.js
@@ -52,7 +52,7 @@ const createContentStyles = (theme, bottomList) => {
       minWidth: width,
     },
     embedLogo: {
-      top: 0,
+      bottom: 0,
       left: 0,
       height: 'auto',
       position: 'fixed',

--- a/src/views/MapView/components/MarkerCluster/MarkerCluster.js
+++ b/src/views/MapView/components/MarkerCluster/MarkerCluster.js
@@ -21,9 +21,9 @@ const tooltipOptions = (permanent, classes) => ({
   offset: [0, -25],
 });
 
-const popupOptions = () => ({
+const popupOptions = isMobile => ({
   autoClose: false,
-  autoPan: false,
+  autoPan: !!isMobile,
   closeButton: true,
   closeOnClick: false,
   direction: 'top',
@@ -389,7 +389,7 @@ const MarkerCluster = ({
           },
         ).bindPopup(
           popupContent,
-          popupOptions(),
+          popupOptions(isMobile),
         );
 
         if (isMobile) {

--- a/src/views/MapView/components/PanControl/styles.js
+++ b/src/views/MapView/components/PanControl/styles.js
@@ -13,6 +13,7 @@ export default {
       height: 34,
       lineHeight: '30px',
       padding: 0,
+      pointerEvents: 'auto',
     },
   },
   top: {

--- a/src/views/MapView/components/TransitStops/TransitStops.js
+++ b/src/views/MapView/components/TransitStops/TransitStops.js
@@ -124,7 +124,7 @@ const TransitStops = ({ mapObject, classes }) => {
             keyboard={false}
           >
             <div aria-hidden>
-              <Popup closeButton={false} className="popup" autoPan={false}>
+              <Popup closeButton={false} className="popup" autoPan={isMobile}>
                 <TransitStopInfo
                   stop={stop}
                   onCloseClick={() => closePopup()}
@@ -144,7 +144,7 @@ const TransitStops = ({ mapObject, classes }) => {
             keyboard={false}
           >
             <div aria-hidden>
-              <Popup closeButton={false} className="popup" autoPan={false}>
+              <Popup closeButton={false} className="popup" autoPan={isMobile}>
                 <TransitStopInfo
                   stop={station}
                   type="bikeStation"


### PR DESCRIPTION
On smaller embedded views (mobile) marker popups were hard to use. Servicemap logo would be on top of the popup and usually popup were opened outside of screen bounds.

Moved logo to bottom and added autoPan to marker popups

Also improved mobile click responsiveness