### PR TITLE
New search embedded fixes (unit id list, events and addresses)

### DIFF
--- a/src/layouts/EmbedLayout.js
+++ b/src/layouts/EmbedLayout.js
@@ -231,7 +231,7 @@ const EmbedLayout = ({ intl }) => {
               )}
             />
             <Route
-              path="*/embed/address/:municipality/:street/:number/"
+              path="*/embed/address/:municipality/:street"
               render={() => (
                 <>
                   <PageHandler embed page="address" />

--- a/src/redux/actions/search.js
+++ b/src/redux/actions/search.js
@@ -38,6 +38,9 @@ const smFetch = (dispatch, options) => {
       smAPI.search(address, addressFetchOptions, true),
       smAPI.units(unitFetchOptions),
     ]);
+  } else if (options.id) {
+    const unitFetchOptions = { id: options.id };
+    results = smAPI.units(unitFetchOptions);
   }
 
   return results;
@@ -48,7 +51,11 @@ const fetchSearchResults = (options = null) => async (dispatch, getState) => {
   const searchFetchState = getState().searchResults;
   const { locale } = getState().user;
 
-  const searchQuery = options.q || options.address || options.service_node || options.service_id;
+  const searchQuery = options.q
+    || options.address
+    || options.service_node
+    || options.service_id
+    || options.id;
 
   if (searchFetchState.isFetching) {
     throw Error('Unable to fetch search results because previous fetch is still active');
@@ -66,8 +73,8 @@ const fetchSearchResults = (options = null) => async (dispatch, getState) => {
     if (options.q) {
       saveSearchToHistory(searchQuery, { object_type: 'searchHistory', text: searchQuery });
     }
-    // Handle service and sercice node results
-    if (options.service_node || options.service_id) {
+    // Handle unit results that have no object_type
+    if (options.service_node || options.service_id || options.id) {
       results.forEach((item) => {
         item.object_type = 'unit';
       });

--- a/src/utils/newFetch/HTTPClient.js
+++ b/src/utils/newFetch/HTTPClient.js
@@ -3,6 +3,7 @@ import config from '../../../config';
 
 export const hearingMapAPIName = 'hearingmap';
 export const serviceMapAPIName = 'servicemap';
+export const LinkedEventsAPIName = 'linkedEvens';
 
 export class APIFetchError extends Error {
   constructor(props) {
@@ -91,9 +92,29 @@ export default class HttpClient {
     return response.results;
   }
 
+  handleLinkedEventsResults = async (response, type) => {
+    if (type && type === 'count') {
+      return response.meta.count;
+    }
+    if (this.onProgressUpdate) {
+      this.onProgressUpdate(response.data.length, response.meta.count);
+    }
+    if (type && type === 'single') {
+      return response.data;
+    }
+    if (response.next) {
+      return this.fetchNext(response.meta.next, response.data);
+    }
+
+    return response.data;
+  }
+
   handleResults = async (response, type) => {
     if (this.apiName === serviceMapAPIName) {
       return this.handleServiceMapResults(response, type);
+    }
+    if (this.apiName === LinkedEventsAPIName) {
+      return this.handleLinkedEventsResults(response, type);
     }
 
     // Default to given response

--- a/src/utils/newFetch/LinkedEventsAPI.js
+++ b/src/utils/newFetch/LinkedEventsAPI.js
@@ -1,0 +1,30 @@
+import config from '../../../config';
+import HttpClient, { APIFetchError, LinkedEventsAPIName } from './HTTPClient';
+
+export default class LinkedEventsAPI extends HttpClient {
+  constructor() {
+    if (
+      typeof config?.eventsAPI?.root === 'string'
+      && config.eventsAPI.root.indexOf('undefined') !== -1
+    ) {
+      throw new APIFetchError('LindkedEventsAPIName baseURL missing');
+    }
+    super(config.eventsAPI.root, LinkedEventsAPIName);
+  }
+
+  eventsByKeyword = async (keyword) => {
+    if (typeof keyword !== 'string') {
+      throw new APIFetchError('LinkedEventsAPI: Invalid keyword provided to events fetch method');
+    }
+    const options = {
+      keyword,
+      type: 'event',
+      page_size: 300,
+      include: 'location,location.id',
+      start: 'today',
+      sort: 'end_time',
+    };
+
+    return this.getConcurrent('event', options);
+  }
+}

--- a/src/views/MapView/utils/useMapUnits.js
+++ b/src/views/MapView/utils/useMapUnits.js
@@ -106,7 +106,10 @@ const useMapUnits = () => {
     return [];
   }
 
-  const filteredUnits = searchResults.filter(item => item.object_type === 'unit');
+  const filteredUnits = searchResults.filter(item => (
+    item.object_type === 'unit'
+    || (item.object_type === 'event' && item.location)
+  ));
 
   // Figure out which units to show on map on different pages
   const getMapUnits = () => {

--- a/src/views/SearchView/SearchView.js
+++ b/src/views/SearchView/SearchView.js
@@ -202,7 +202,8 @@ const SearchView = (props) => {
       || data.address
       || data.service_node
       || data.service_id
-      || data.id;
+      || data.id
+      || data.events;
 
     // Should fetch if previousSearch has changed and data has required parameters
     if (previousSearch) {

--- a/src/views/SearchView/SearchView.js
+++ b/src/views/SearchView/SearchView.js
@@ -114,6 +114,7 @@ const SearchView = (props) => {
         options.events = events;
       }
 
+      // This is used when embedding a specified list of units by IDs
       if (units) {
         options.id = units;
       }
@@ -197,7 +198,11 @@ const SearchView = (props) => {
       return false;
     }
     const data = getSearchParamData();
-    const searchQuery = data.q || data.address || data.service_node || data.service_id;
+    const searchQuery = data.q
+      || data.address
+      || data.service_node
+      || data.service_id
+      || data.id;
 
     // Should fetch if previousSearch has changed and data has required parameters
     if (previousSearch) {


### PR DESCRIPTION
Fixed some embed urls that did not work with the new search
- Unit id list: https://palvelukartta.hel.fi/fi/embed/search?units=8215,51342,8264,32359
- Events: https://palvelukartta.hel.fi/fi/embed/search?events=yso:p4354
- Address: https://palvelukartta.hel.fi/fi/embed/address/helsinki/El%C3%A4intarhantie%203/