### PR TITLE
Add sub group contact informations to unit view

### DIFF
--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -455,6 +455,7 @@ const translations = {
     one {# service}
     other {# services}
   }`,
+  'unit.subgroup.title': 'See group specific contanct information',
   'unit.educationServices': 'The unit’s services per school year',
   'unit.educationServices.description': 'School year {period}',
   'unit.educationServices.more': 'Show more services ({count})',

--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -457,6 +457,7 @@ const translations = {
     one {# palvelu}
     other {# palvelua}
   }`,
+  'unit.subgroup.title': 'Katso ryhmäkohtaiset yhteystiedot',
   'unit.educationServices': 'Toimipisteen lukuvuosikohtaiset palvelut',
   'unit.educationServices.description': 'Lukuvuosi {period}',
   'unit.educationServices.more': 'Näytä lisää palveluja ({count})',

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -456,7 +456,7 @@ const translations = {
     one {# tjänst}
     other {# tjänster}
   }`,
-  'unit.subgroup.title': 'See group specific contanct information', // TODO: Translate
+  'unit.subgroup.title': 'Se gruppspecifika kontaktuppgifter',
   'unit.educationServices': 'Verksamhetsställets tjänster per läsår',
   'unit.educationServices.description': 'Läsåret {period}',
   'unit.educationServices.more': 'Visa fler tjänster ({count})',

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -456,6 +456,7 @@ const translations = {
     one {# tjänst}
     other {# tjänster}
   }`,
+  'unit.subgroup.title': 'See group specific contanct information', // TODO: Translate
   'unit.educationServices': 'Verksamhetsställets tjänster per läsår',
   'unit.educationServices.description': 'Läsåret {period}',
   'unit.educationServices.more': 'Visa fler tjänster ({count})',

--- a/src/views/UnitView/components/ContactInfo/ContactInfo.js
+++ b/src/views/UnitView/components/ContactInfo/ContactInfo.js
@@ -20,6 +20,7 @@ const ContactInfo = ({
   const location = useLocation();
   const getLocaleText = useLocaleText();
   const additionalEntrances = unit?.entrances?.filter(entrance => !entrance.is_main_entrance);
+  const subgroupContacts = unit?.connections?.filter(c => c.section_type === 'SUBGROUP');
 
   const address = {
     type: 'ADDRESS',
@@ -29,7 +30,7 @@ const ContactInfo = ({
   const phone = {
     type: 'PHONE',
     value: unit.phone ? { phone: unit.phone } : intl.formatMessage({ id: 'unit.phone.missing' }),
-    noDivider: unit.call_charge_info && unit.call_charge_info.fi !== 'pvm/mpm', // TODO: fix this hard coded value when unit data returns call charge boolean
+    noDivider: (unit.call_charge_info && unit.call_charge_info.fi !== 'pvm/mpm') || (subgroupContacts && subgroupContacts.length > 0), // TODO: fix this hard coded value when unit data returns call charge boolean
   };
   const email = {
     type: 'EMAIL',
@@ -114,6 +115,37 @@ const ContactInfo = ({
     ),
   };
 
+  const subgroups = {
+    component: subgroupContacts?.length > 0 && (
+      <React.Fragment key="entrances">
+        <ListItem className={classes.accordionItem}>
+          <SMAccordion
+            className={classes.accordionRoot}
+            disableUnmount
+            titleContent={<Typography><FormattedMessage id="unit.subgroup.title" /></Typography>}
+            collapseContent={(
+              <div className={classes.accordionContaianer}>
+                {subgroupContacts.map(subgroup => (
+                  subgroup.contact_person ? (
+                    <div key={subgroup.contact_person} className={classes.subgroupItem}>
+                      <Typography key={subgroup.contact_person}>
+                        {`${subgroup.contact_person}, ${getLocaleText(subgroup.name)}, `}
+                      </Typography>
+                      <a href={`tel:${subgroup.phone}`}>{subgroup.phone}</a>
+                    </div>
+                  ) : null
+                ))}
+              </div>
+              )}
+          />
+        </ListItem>
+        <li aria-hidden>
+          <Divider className={classes.dividerShort} />
+        </li>
+      </React.Fragment>
+    ),
+  };
+
   // For infomration that is in data's connections array, use unitSectionFilter
   const hours = unitSectionFilter(unit.connections, 'OPENING_HOURS');
   const contact = unitSectionFilter(unit.connections, 'PHONE_OR_EMAIL');
@@ -124,6 +156,7 @@ const ContactInfo = ({
     address,
     entrances,
     phone,
+    subgroups,
     callInformation,
     email,
     website,

--- a/src/views/UnitView/styles/styles.js
+++ b/src/views/UnitView/styles/styles.js
@@ -154,4 +154,7 @@ export default theme => ({
   callInfoText: {
     whiteSpace: 'pre-line',
   },
+  subgroupItem: {
+    marginBottom: theme.spacing(2),
+  },
 });


### PR DESCRIPTION
Add new kindergarten group contacts.  Data is part of connections with type "SUBGROUP" These were not shown previously but this PR introduces UI changes to show this data. Since subgroups are not necessarily kindergarten only data we've changed the text to be more generic in case someone adds subgroups for other services.
