### PR TITLE
Fix closing window issue by separating hearing map test to own test

### DIFF
--- a/browserTests/views/unitPageTest.js
+++ b/browserTests/views/unitPageTest.js
@@ -167,7 +167,9 @@ test('Unit page links do work correctly', async (t) => {
     .closeWindow() // Since hsl link opens in new window we need to close it
     .navigateTo(testUrl)
   ;
+});
 
+test.only('Unit view hearing map link opens correctly', async (t) => {
   // Test accessibility hearing map link
   const aLinks = Selector('#tab-content-1 li[role="link"]');
   const accessibilityTab = Selector('div[role="tablist"] button').nth(1);
@@ -181,6 +183,7 @@ test('Unit page links do work correctly', async (t) => {
     .click(hearingMapLink)
     .expect(getLocation()).contains('https://kuulokuvat.fi')
     .closeWindow() // Since hearing map link opens in new window we need to close it
+  ;
 });
 
 


### PR DESCRIPTION
There seems to be a bug with new window being closed when trying to get use ClientFunction. Maybe it's caused by multiple ClientFunctions being called in single test.

Separating hearing map test to own test seems to solve this.