### PR TITLE
Refactor jest providers to single file

### DIFF
--- a/jestUtils.js
+++ b/jestUtils.js
@@ -13,6 +13,7 @@ const mockStore = configureStore([]);
 const intlMock = {
   locale: 'en',
   messages: english,
+  wrapRichTextChunksInFragment: false,
 };
 
 const Providers = (mockState) => ({ children }) => {

--- a/src/components/FocusableSRLinks/__tests__/FocusableSRLinks.test.js
+++ b/src/components/FocusableSRLinks/__tests__/FocusableSRLinks.test.js
@@ -1,10 +1,9 @@
 // Link.react.test.js
 import React from 'react';
-import { render } from '@testing-library/react';
-import { ThemeProvider } from '@mui/material/styles';
-import { IntlProvider, FormattedMessage } from 'react-intl';
-import themes from '../../../themes';
+import { FormattedMessage } from 'react-intl';
 import FocusableSRLinks from '../index';
+import { getRenderWithProviders } from '../../../../jestUtils';
+import englishTranslations from '../../../i18n/en';
 
 // Generic required props for SimpleListItem
 const mockProps = {
@@ -16,24 +15,7 @@ const mockProps = {
   ],
 };
 
-// Mock props for intl provider
-const intlMock = {
-  locale: 'en',
-  messages: {
-    'fm.test': 'FM test text',
-  },
-};
-
-// eslint-disable-next-line react/prop-types
-const Providers = ({ children }) => (
-  <IntlProvider {...intlMock}>
-    <ThemeProvider theme={themes.SMTheme}>
-      {children}
-    </ThemeProvider>
-  </IntlProvider>
-);
-
-const renderWithProviders = component => render(component, { wrapper: Providers });
+const renderWithProviders = getRenderWithProviders({});
 
 describe('<FocusableSRLinks />', () => {
   it('should work', () => {
@@ -49,7 +31,7 @@ describe('<FocusableSRLinks />', () => {
           items={[
             {
               href: '#test-href',
-              text: <FormattedMessage id="fm.test" />,
+              text: <FormattedMessage id="app.title" />,
             },
           ]}
         />
@@ -57,7 +39,7 @@ describe('<FocusableSRLinks />', () => {
     );
 
     expect(getByText(mockProps.items[0].text, { selector: 'a' }).text).toEqual(mockProps.items[0].text);
-    expect(getByText(intlMock.messages['fm.test'], { selector: 'a' }).text).toEqual(intlMock.messages['fm.test']);
+    expect(getByText(englishTranslations['app.title'], { selector: 'a' }).text).toEqual(englishTranslations['app.title']);
   });
 
   it('does set href correctly', () => {

--- a/src/components/ListItems/ResultItem/__tests__/ResultItem.test.js
+++ b/src/components/ListItems/ResultItem/__tests__/ResultItem.test.js
@@ -1,12 +1,9 @@
 // Link.react.test.js
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react';
-import { ThemeProvider } from '@mui/material/styles';
-import { Provider } from 'react-redux';
-import configureStore from 'redux-mock-store';
-import themes from '../../../../themes';
+import { fireEvent } from '@testing-library/react';
 import ResultItem from '../index';
 import { initialState } from '../../../../redux/reducers/user';
+import { getRenderWithProviders } from '../../../../../jestUtils';
 
 // Generic required props for ResultItem
 const mockProps = {
@@ -19,23 +16,9 @@ const mockProps = {
   subtitle: 'Subtitle text',
 };
 
-const mockStore = configureStore([]);
-
-// eslint-disable-next-line react/prop-types
-const Providers = ({ children }) => {
-  const store = mockStore({
-    user: initialState,
-  });
-  return (
-    <Provider store={store}>
-      <ThemeProvider theme={themes.SMTheme}>
-        {children}
-      </ThemeProvider>
-    </Provider>
-  );
-};
-
-const renderWithProviders = component => render(component, { wrapper: Providers });
+const renderWithProviders = getRenderWithProviders({
+  user: initialState,
+});
 
 describe('<ResultItem />', () => {
   it('should work', () => {

--- a/src/components/ListItems/SimpleListItem/__tests__/SimpleListItem.test.js
+++ b/src/components/ListItems/SimpleListItem/__tests__/SimpleListItem.test.js
@@ -1,23 +1,15 @@
 // Link.react.test.js
 import React from 'react';
-import { ThemeProvider } from '@mui/material/styles';
-import { fireEvent, render } from '@testing-library/react';
-import themes from '../../../../themes';
+import { fireEvent } from '@testing-library/react';
 import SimpleListItem from '../index';
+import { getRenderWithProviders } from '../../../../../jestUtils';
 
 // Generic required props for SimpleListItem
 const mockProps = {
   text: 'Title text',
 };
 
-// eslint-disable-next-line react/prop-types
-const Providers = ({ children }) => (
-  <ThemeProvider theme={themes.SMTheme}>
-    {children}
-  </ThemeProvider>
-);
-
-const renderWithProviders = component => render(component, { wrapper: Providers });
+const renderWithProviders = getRenderWithProviders({});
 
 describe('<SimpleListItem />', () => {
   it('should work', () => {

--- a/src/components/ListItems/SuggestionItem/__tests__/SuggestionItem.test.js
+++ b/src/components/ListItems/SuggestionItem/__tests__/SuggestionItem.test.js
@@ -1,20 +1,9 @@
 // // Link.react.test.js
 import React from 'react';
-import { ThemeProvider } from '@mui/material/styles';
-import { IntlProvider } from 'react-intl';
 import { Search } from '@mui/icons-material';
-import { fireEvent, render } from '@testing-library/react';
-import themes from '../../../../themes';
+import { fireEvent } from '@testing-library/react';
 import SuggestionItem from '../index';
-
-// Mock props for intl provider
-const intlMock = {
-  locale: 'en',
-  messages: {
-    'search.arrowLabel': 'Arrow button label',
-  },
-  wrapRichTextChunksInFragment: false,
-};
+import { getRenderWithProviders } from '../../../../../jestUtils';
 
 // Generic required props for SimpleListItem
 const mockProps = {
@@ -23,16 +12,7 @@ const mockProps = {
   icon: <Search />,
 };
 
-// eslint-disable-next-line react/prop-types
-const Providers = ({ children }) => (
-  <IntlProvider {...intlMock}>
-    <ThemeProvider theme={themes.SMTheme}>
-      {children}
-    </ThemeProvider>
-  </IntlProvider>
-);
-
-const renderWithProviders = component => render(component, { wrapper: Providers });
+const renderWithProviders = getRenderWithProviders({});
 
 describe('<SuggestionItem />', () => {
   it('should work', () => {

--- a/src/components/Lists/ResultList/__tests__/ResultList.test.js
+++ b/src/components/Lists/ResultList/__tests__/ResultList.test.js
@@ -1,13 +1,8 @@
 // Link.react.test.js
 import React from 'react';
-import { ThemeProvider } from '@mui/material/styles';
-import { IntlProvider } from 'react-intl';
-import { Provider } from 'react-redux';
-import configureStore from 'redux-mock-store';
-import { render } from '@testing-library/react';
-import themes from '../../../../themes';
 import ResultList from '../ResultList';
 import { initialState } from '../../../../redux/reducers/user';
+import { getRenderWithProviders } from '../../../../../jestUtils';
 
 const mockData = [
   {
@@ -53,36 +48,10 @@ const mockProps = {
   titleComponent: 'h3',
 };
 
-// Mock props for intl provider
-const intlMock = {
-  locale: 'en',
-  messages: {
-    'search.resultList': 'Search result text',
-    'general.pagination.pageCount': 'Page {current} of {max}',
-  },
-};
-
-const mockStore = configureStore([]);
-
-// eslint-disable-next-line react/prop-types
-const Providers = ({ children }) => {
-  const store = mockStore({
-    user: initialState,
-    settings: {},
-  });
-
-  return (
-    <Provider store={store}>
-      <IntlProvider {...intlMock}>
-        <ThemeProvider theme={themes.SMTheme}>
-          {children}
-        </ThemeProvider>
-      </IntlProvider>
-    </Provider>
-  );
-};
-
-const renderWithProviders = component => render(component, { wrapper: Providers });
+const renderWithProviders = getRenderWithProviders({
+  user: initialState,
+  settings: {},
+});
 
 describe('<ResultList />', () => {
   it('should work', () => {

--- a/src/components/Lists/ResultList/__tests__/__snapshots__/ResultList.test.js.snap
+++ b/src/components/Lists/ResultList/__tests__/__snapshots__/ResultList.test.js.snap
@@ -18,7 +18,7 @@ exports[`<ResultList /> should work 1`] = `
           class="MuiTypography-root MuiTypography-caption css-r3hlsg-MuiTypography-root"
           id="testID-result-title-info"
         >
-          Search result text
+          5 matches
         </p>
       </div>
     </div>

--- a/src/components/PaginationComponent/__tests__/PageElement.test.js
+++ b/src/components/PaginationComponent/__tests__/PageElement.test.js
@@ -1,10 +1,8 @@
 // Link.react.test.js
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react';
-import { ThemeProvider } from '@mui/material/styles';
-import { IntlProvider } from 'react-intl';
-import themes from '../../../themes';
+import { fireEvent } from '@testing-library/react';
 import PageElement from '../PageElement';
+import { getRenderWithProviders } from '../../../../jestUtils';
 
 // Mock props for intl provider
 const intlMock = {
@@ -23,16 +21,7 @@ const mockProps = {
   isActive: false,
 };
 
-// eslint-disable-next-line react/prop-types
-const Providers = ({ children }) => (
-  <IntlProvider {...intlMock}>
-    <ThemeProvider theme={themes.SMTheme}>
-      {children}
-    </ThemeProvider>
-  </IntlProvider>
-);
-
-const renderWithProviders = component => render(component, { wrapper: Providers });
+const renderWithProviders = getRenderWithProviders({});
 
 describe('<PageElement />', () => {
   it('should work', () => {
@@ -103,7 +92,7 @@ describe('<PageElement />', () => {
       />,
     );
 
-    expect(container.querySelectorAll('p')[1]).toHaveTextContent(`Sivu ${mockProps.number}, avattu`);
+    expect(container.querySelectorAll('p')[1]).toHaveTextContent(`Page ${mockProps.number} currently opened`);
 
     // Expect element to have tabIndex -1
     expect(getByRole('link')).toHaveAttribute('tabindex', '-1');

--- a/src/components/PaginationComponent/__tests__/PaginationComponent.test.js
+++ b/src/components/PaginationComponent/__tests__/PaginationComponent.test.js
@@ -1,10 +1,9 @@
 // Link.react.test.js
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react';
-import { ThemeProvider } from '@mui/material/styles';
-import { IntlProvider } from 'react-intl';
-import themes from '../../../themes';
+import { fireEvent } from '@testing-library/react';
 import PaginationComponent from '../index';
+import { getRenderWithProviders } from '../../../../jestUtils';
+import englishTranslations from '../../../i18n/en';
 
 // Mock props for intl provider
 const intlMock = {
@@ -26,16 +25,7 @@ const mockProps = {
   pageCount: 8,
 };
 
-// eslint-disable-next-line react/prop-types
-const Providers = ({ children }) => (
-  <IntlProvider {...intlMock}>
-    <ThemeProvider theme={themes.SMTheme}>
-      {children}
-    </ThemeProvider>
-  </IntlProvider>
-);
-
-const renderWithProviders = component => render(component, { wrapper: Providers });
+const renderWithProviders = getRenderWithProviders({});
 
 describe('<PaginationComponent />', () => {
   it('should work', () => {
@@ -68,17 +58,17 @@ describe('<PaginationComponent />', () => {
     const buttons = getAllByRole('link');
 
     // Test previous page button accessibility
-    expect(buttons[0]).toHaveAttribute('aria-label', intlMock.messages['general.pagination.previous']);
+    expect(buttons[0]).toHaveAttribute('aria-label', englishTranslations['general.pagination.previous']);
     expect(buttons[0]).toBeDisabled();
     expect(buttons[0]).toHaveAttribute('role', 'link');
     // Test next page button accessibility
-    expect(buttons[1]).toHaveAttribute('aria-label', intlMock.messages['general.pagination.next']);
+    expect(buttons[1]).toHaveAttribute('aria-label', englishTranslations['general.pagination.next']);
     expect(buttons[1]).not.toBeDisabled();
     expect(buttons[1]).toHaveAttribute('role', 'link');
 
     // Expect page 1 button to have opened text
-    expect(buttons[2].querySelectorAll('p')[1]).toHaveTextContent('Sivu 1, avattu');
+    expect(buttons[2].querySelectorAll('p')[1]).toHaveTextContent('Page 1 currently opened');
     // expect page 2 button to have open new page text
-    expect(buttons[3].querySelectorAll('p')[1]).toHaveTextContent('Avaa sivu 2');
+    expect(buttons[3].querySelectorAll('p')[1]).toHaveTextContent('Open page 2');
   });
 });

--- a/src/components/PaginationComponent/__tests__/__snapshots__/PaginationComponent.test.js.snap
+++ b/src/components/PaginationComponent/__tests__/__snapshots__/PaginationComponent.test.js.snap
@@ -6,7 +6,7 @@ exports[`<PaginationComponent /> should work 1`] = `
     class="Container-root-11    injectIntl(PaginationComponent)-buttonContainer-5"
   >
     <button
-      aria-label="Aiempi sivu"
+      aria-label="Previous page"
       class="MuiButtonBase-root SMButton SMButton-button-16  SMButton-marginRight-19 injectIntl(PaginationComponent)-button-4 injectIntl(PaginationComponent)-arrowFlip-2 injectIntl(PaginationComponent)-borderBlack-3 SMButton-primary-20 css-fvdnvy-MuiButtonBase-root"
       role="link"
       tabindex="0"
@@ -26,7 +26,7 @@ exports[`<PaginationComponent /> should work 1`] = `
       </svg>
     </button>
     <button
-      aria-label="Seuraava sivu"
+      aria-label="Next page"
       class="MuiButtonBase-root SMButton SMButton-button-16  SMButton-marginRight-19 injectIntl(PaginationComponent)-button-4 injectIntl(PaginationComponent)-borderBlack-3 SMButton-primary-20 css-fvdnvy-MuiButtonBase-root"
       role="link"
       tabindex="0"
@@ -65,7 +65,7 @@ exports[`<PaginationComponent /> should work 1`] = `
                 class="MuiTypography-root MuiTypography-body2 css-1ak20dk-MuiTypography-root"
                 style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; white-space: nowrap; width: 1px;"
               >
-                Avaa sivu 1
+                Open page 1
               </p>
               <span
                 aria-hidden="true"
@@ -90,7 +90,7 @@ exports[`<PaginationComponent /> should work 1`] = `
                 class="MuiTypography-root MuiTypography-body2 css-1ak20dk-MuiTypography-root"
                 style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; white-space: nowrap; width: 1px;"
               >
-                Sivu 2, avattu
+                Page 2 currently opened
               </p>
               <span
                 aria-hidden="true"
@@ -114,7 +114,7 @@ exports[`<PaginationComponent /> should work 1`] = `
                 class="MuiTypography-root MuiTypography-body2 css-1ak20dk-MuiTypography-root"
                 style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; white-space: nowrap; width: 1px;"
               >
-                Avaa sivu 3
+                Open page 3
               </p>
               <span
                 aria-hidden="true"
@@ -138,7 +138,7 @@ exports[`<PaginationComponent /> should work 1`] = `
                 class="MuiTypography-root MuiTypography-body2 css-1ak20dk-MuiTypography-root"
                 style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; white-space: nowrap; width: 1px;"
               >
-                Avaa sivu 4
+                Open page 4
               </p>
               <span
                 aria-hidden="true"
@@ -162,7 +162,7 @@ exports[`<PaginationComponent /> should work 1`] = `
                 class="MuiTypography-root MuiTypography-body2 css-1ak20dk-MuiTypography-root"
                 style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; white-space: nowrap; width: 1px;"
               >
-                Avaa sivu 5
+                Open page 5
               </p>
               <span
                 aria-hidden="true"

--- a/src/components/PaperButton/__tests__/PaperButton.test.js
+++ b/src/components/PaperButton/__tests__/PaperButton.test.js
@@ -1,41 +1,11 @@
 // Link.react.test.js
 import React from 'react';
-import { ThemeProvider } from '@mui/material/styles';
-import { fireEvent, render } from '@testing-library/react';
-import { IntlProvider } from 'react-intl';
-import { Provider } from 'react-redux';
-import configureStore from 'redux-mock-store';
-import themes, { paletteDefault } from '../../../themes';
+import { fireEvent } from '@testing-library/react';
 import { initialState } from '../../../redux/reducers/user';
-import finnishTranslations from '../../../i18n/fi';
+import englishTranslations from '../../../i18n/en';
 import PaperButton from '../index';
 import { getIcon } from '../../SMIcon';
-
-// Mock props for intl provider
-const intlMock = {
-  locale: 'fi',
-  messages: finnishTranslations,
-};
-
-const mockStore = configureStore([]);
-
-// eslint-disable-next-line react/prop-types
-const Providers = ({ children }) => {
-  const store = mockStore({
-    user: initialState,
-    settings: {},
-  });
-
-  return (
-    <Provider store={store}>
-      <IntlProvider {...intlMock}>
-        <ThemeProvider theme={themes.SMTheme}>
-          {children}
-        </ThemeProvider>
-      </IntlProvider>
-    </Provider>
-  );
-};
+import { getRenderWithProviders } from '../../../../jestUtils';
 
 const paperButtonProps = {
   messageID: "home.buttons.closeByServices",
@@ -45,7 +15,10 @@ const paperButtonProps = {
   subtitleID: "location.notAllowed",
 };
 
-const renderWithProviders = component => render(component, { wrapper: Providers });
+const renderWithProviders = getRenderWithProviders({
+  user: initialState,
+  settings: {},
+});
 
 describe('<PaperButton />', () => {
   it('should work', () => {
@@ -76,7 +49,7 @@ describe('<PaperButton />', () => {
     expect(buttonBase).toHaveAttribute('tabindex', '0');
     // Expect aria label
     const ariaLabel = buttonBase.getAttribute('aria-label')
-    expect(ariaLabel).toContain(finnishTranslations['home.buttons.closeByServices']);
+    expect(ariaLabel).toContain(englishTranslations['home.buttons.closeByServices']);
   });
 
   if('does render given accessibility attributes correctly', () => {

--- a/src/components/PaperButton/__tests__/__snapshots__/PaperButton.test.js.snap
+++ b/src/components/PaperButton/__tests__/__snapshots__/PaperButton.test.js.snap
@@ -6,7 +6,7 @@ exports[`<PaperButton /> should work 1`] = `
     class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 Container-root-9 Container-margin-11   SM-PaperButton PaperButton-container-1    css-1ps6pg7-MuiPaper-root"
   >
     <button
-      aria-label="Näytä lähellä olevat palvelut Sijaintia ei sallittu "
+      aria-label="Show nearby services Location not allowed "
       class="MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButtonBase-root PaperButton-iconButton-3 css-1p2nkht-MuiButtonBase-root-MuiButton-root"
       role="link"
       tabindex="0"
@@ -58,13 +58,13 @@ exports[`<PaperButton /> should work 1`] = `
           aria-hidden="true"
           class="MuiTypography-root MuiTypography-body2 PaperButton-text-7 css-1ak20dk-MuiTypography-root"
         >
-          Näytä lähellä olevat palvelut
+          Show nearby services
         </p>
         <span
           aria-hidden="true"
           class="MuiTypography-root MuiTypography-caption PaperButton-text-7 css-r3hlsg-MuiTypography-root"
         >
-          Sijaintia ei sallittu
+          Location not allowed
         </span>
       </div>
     </button>

--- a/src/components/SMRadio/__tests__/SMRadio.test.js
+++ b/src/components/SMRadio/__tests__/SMRadio.test.js
@@ -1,9 +1,7 @@
 // // Link.react.test.js
 import React from 'react';
-import { render } from '@testing-library/react';
-import { ThemeProvider } from '@mui/material/styles';
-import themes from '../../../themes';
 import SMRadio from '../index';
+import { getRenderWithProviders } from '../../../../jestUtils';
 
 // Generic required props for SimpleListItem
 const mockProps = {
@@ -17,14 +15,7 @@ const mockProps = {
   onChange: () => {},
 };
 
-// eslint-disable-next-line react/prop-types
-const Providers = ({ children }) => (
-  <ThemeProvider theme={themes.SMTheme}>
-    {children}
-  </ThemeProvider>
-);
-
-const renderWithProviders = component => render(component, { wrapper: Providers });
+const renderWithProviders = getRenderWithProviders({});
 
 describe('<SMRadio />', () => {
   it('should work', () => {

--- a/src/components/SearchBar/components/__tests__/CloseSuggestionButton.test.js
+++ b/src/components/SearchBar/components/__tests__/CloseSuggestionButton.test.js
@@ -1,20 +1,10 @@
 // CloseSuggestionButton.test.js
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react';
-import { ThemeProvider } from '@mui/material/styles';
-import { IntlProvider } from 'react-intl';
+import { fireEvent } from '@testing-library/react';
 import { ArrowDownward } from '@mui/icons-material';
-import themes from '../../../../themes';
 import { CloseSuggestionButton } from '../CloseSuggestionButton';
-
-// Mock props for intl provider
-const intlMock = {
-  locale: 'en',
-  messages: {
-    'search.suggestions.hideButton': 'Hide the list of suggestions',
-  },
-  wrapRichTextChunksInFragment: false,
-};
+import { getRenderWithProviders } from '../../../../../jestUtils';
+import englishTranslations from '../../../../i18n/en';
 
 // Generic required props for ResultItem
 const mockProps = {
@@ -25,16 +15,7 @@ const mockProps = {
   srOnly: false,
 };
 
-// eslint-disable-next-line react/prop-types
-const Providers = ({ children }) => (
-  <IntlProvider {...intlMock}>
-    <ThemeProvider theme={themes.SMTheme}>
-      {children}
-    </ThemeProvider>
-  </IntlProvider>
-);
-
-const renderWithProviders = component => render(component, { wrapper: Providers });
+const renderWithProviders = getRenderWithProviders({});
 
 describe('<CloseSuggestionButton />', () => {
   it('should work', () => {
@@ -95,7 +76,7 @@ describe('<CloseSuggestionButton />', () => {
   it('does show text correctly', () => {
     const { container } = renderWithProviders(<CloseSuggestionButton {...mockProps} />);
 
-    expect(container.querySelector('p')).toHaveTextContent(`${intlMock.messages['search.suggestions.hideButton']}`);
+    expect(container.querySelector('p')).toHaveTextContent(`${englishTranslations['search.suggestions.hideButton']}`);
   });
 
   it('does use accessibility attributes correctly', () => {

--- a/src/components/ServiceMapButton/__tests__/ServiceMapButton.test.js
+++ b/src/components/ServiceMapButton/__tests__/ServiceMapButton.test.js
@@ -1,19 +1,9 @@
 // Link.react.test.js
 import React from 'react';
-import { IntlProvider } from 'react-intl';
-import { fireEvent, render } from '@testing-library/react';
-import { ThemeProvider } from '@mui/material/styles';
+import { fireEvent } from '@testing-library/react';
 import ServiceMapButton from '../index';
-import themes from '../../../themes';
-
-// Mock props for intl provider
-const intlMock = {
-  locale: 'en',
-  messages: {
-    'button.text': 'Button text',
-  },
-  wrapRichTextChunksInFragment: false,
-};
+import { getRenderWithProviders } from '../../../../jestUtils';
+import englishTranslations from '../../../i18n/en';
 
 // Generic required props for ServiceMapButton
 const buttonMockProps = {
@@ -21,16 +11,7 @@ const buttonMockProps = {
   role: 'button',
 };
 
-// eslint-disable-next-line react/prop-types
-const Providers = ({ children }) => (
-  <IntlProvider {...intlMock}>
-    <ThemeProvider theme={themes.SMTheme}>
-      {children}
-    </ThemeProvider>
-  </IntlProvider>
-);
-
-const renderWithProviders = component => render(component, { wrapper: Providers });
+const renderWithProviders = getRenderWithProviders({});
 
 describe('<ServiceMapButton />', () => {
   it('should work', () => {
@@ -49,9 +30,9 @@ describe('<ServiceMapButton />', () => {
 
   it('does show text using intl message id', () => {
     const { getByRole } = renderWithProviders(
-      <ServiceMapButton {...buttonMockProps} messageID="button.text" />,
+      <ServiceMapButton {...buttonMockProps} messageID="app.title" />,
     );
-    expect(getByRole('button')).toHaveTextContent(intlMock.messages['button.text']);
+    expect(getByRole('button')).toHaveTextContent(englishTranslations['app.title']);
   });
 
   it('simulates click event', () => {
@@ -70,17 +51,17 @@ describe('<ServiceMapButton />', () => {
     const { getByRole } = renderWithProviders(
       <ServiceMapButton
         {...buttonMockProps}
-        messageID="button.text"
+        messageID="app.title"
       />,
     );
     const buttonBase = getByRole('button');
     const p = buttonBase.querySelector('p');
     // Expect aria-label to be same as given text
-    expect(buttonBase).toHaveAttribute('aria-label', intlMock.messages['button.text']);
+    expect(buttonBase).toHaveAttribute('aria-label', englishTranslations['app.title']);
     // Expect visible text to be hidden from screen readers
     expect(p).toHaveAttribute('aria-hidden', 'true');
     // Expect visible text to be same as aria-label
-    expect(p).toHaveTextContent(intlMock.messages['button.text']);
+    expect(p).toHaveTextContent(englishTranslations['app.title']);
   });
 
   it('does use given accessibility attributes correctly', () => {

--- a/src/components/ToolMenu/MeasuringStopButton/__tests__/MeasuringStopButton.test.js
+++ b/src/components/ToolMenu/MeasuringStopButton/__tests__/MeasuringStopButton.test.js
@@ -1,29 +1,12 @@
 // Link.react.test.js
 import React from 'react';
-import { IntlProvider } from 'react-intl';
-import { fireEvent, render } from '@testing-library/react';
-import { ThemeProvider } from '@mui/material/styles';
+import { fireEvent } from '@testing-library/react';
 import MeasuringStopButton from '../index';
-import themes from '../../../../themes';
-import finnishTranslations from '../../../../i18n/fi';
+import { getRenderWithProviders } from '../../../../../jestUtils';
+import englishTranslations from '../../../../i18n/en';
 
-// Mock props for intl provider
-const intlMock = {
-  locale: 'fi',
-  messages: finnishTranslations,
-  wrapRichTextChunksInFragment: false,
-};
 
-// eslint-disable-next-line react/prop-types
-const Providers = ({ children }) => (
-  <IntlProvider {...intlMock}>
-    <ThemeProvider theme={themes.SMTheme}>
-      {children}
-    </ThemeProvider>
-  </IntlProvider>
-);
-
-const renderWithProviders = component => render(component, { wrapper: Providers });
+const renderWithProviders = getRenderWithProviders({});
 
 describe('<MeasuringStopButton />', () => {
   it('should work', () => {
@@ -50,7 +33,7 @@ describe('<MeasuringStopButton />', () => {
     );
     const buttonBase = getByRole('button');
     const p = buttonBase.querySelector('p');
-    const contentText = finnishTranslations['tool.measuring.stop'];
+    const contentText = englishTranslations['tool.measuring.stop'];
     // Expect aria-label to be same as text content
     expect(buttonBase).toHaveAttribute('aria-label', contentText);
     // Expect aria-hidden to be false Eficode report 05-2022 page 47

--- a/src/components/ToolMenu/MeasuringStopButton/__tests__/__snapshots__/MeasuringStopButton.test.js.snap
+++ b/src/components/ToolMenu/MeasuringStopButton/__tests__/__snapshots__/MeasuringStopButton.test.js.snap
@@ -3,7 +3,7 @@
 exports[`<MeasuringStopButton /> should work 1`] = `
 <div>
   <button
-    aria-label="Lopeta mittaus"
+    aria-label="Stop measuring"
     class="MuiButtonBase-root SMButton SMButton-button-7  SMButton-marginRight-10 MeasuringStopButtonComponent-measuringButton-6 SMButton-primary-11 css-fvdnvy-MuiButtonBase-root"
     id="MeasuringStopButton"
     role="button"
@@ -15,7 +15,7 @@ exports[`<MeasuringStopButton /> should work 1`] = `
       aria-hidden="true"
       class="MuiTypography-root MuiTypography-caption SMButton-typography-14 css-o763o0-MuiTypography-root"
     >
-      Lopeta mittaus
+      Stop measuring
     </p>
   </button>
 </div>

--- a/src/components/TopBar/DrawerMenu/__tests__/DrawerButton.test.js
+++ b/src/components/TopBar/DrawerMenu/__tests__/DrawerButton.test.js
@@ -1,10 +1,9 @@
 // Link.react.test.js
 import React from 'react';
-import { ThemeProvider } from '@mui/material/styles';
 import { Search } from '@mui/icons-material';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
 import DrawerButton from '../DrawerButton';
-import themes from '../../../../themes';
+import { getRenderWithProviders } from '../../../../../jestUtils';
 
 // Generic required props for ServiceMapButton
 const buttonMockProps = {
@@ -18,14 +17,7 @@ const buttonMockProps = {
   subText: 'Drawer button subtext',
 };
 
-// eslint-disable-next-line react/prop-types
-const Providers = ({ children }) => (
-  <ThemeProvider theme={themes.SMTheme}>
-    {children}
-  </ThemeProvider>
-);
-
-const renderWithProviders = component => render(component, { wrapper: Providers });
+const renderWithProviders = getRenderWithProviders({});
 
 describe('<DrawerButton />', () => {
   it('should work', () => {

--- a/src/components/TopBar/LanguageMenu/__tests__/LanguageMenu.test.js
+++ b/src/components/TopBar/LanguageMenu/__tests__/LanguageMenu.test.js
@@ -1,42 +1,13 @@
 // Link.react.test.js
 import React from 'react';
-import { ThemeProvider } from '@mui/material/styles';
-import { render } from '@testing-library/react';
-import { IntlProvider } from 'react-intl';
-import { Provider } from 'react-redux';
-import configureStore from 'redux-mock-store';
-import themes from '../../../../themes';
 import LanguageMenu from '../index';
 import { initialState } from '../../../../redux/reducers/user';
-import finnishTranslations from '../../../../i18n/fi';
+import { getRenderWithProviders } from '../../../../../jestUtils';
 
-// Mock props for intl provider
-const intlMock = {
-  locale: 'fi',
-  messages: finnishTranslations,
-};
-
-const mockStore = configureStore([]);
-
-// eslint-disable-next-line react/prop-types
-const Providers = ({ children }) => {
-  const store = mockStore({
-    user: initialState,
-    settings: {},
-  });
-
-  return (
-    <Provider store={store}>
-      <IntlProvider {...intlMock}>
-        <ThemeProvider theme={themes.SMTheme}>
-          {children}
-        </ThemeProvider>
-      </IntlProvider>
-    </Provider>
-  );
-};
-
-const renderWithProviders = component => render(component, { wrapper: Providers });
+const renderWithProviders = getRenderWithProviders({
+  user: initialState,
+  settings: {},
+});
 
 describe('<LanguageMenu />', () => {
   it('does render default accessibility attributes correctly', () => {

--- a/src/components/TopBar/MenuButton/__tests__/MenuButton.test.js
+++ b/src/components/TopBar/MenuButton/__tests__/MenuButton.test.js
@@ -1,9 +1,7 @@
 import React from 'react';
-import { render } from '@testing-library/react';
-import { ThemeProvider } from '@mui/material/styles';
-import { IntlProvider } from 'react-intl';
-import themes from '../../../../themes';
 import MenuButton from '../MenuButton';
+import { getRenderWithProviders } from '../../../../../jestUtils';
+import englishTranslations from '../../../../i18n/en';
 
 
 const mockProps = {
@@ -12,23 +10,7 @@ const mockProps = {
   toggleDrawerMenu: () => {},
 };
 
-const intlMock = {
-  locale: 'en',
-  messages: {
-    'general.menu': 'Valikko',
-  },
-};
-
-// eslint-disable-next-line react/prop-types
-const Providers = ({ children }) => (
-  <IntlProvider {...intlMock}>
-    <ThemeProvider theme={themes.SMTheme}>
-      {children}
-    </ThemeProvider>
-  </IntlProvider>
-);
-
-const renderWithProviders = component => render(component, { wrapper: Providers });
+const renderWithProviders = getRenderWithProviders({});
 
 
 describe('<MenuButton />', () => {
@@ -44,10 +26,10 @@ describe('<MenuButton />', () => {
       The following aria-attributes are based on the accessibility testing report from 26.4.2021
     */
     // Expect button aria-haspopup value to be true
-    expect(getByLabelText('Valikko').getAttribute('aria-haspopup')).toEqual('true');
+    expect(getByLabelText(englishTranslations['general.menu']).getAttribute('aria-haspopup')).toEqual('true');
     // Expect button aria-label value to be Valikko
-    expect(getByLabelText('Valikko').getAttribute('aria-label')).toEqual('Valikko');
+    expect(getByLabelText(englishTranslations['general.menu']).getAttribute('aria-label')).toEqual(englishTranslations['general.menu']);
     // // Expect button aria-expanded value to be same as from props
-    expect(getByLabelText('Valikko').getAttribute('aria-expanded')).toEqual(`${mockProps.drawerOpen}`);
+    expect(getByLabelText(englishTranslations['general.menu']).getAttribute('aria-expanded')).toEqual(`${mockProps.drawerOpen}`);
   });
 });

--- a/src/components/TopBar/MenuButton/__tests__/__snapshots__/MenuButton.test.js.snap
+++ b/src/components/TopBar/MenuButton/__tests__/__snapshots__/MenuButton.test.js.snap
@@ -5,7 +5,7 @@ exports[`<MenuButton /> should work 1`] = `
   <button
     aria-expanded="false"
     aria-haspopup="true"
-    aria-label="Valikko"
+    aria-label="Menu"
     class="MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButtonBase-root undefined undefined css-1p2nkht-MuiButtonBase-root-MuiButton-root"
     id="MenuButton"
     tabindex="0"
@@ -25,7 +25,7 @@ exports[`<MenuButton /> should work 1`] = `
     <p
       class="MuiTypography-root MuiTypography-body2 css-q91igz-MuiTypography-root"
     >
-      Valikko
+      Menu
     </p>
   </button>
 </div>

--- a/src/components/TopBar/SMLogo/__tests__/SMLogo.test.js
+++ b/src/components/TopBar/SMLogo/__tests__/SMLogo.test.js
@@ -1,42 +1,15 @@
 // Link.react.test.js
 import React from 'react';
-import { ThemeProvider } from '@mui/material/styles';
-import { fireEvent, render } from '@testing-library/react';
-import { IntlProvider } from 'react-intl';
-import { Provider } from 'react-redux';
-import configureStore from 'redux-mock-store';
-import themes from '../../../../themes';
+import { fireEvent } from '@testing-library/react';
 import SMLogo from '../index';
 import { initialState } from '../../../../redux/reducers/user';
-import finnishTranslations from '../../../../i18n/fi';
+import { getRenderWithProviders } from '../../../../../jestUtils';
+import englishTranslations from '../../../../i18n/en';
 
-// Mock props for intl provider
-const intlMock = {
-  locale: 'fi',
-  messages: finnishTranslations,
-};
-
-const mockStore = configureStore([]);
-
-// eslint-disable-next-line react/prop-types
-const Providers = ({ children }) => {
-  const store = mockStore({
-    user: initialState,
-    settings: {},
-  });
-
-  return (
-    <Provider store={store}>
-      <IntlProvider {...intlMock}>
-        <ThemeProvider theme={themes.SMTheme}>
-          {children}
-        </ThemeProvider>
-      </IntlProvider>
-    </Provider>
-  );
-};
-
-const renderWithProviders = component => render(component, { wrapper: Providers });
+const renderWithProviders = getRenderWithProviders({
+  user: initialState,
+  settings: {},
+});
 
 describe('<SMLogo />', () => {
   it('should work', () => {
@@ -66,7 +39,7 @@ describe('<SMLogo />', () => {
     expect(buttonBase).toHaveAttribute('aria-current', 'page');
     // Home logo which is image should containe image text in aria label
     // so aria label should contain "Palvelukartta" text in addition to action description
-    expect(buttonBase).toHaveAttribute('aria-label', 'Palvelukartta - Siirry etusivulle');
+    expect(buttonBase).toHaveAttribute('aria-label', englishTranslations['general.home.logo.ariaLabel']);
     // Expect visible text to be hidden from screen readers
     expect(buttonBase.querySelector('div')).toHaveAttribute('aria-hidden', 'true');
     expect(buttonBase.querySelector('div')).toHaveAttribute('role', 'img');

--- a/src/components/TopBar/SMLogo/__tests__/__snapshots__/SMLogo.test.js.snap
+++ b/src/components/TopBar/SMLogo/__tests__/__snapshots__/SMLogo.test.js.snap
@@ -4,7 +4,7 @@ exports[`<SMLogo /> should work 1`] = `
 <div>
   <button
     aria-current="page"
-    aria-label="Palvelukartta - Siirry etusivulle"
+    aria-label="Servicemap - Go to home page"
     class="MuiButtonBase-root css-fvdnvy-MuiButtonBase-root"
     role="link"
     tabindex="0"

--- a/src/components/TopBar/SettingsButton/__tests__/SettingsButton.test.js
+++ b/src/components/TopBar/SettingsButton/__tests__/SettingsButton.test.js
@@ -1,12 +1,6 @@
 import React from 'react';
-import { render } from '@testing-library/react';
-import { ThemeProvider } from '@mui/material/styles';
-import configureStore from 'redux-mock-store';
-import { Provider } from 'react-redux';
 import SettingsButton from '../SettingsButton';
-import themes from '../../../../themes';
-import initialState from '../../../../redux/rootReducer';
-import { IntlProvider } from 'react-intl';
+import { getRenderWithProviders } from '../../../../../jestUtils';
 
 
 const mockProps = {
@@ -17,41 +11,16 @@ const mockProps = {
   onClick: () => {},
 };
 
-// Mock props for intl provider
-const intlMock = {
-  locale: 'en',
-  messages: {
-    'settings.city.all': 'Cities all',
-    'settings.citySettings': 'City settings',
+const renderWithProviders = getRenderWithProviders({
+  settings: {
+    visuallyImpaired: false,
+    colorblind: false,
+    hearingAid: false,
+    mapType: 'servicemap',
+    mobility: 'none',
+    cities: 'helsinki',
   },
-};
-
-const mockStore = configureStore([]);
-
-// eslint-disable-next-line react/prop-types
-const Providers = ({ children }) => {
-  const store = mockStore({
-    settings: {
-      visuallyImpaired: false,
-      colorblind: false,
-      hearingAid: false,
-      mapType: 'servicemap',
-      mobility: 'none',
-      cities: 'helsinki',
-    },
-  });
-  return (
-    <Provider store={store}>
-      <IntlProvider {...intlMock}>
-        <ThemeProvider theme={themes.SMTheme}>
-          {children}
-        </ThemeProvider>
-      </IntlProvider>
-    </Provider>
-  );
-};
-
-const renderWithProviders = component => render(component, { wrapper: Providers });
+});
 
 describe('<SettingsButton />', () => {
   it('should work', () => {

--- a/src/components/TopBar/SettingsButton/__tests__/__snapshots__/SettingsButton.test.js.snap
+++ b/src/components/TopBar/SettingsButton/__tests__/__snapshots__/SettingsButton.test.js.snap
@@ -17,12 +17,12 @@ exports[`<SettingsButton /> should work 1`] = `
     <p
       class="MuiTypography-root MuiTypography-subtitle1 SettingsText-title-1 css-dlbwt1-MuiTypography-root"
     >
-      City settings
+      City
     </p>
     <p
       class="MuiTypography-root MuiTypography-body2 SettingsTextCurrentSettings SettingsText-text-3 css-1ak20dk-MuiTypography-root"
     >
-      Cities all
+      Show all
     </p>
   </button>
 </div>


### PR DESCRIPTION
We had quite a bit duplicated code in jest tests. This PR moves Providers to single file and refactors jest test files to follow these changes. New solution uses same IntlProvider for each test which is using English locale. This means some tests had to be refactored to use English texts and updated snapshots.