### PR TITLE
Add info text to describe service tree functionality for user

### DIFF
--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -556,7 +556,7 @@ const translations = {
   'services.search.sr.selected': 'Perform search with services: {services}',
   'services.category.select': 'All',
   'services.category.open': 'Open category',
-  'services.info': 'Before you can perform a search you must choose atleast one search criteria from service tree',
+  'services.info': 'Before you can perform a search you must choose at least one service from services list below.',
   'services.tree.level': 'Level',
 
   // Settings

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -556,6 +556,7 @@ const translations = {
   'services.search.sr.selected': 'Perform search with services: {services}',
   'services.category.select': 'All',
   'services.category.open': 'Open category',
+  'services.info': 'Before you can perform a search you must choose atleast one search criteria from service tree',
   'services.tree.level': 'Level',
 
   // Settings

--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -559,6 +559,7 @@ const translations = {
   'services.search.sr.selected': 'Tee haku palveluilla: {services}',
   'services.category.select': 'Kaikki',
   'services.category.open': 'Avaa kategoria',
+  'services.info': 'Valitse vähintään yksi hakuehto palvelupuusta, että voit suorittaa haun',
   'services.tree.level': 'Taso',
 
   // Settings

--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -559,7 +559,7 @@ const translations = {
   'services.search.sr.selected': 'Tee haku palveluilla: {services}',
   'services.category.select': 'Kaikki',
   'services.category.open': 'Avaa kategoria',
-  'services.info': 'Valitse vähintään yksi hakuehto palvelupuusta, että voit suorittaa haun',
+  'services.info': 'Valitse vähintään yksi palvelu alla olevasta palveluluettelosta, että voit suorittaa haun.',
   'services.tree.level': 'Taso',
 
   // Settings

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -557,6 +557,7 @@ const translations = {
   'services.search.sr.selected': 'Sök med tjänsterna: {services}',
   'services.category.select': 'Alla',
   'services.category.open': 'Öppna kategori',
+  'services.info': 'Before you can perform a search you must choose atleast one search criteria from service tree', // TODO translate
   'services.tree.level': 'Nivå',
 
   // Settings

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -557,7 +557,7 @@ const translations = {
   'services.search.sr.selected': 'Sök med tjänsterna: {services}',
   'services.category.select': 'Alla',
   'services.category.open': 'Öppna kategori',
-  'services.info': 'Before you can perform a search you must choose atleast one search criteria from service tree', // TODO translate
+  'services.info': 'Välj minst en tjänst från listan över tjänster nedan som du kan utföra sökningen.',
   'services.tree.level': 'Nivå',
 
   // Settings

--- a/src/views/ServiceTreeView/ServiceTreeView.js
+++ b/src/views/ServiceTreeView/ServiceTreeView.js
@@ -448,6 +448,7 @@ const ServiceTreeView = (props) => {
         {renderSelectionList(selectedList)}
       </div>
       <div className={classes.mainContent}>
+        <Typography className={classes.guidanceInfoText} variant="body2">{intl.formatMessage({ id: 'services.info' })}</Typography>
         {renderSearchButton(selectedList)}
         {renderServiceNodeList()}
       </div>

--- a/src/views/ServiceTreeView/styles.js
+++ b/src/views/ServiceTreeView/styles.js
@@ -64,6 +64,10 @@ export default theme => ({
   checkboxFocus: {
     boxShadow: `inset 0 0 0 4px ${theme.palette.primary.main} !important`,
   },
+  guidanceInfoText: {
+    margin: `${theme.spacing(2)} ${theme.spacing(3)}`,
+    marginBottom: 0,
+  },
   outerLines: {
     height: '100%',
     width: 26,


### PR DESCRIPTION
There is an issue with user not having understanding of how service tree is supposed to work. So we've added an info text to describe in short how the service tree view is used. This should improve screen reader accessibility as well since user gets information about why search button is disable initially.