### PR TITLE
Fix tabindex values to numbers for elements that utilize buttonbase

### DIFF
--- a/src/components/AddressSearchBar/AddressSearchBar.js
+++ b/src/components/AddressSearchBar/AddressSearchBar.js
@@ -173,7 +173,7 @@ const AddressSearchBar = ({
             <List role="listbox" id="address-results">
               {addressResults.map((address, i) => (
                 <ListItem
-                  tabIndex="-1"
+                  tabIndex={-1}
                   id={`address-suggestion${i}`}
                   role="option"
                   selected={i === resultIndex}

--- a/src/components/DropDownMenuButton/DropDownMenuButton.js
+++ b/src/components/DropDownMenuButton/DropDownMenuButton.js
@@ -66,7 +66,7 @@ class DropDownMenuButton extends React.Component {
                 onKeyPress={keyboardHandler(this.handleItemClick, ['space', 'enter'])}
                 onBlur={this.closeMenuOnFocusExit}
                 component="span"
-                tabIndex="0"
+                tabIndex={0}
                 aria-hidden={v.ariaHidden}
               >
                 <span>{v.icon}</span>

--- a/src/components/Link/Link.js
+++ b/src/components/Link/Link.js
@@ -10,7 +10,7 @@ const Link = ({
   <span
     className={`${classes.link} ${className || ''} link`}
     role="link"
-    tabIndex="0"
+    tabIndex={0}
     onClick={onClick}
     onKeyPress={onClick}
   >

--- a/src/components/Lists/ResultList/ResultList.js
+++ b/src/components/Lists/ResultList/ResultList.js
@@ -43,7 +43,7 @@ class ResultList extends React.Component {
                   component={titleComponent}
                   variant="subtitle1"
                   aria-labelledby={`${listId}-result-title ${listId}-result-title-info`}
-                  tabIndex="-1"
+                  tabIndex={-1}
                 >
                   {title}
 

--- a/src/components/PaginationComponent/PageElement.js
+++ b/src/components/PaginationComponent/PageElement.js
@@ -19,7 +19,7 @@ const PageElement = ({
         disabled={isActive}
         onClick={onClick}
         onKeyDown={keyboardHandler(onClick, ['space', 'enter'])}
-        tabIndex={isActive ? '-1' : '0'}
+        tabIndex={isActive ? -1 : 0}
       >
         <Typography
           variant="subtitle1"

--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -696,7 +696,7 @@ class Settings extends React.Component {
     return (
       <div id="SettingsContainer" className={`${classes.container}`} ref={this.dialogRef} role="dialog">
         {/* Empty element that makes keyboard focus loop in dialog */}
-        <Typography style={visuallyHidden} aria-hidden tabIndex="0" onFocus={() => this.focusToLastElement()} />
+        <Typography style={visuallyHidden} aria-hidden tabIndex={0} onFocus={() => this.focusToLastElement()} />
 
         <TitleBar id="SettingsTitle" titleComponent="h2" title={<FormattedMessage id={`settings.${settingsPage}.long`} />} />
         <>
@@ -738,7 +738,7 @@ class Settings extends React.Component {
           </Typography>
         </>
         {/* Empty element that makes keyboard focus loop in dialog */}
-        <Typography style={visuallyHidden} aria-hidden tabIndex="0" onFocus={() => this.focusToFirstElement()} />
+        <Typography style={visuallyHidden} aria-hidden tabIndex={0} onFocus={() => this.focusToFirstElement()} />
       </div>
     );
   }

--- a/src/components/TabLists/TabLists.js
+++ b/src/components/TabLists/TabLists.js
@@ -204,7 +204,7 @@ const TabLists = ({
           focusClass
           && focusText
           && (
-            <Typography style={visuallyHidden} className={focusClass} tabIndex="-1">{focusText}</Typography>
+            <Typography style={visuallyHidden} className={focusClass} tabIndex={-1}>{focusText}</Typography>
           )
         }
         <Tabs

--- a/src/components/TitleBar/TitleBar.js
+++ b/src/components/TitleBar/TitleBar.js
@@ -57,7 +57,7 @@ const TitleBar = ({
           aria-hidden={ariaHidden}
           className={`TitleText ${classes.title} ${backButton ? classes.titleLarge : ''}`}
           component={titleComponent}
-          tabIndex="-1"
+          tabIndex={-1}
         >
           {title}
         </Typography>

--- a/src/layouts/DefaultLayout.js
+++ b/src/layouts/DefaultLayout.js
@@ -155,7 +155,7 @@ const DefaultLayout = (props) => {
         (
           <ErrorBoundary>
             <div id="topArea" aria-hidden={!!settingsToggled} className={printClass}>
-              <h1 id="app-title" tabIndex="-1" className="sr-only app-title" component="h1">
+              <h1 id="app-title" tabIndex={-1} className="sr-only app-title" component="h1">
                 <FormattedMessage id="app.title" />
               </h1>
               {/* Jump link to main content for screenreaders
@@ -190,7 +190,7 @@ const DefaultLayout = (props) => {
               <Typography style={visuallyHidden}>{intl.formatMessage({ id: 'map.ariaLabel' })}</Typography>
               <div
                 aria-hidden
-                tabIndex="-1"
+                tabIndex={-1}
                 style={styles.map}
               >
                 <MapView

--- a/src/layouts/EmbedLayout.js
+++ b/src/layouts/EmbedLayout.js
@@ -194,7 +194,7 @@ const EmbedLayout = ({ intl }) => {
           </Switch>
         </div>
         <Typography style={visuallyHidden}>{intl.formatMessage({ id: 'map.ariaLabel' })}</Typography>
-        <div aria-hidden tabIndex="-1" style={styles.map}>
+        <div aria-hidden tabIndex={-1} style={styles.map}>
           <MapView />
         </div>
       </div>

--- a/src/layouts/components/ViewRouter/ViewTitle/ViewTitle.js
+++ b/src/layouts/components/ViewRouter/ViewTitle/ViewTitle.js
@@ -56,7 +56,7 @@ class ViewTitle extends React.Component {
     }
 
     return (
-      <Typography id={viewTitleID} style={visuallyHidden} component="h2" tabIndex="-1" ref={this.titleRef}>
+      <Typography id={viewTitleID} style={visuallyHidden} component="h2" tabIndex={-1} ref={this.titleRef}>
         <FormattedMessage id={message + type} />
       </Typography>
     );

--- a/src/views/FeedbackView/FeedbackView.js
+++ b/src/views/FeedbackView/FeedbackView.js
@@ -158,7 +158,7 @@ const FeedbackView = ({
         && (
           <Dialog open={!!modalOpen} onEntered={() => document.getElementById('dialog-title').focus()}>
             <div className={classes.modalContainer}>
-              <DialogTitle tabIndex="-1" id="dialog-title">
+              <DialogTitle tabIndex={-1} id="dialog-title">
                 <Typography aria-live="polite" className={classes.modalTitle}>
                   <FormattedMessage id={modalOpen === 'send' ? 'feedback.modal.success' : 'feedback.modal.error'} />
                 </Typography>

--- a/src/views/MapView/components/PanControl/PanControl.js
+++ b/src/views/MapView/components/PanControl/PanControl.js
@@ -96,7 +96,7 @@ const PanControl = ({ classes }) => {
             className={classes.top}
             onClick={() => callback('up')}
             onKeyDown={keyboardCallback}
-            tabIndex="0"
+            tabIndex={0}
           >
             <ArrowDropUp />
           </ButtonBase>
@@ -106,7 +106,7 @@ const PanControl = ({ classes }) => {
             className={classes.left}
             onClick={() => callback('left')}
             onKeyDown={keyboardCallback}
-            tabIndex="0"
+            tabIndex={0}
           >
             <ArrowLeft />
           </ButtonBase>
@@ -116,7 +116,7 @@ const PanControl = ({ classes }) => {
             className={classes.right}
             onClick={() => callback('right')}
             onKeyDown={keyboardCallback}
-            tabIndex="0"
+            tabIndex={0}
           >
             <ArrowRight />
           </ButtonBase>
@@ -126,7 +126,7 @@ const PanControl = ({ classes }) => {
             className={classes.bottom}
             onClick={() => callback('down')}
             onKeyDown={keyboardCallback}
-            tabIndex="0"
+            tabIndex={0}
           >
             <ArrowDropDown />
           </ButtonBase>
@@ -138,7 +138,7 @@ const PanControl = ({ classes }) => {
         className={`${classes.zoomIn} ${embedded ? classes.embedded : ''} zoomIn `}
         onClick={() => callback('in')}
         onKeyDown={keyboardCallback}
-        tabIndex="0"
+        tabIndex={0}
       >
         <Add />
       </ButtonBase>
@@ -148,7 +148,7 @@ const PanControl = ({ classes }) => {
         className={`${classes.zoomOut} ${embedded ? classes.embedded : ''} zoomOut`}
         onClick={() => callback('out')}
         onKeyDown={keyboardCallback}
-        tabIndex="0"
+        tabIndex={0}
       >
         <Remove />
       </ButtonBase>

--- a/src/views/PrintView/PrintView.js
+++ b/src/views/PrintView/PrintView.js
@@ -261,7 +261,7 @@ const PrintView = ({
   return (
     <div ref={dialogRef} role="dialog" className={classes.wrapper}>
       {/* Empty element that makes keyboard focus loop in dialog */}
-      <Typography style={visuallyHidden} aria-hidden tabIndex="0" onFocus={focusToLastElement} />
+      <Typography style={visuallyHidden} aria-hidden tabIndex={0} onFocus={focusToLastElement} />
       <div className={classes.container}>
         <div className={classes.buttonContainer}>
           <SMButton
@@ -285,7 +285,7 @@ const PrintView = ({
           aria-label={intl.formatMessage({ id: 'map.ariaLabel' })}
           id="print-map"
           className={classes.map}
-          tabIndex="-1"
+          tabIndex={-1}
         />
         <div>
           <TableContainer component={Paper} className={classes.table}>

--- a/src/views/SearchView/SearchView.js
+++ b/src/views/SearchView/SearchView.js
@@ -390,7 +390,7 @@ class SearchView extends React.Component {
       <NoSsr>
         <Typography
           role="link"
-          tabIndex="-1"
+          tabIndex={-1}
           onClick={this.skipToContent}
           onKeyPress={() => { keyboardHandler(this.skipToContent(), ['space', 'enter']); }}
           style={visuallyHidden}
@@ -559,7 +559,7 @@ class SearchView extends React.Component {
     } = this.props;
 
     return (
-      <Typography className={classes.srOnly} style={visuallyHidden} component="h3" tabIndex="-1">
+      <Typography className={classes.srOnly} style={visuallyHidden} component="h3" tabIndex={-1}>
         {
           !isFetching
           && (
@@ -630,7 +630,7 @@ class SearchView extends React.Component {
         }
         <DesktopComponent>
           <Typography style={visuallyHidden} component="h3">
-            <Link href={`#${viewTitleID}`} tabIndex="-1">
+            <Link href={`#${viewTitleID}`} tabIndex={-1}>
               <FormattedMessage id="general.return.viewTitle" />
             </Link>
           </Typography>


### PR DESCRIPTION
After MaterialUI update some components have thrown error when tabIndex has been string. Changed all react components use number for tabindex props.