### PR TITLE
Add better label for result order select element

### DIFF
--- a/src/components/ResultOrderer/ResultOrderer.js
+++ b/src/components/ResultOrderer/ResultOrderer.js
@@ -77,7 +77,7 @@ const ResultOrderer = ({
   return (
     <form className={classes.root} autoComplete="off">
       <FormControl className={classes.formControl}>
-        <Typography color="inherit" variant="caption" className={classes.inputLabel}>
+        <Typography color="inherit" variant="caption" component="label" for="result-sorter" className={classes.inputLabel}>
           <FormattedMessage id="sorting.label" />
         </Typography>
         <Select


### PR DESCRIPTION
Result orderer select element was missing linked label. Now it should read the label when navigating to the element. (Accessibility report page 32)