### PR TITLE
Fix/link underlines

### DIFF
--- a/src/components/ListItems/SimpleListItem/styles.js
+++ b/src/components/ListItems/SimpleListItem/styles.js
@@ -16,6 +16,7 @@ export default theme => ({
   },
   link: {
     color: '#0000EE',
+    textDecoration: 'underline',
   },
   whiteText: {
     color: '#fff',

--- a/src/components/ListItems/SimpleListItem/styles.js
+++ b/src/components/ListItems/SimpleListItem/styles.js
@@ -15,7 +15,7 @@ export default theme => ({
     whiteSpace: 'pre-line',
   },
   link: {
-    color: '#0000EE',
+    color: theme.palette.link.main,
     textDecoration: 'underline',
   },
   whiteText: {

--- a/src/themes/index.js
+++ b/src/themes/index.js
@@ -252,6 +252,9 @@ export const paletteDefault = {
     background: 'rgb(25, 100, 230)',
     border: '#fff',
   },
+  link: {
+    main: '#0000EE',
+  },
 };
 
 // Color palette for dark theme
@@ -293,6 +296,9 @@ export const paletteDark = {
     main: '#313131',
     background: '#A6A6A6',
     border: '#fff',
+  },
+  link: {
+    main: '#0000EE',
   },
 };
 

--- a/src/themes/index.js
+++ b/src/themes/index.js
@@ -253,7 +253,7 @@ export const paletteDefault = {
     border: '#fff',
   },
   link: {
-    main: '#0000EE',
+    main: '#3333FF',
   },
 };
 
@@ -298,7 +298,7 @@ export const paletteDark = {
     border: '#fff',
   },
   link: {
-    main: '#0000EE',
+    main: '#3333FF',
   },
 };
 

--- a/src/views/AddressView/styles.js
+++ b/src/views/AddressView/styles.js
@@ -32,6 +32,7 @@ export default theme => ({
     textAlign: 'left',
   },
   areaLink: {
+    color: theme.palette.link.main,
     textDecoration: 'underline',
     marginBottom: theme.spacing(1),
     marginTop: theme.spacing(1),

--- a/src/views/AreaView/styles.js
+++ b/src/views/AreaView/styles.js
@@ -15,12 +15,6 @@ const styles = theme => ({
     textAlign: 'start',
     display: 'flex',
   },
-  deleteLink: {
-    fontSize: 14,
-    color: '#3344dd',
-    textDecoration: 'underline',
-    marginLeft: theme.spacing(1),
-  },
   list: {
     paddingLeft: 10,
   },

--- a/src/views/FeedbackView/styles.js
+++ b/src/views/FeedbackView/styles.js
@@ -101,6 +101,7 @@ export default theme => ({
     marginTop: 14,
   },
   link: {
+    color: theme.palette.link.main,
     marginTop: 14,
     marginBottom: 26,
     textAlign: 'left',

--- a/src/views/InfoView/styles.js
+++ b/src/views/InfoView/styles.js
@@ -26,13 +26,13 @@ const styles = theme => ({
     paddingBottom: theme.spacing(1),
   },
   link: {
-    color: '#0000EE',
+    color: theme.palette.link.main,
   },
   linkButton: {
     padding: theme.spacing(2),
     paddingTop: 0,
     fontSize: 16,
-    color: '#0000EE',
+    color: theme.palette.link.main,
     textDecoration: 'underline',
   },
 });

--- a/src/views/MapView/styles.js
+++ b/src/views/MapView/styles.js
@@ -26,7 +26,7 @@ const styles = theme => ({
     },
   },
   addressLink: {
-    color: theme.palette.primary.main,
+    color: theme.palette.link.main,
     textDecoration: 'underline',
   },
   loadingScreen: {
@@ -60,7 +60,7 @@ const styles = theme => ({
     paddingBottom: theme.spacing(2),
   },
   coordinateLink: {
-    color: theme.palette.primary.main,
+    color: theme.palette.link.main,
     wordBreak: 'break-word',
     textAlign: 'left',
     maxWidth: 240,
@@ -224,7 +224,7 @@ const styles = theme => ({
     ...theme.typography.body2,
     paddingTop: theme.spacing(1),
     textAlign: 'center',
-    color: theme.palette.primary.main,
+    color: theme.palette.primary.link,
   },
   unitTooltipWrapper: {
     padding: theme.spacing(3),

--- a/src/views/MapView/styles.js
+++ b/src/views/MapView/styles.js
@@ -27,6 +27,7 @@ const styles = theme => ({
   },
   addressLink: {
     color: theme.palette.primary.main,
+    textDecoration: 'underline',
   },
   loadingScreen: {
     height: '100%',

--- a/src/views/UnitView/styles/styles.js
+++ b/src/views/UnitView/styles/styles.js
@@ -42,7 +42,7 @@ export default theme => ({
     borderBottom: '1px solid rgba(0,0,0,0.2)',
   },
   link: {
-    color: '#0000EE',
+    color: theme.palette.link.main,
     textDecoration: 'underline',
   },
   linkButton: {
@@ -149,7 +149,7 @@ export default theme => ({
   },
   accessibilityLink: {
     paddingTop: theme.spacing(1),
-    color: '#0000EE',
+    color: theme.palette.link.main,
   },
   callInfoText: {
     whiteSpace: 'pre-line',


### PR DESCRIPTION
Accessibility report pages 11-12: Some links did not have underline to indicate it is a link. 
Added link color to theme so that the color is more consistent.