### PR TITLE
Release v1.5.1

### DIFF
--- a/src/views/SearchView/SearchView.js
+++ b/src/views/SearchView/SearchView.js
@@ -172,19 +172,19 @@ const SearchView = (props) => {
       setServiceRedirect(null);
 
       // Fetch service_node for given old service data
-      dispatch(fetchRedirectService({ service: options.service }, (data) => {
-        // Success
-        if (data.service_node) {
-          // Need to stringify current search params for unit fetch
-          // Otherwise componentDidMount shouldFetch will compare previous searches incorrectly
-          delete options.service;
-          options.service_node = `${(options.service_node ? `${options.service_node},` : '')}${data.service_node}`;
+      // dispatch(fetchRedirectService({ service: options.service }, (data) => {
+      //   // Success
+      //   if (data.service_node) {
+      //     // Need to stringify current search params for unit fetch
+      //     // Otherwise componentDidMount shouldFetch will compare previous searches incorrectly
+      //     delete options.service;
+      //     options.service_node = `${(options.service_node ? `${options.service_node},` : '')}${data.service_node}`;
 
-          // Set serviceRedirect and fetch units
-          dispatch(fetchSearchResults(options));
-          setServiceRedirect(options.service_node);
-        }
-      }));
+      //     // Set serviceRedirect and fetch units
+      //     dispatch(fetchSearchResults(options));
+      //     setServiceRedirect(options.service_node);
+      //   }
+      // }));
       return true;
     }
     return false;


### PR DESCRIPTION
Hotfix: Fix looping service redirect
This was causing some embeds to infinitely loop since the url was giving 404 response and redirect handling wasn't handling this well. I've just commented the code until we can take a closer look at this.