### PR TITLE
Feature/simple pageview tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,8 @@ ACCESSIBILITY_STATEMENT_URL_SV="https://www.hel.fi/static/liitteet-2019/Helsinki
 ACCESSIBILITY_STATEMENT_URL_EN="https://www.hel.fi/static/liitteet-2019/Helsinki/Saavutettavuusselosteet/Servicemap.hel.fi-accessibility_evaluation_the_website_fulfils_the_accessibility_requirements_partially.pdf"
 PRODUCTION_PREFIX="SM"
 CITIES="helsinki,espoo,vantaa,kauniainen,kirkkonummi"
+
+FEATURE_SERVICEMAP_PAGE_TRACKING="false"
 # SERVER_TYPE="staging" This is used to disable search engine crawlers on staging server
 # SENTRY_DSN_SERVER=
 

--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,8 @@ MODE=development
 
 DOMAIN="https://palvelukartta.hel.fi"
 ACCESSIBILITY_SENTENCE_API="https://www.hel.fi/palvelukarttaws/rest/v4"
-SERVICEMAP_API="https://api.hel.fi/servicemap/v2"
+SERVICEMAP_API="https://api.hel.fi/servicemap"
+SERVICEMAP_API_VERSION="v2"
 EVENTS_API="https://api.hel.fi/linkedevents/v1"
 RESERVATIONS_API="https://api.hel.fi/respa/v1"
 FEEDBACK_URL="https://api.hel.fi/servicemap/open311/"

--- a/config/default.js
+++ b/config/default.js
@@ -177,6 +177,7 @@ export default {
   },
   "serviceMapAPI": {
     "root": settings.SERVICEMAP_API,
+    "version": settings.SERVICEMAP_API_VERSION,
     "id": 'SERVICEMAP_API',
   },
   "eventsAPI": {

--- a/config/default.js
+++ b/config/default.js
@@ -1,4 +1,4 @@
-function getSettings() {
+export function getSettings() {
   if (typeof window !== 'undefined' && typeof window.nodeEnvSettings !== 'undefined') {
       // Needed in browser run context
       return window.nodeEnvSettings;

--- a/config/featureFlags.js
+++ b/config/featureFlags.js
@@ -1,0 +1,11 @@
+import { getSettings } from "./default";
+
+const settings = getSettings();
+
+if (typeof settings.FEATURE_SERVICEMAP_PAGE_TRACKING === 'undefined') {
+  settings.FEATURE_SERVICEMAP_PAGE_TRACKING = false;
+}
+
+export default {
+  servicemapPageTracking: settings.FEATURE_SERVICEMAP_PAGE_TRACKING === 'true',
+}

--- a/server/legacyRedirector.js
+++ b/server/legacyRedirector.js
@@ -234,7 +234,7 @@ const getMunicipalityFromGeocoder = function(address, language, callback) {
   timeout = setTimeout((function() {
     return callback(null);
   }), 3000);
-  url = `${config.serviceMapAPI.root}/address/?language=${language}&number=${address.number}&street=${address.street}&page_size=1`;
+  url = `${config.serviceMapAPI.root}/${config.serviceMapAPI.version}/address/?language=${language}&number=${address.number}&street=${address.street}&page_size=1`;
   request = https.get(url, function(apiResponse) {
     var respData;
     if (apiResponse.statusCode !== 200) {

--- a/server/legacyRedirector.js
+++ b/server/legacyRedirector.js
@@ -234,7 +234,7 @@ const getMunicipalityFromGeocoder = function(address, language, callback) {
   timeout = setTimeout((function() {
     return callback(null);
   }), 3000);
-  url = `${config.serviceMapAPI.root}/${config.serviceMapAPI.version}/address/?language=${language}&number=${address.number}&street=${address.street}&page_size=1`;
+  url = `${config.serviceMapAPI.root}${config.serviceMapAPI.version}/address/?language=${language}&number=${address.number}&street=${address.street}&page_size=1`;
   request = https.get(url, function(apiResponse) {
     var respData;
     if (apiResponse.statusCode !== 200) {

--- a/server/server.js
+++ b/server/server.js
@@ -213,6 +213,7 @@ const htmlTemplate = (req, reactDom, preloadedState, css, cssString, emotionCss,
         window.nodeEnvSettings = {};
         window.nodeEnvSettings.ACCESSIBILITY_SENTENCE_API = "${process.env.ACCESSIBILITY_SENTENCE_API}";
         window.nodeEnvSettings.SERVICEMAP_API = "${process.env.SERVICEMAP_API}";
+        window.nodeEnvSettings.SERVICEMAP_API_VERSION = "${process.env.SERVICEMAP_API_VERSION}";
         window.nodeEnvSettings.EVENTS_API = "${process.env.EVENTS_API}";
         window.nodeEnvSettings.RESERVATIONS_API = "${process.env.RESERVATIONS_API}";
         window.nodeEnvSettings.PRODUCTION_PREFIX = "${process.env.PRODUCTION_PREFIX}";

--- a/server/server.js
+++ b/server/server.js
@@ -254,6 +254,9 @@ const htmlTemplate = (req, reactDom, preloadedState, css, cssString, emotionCss,
         window.nodeEnvSettings.USE_PTV_ACCESSIBILITY_API = "${process.env.USE_PTV_ACCESSIBILITY_API}";
         window.nodeEnvSettings.SENTRY_DSN_CLIENT = "${process.env.SENTRY_DSN_CLIENT}";
 
+
+        window.nodeEnvSettings.FEATURE_SERVICEMAP_PAGE_TRACKING = "${process.env.FEATURE_SERVICEMAP_PAGE_TRACKING}";
+
         window.appVersion = {};
         window.appVersion.tag = "${versionTag}";
         window.appVersion.commit = "${versionCommit}";

--- a/src/components/Navigator/Navigator.js
+++ b/src/components/Navigator/Navigator.js
@@ -5,7 +5,7 @@ import { breadcrumbPush, breadcrumbPop, breadcrumbReplace } from '../../redux/ac
 import { generatePath, isEmbed } from '../../utils/path';
 import config from '../../../config';
 import SettingsUtility from '../../utils/settings';
-import matomoTracker from '../../utils/tracking';
+import matomoTracker, { servicemapTrackPageView } from '../../utils/tracking';
 
 class Navigator extends React.Component {
   unlisten = null;
@@ -52,6 +52,8 @@ class Navigator extends React.Component {
   }
 
   trackPageView = (settings) => {
+    // Simple custom servicemap page view tracking
+    servicemapTrackPageView();
     const embed = isEmbed();
     if (typeof window !== 'undefined' && !embed && window?.cookiehub?.hasConsented('analytics')) {
       if (matomoTracker) {

--- a/src/redux/actions/alerts.js
+++ b/src/redux/actions/alerts.js
@@ -9,7 +9,7 @@ export const fetchNews = () => async (dispatch) => {
   } = alertNews;
 
   dispatch(isFetching());
-  fetch(`${config.serviceMapAPI.root}/announcement/`)
+  fetch(`${config.serviceMapAPI.root}/${config.serviceMapAPI.version}/announcement/`)
     .then(res => res.json())
     .then(data => dispatch(fetchSuccess(data.results)))
     .catch((e) => {
@@ -27,7 +27,7 @@ export const fetchErrors = () => async (dispatch) => {
   } = alertErrors;
 
   dispatch(isFetching());
-  fetch(`${config.serviceMapAPI.root}/error_message/`)
+  fetch(`${config.serviceMapAPI.root}/${config.serviceMapAPI.version}/error_message/`)
     .then(res => res.json())
     .then(data => dispatch(fetchSuccess(data.results)))
     .catch((e) => {

--- a/src/redux/actions/alerts.js
+++ b/src/redux/actions/alerts.js
@@ -9,7 +9,7 @@ export const fetchNews = () => async (dispatch) => {
   } = alertNews;
 
   dispatch(isFetching());
-  fetch(`${config.serviceMapAPI.root}/${config.serviceMapAPI.version}/announcement/`)
+  fetch(`${config.serviceMapAPI.root}${config.serviceMapAPI.version}/announcement/`)
     .then(res => res.json())
     .then(data => dispatch(fetchSuccess(data.results)))
     .catch((e) => {
@@ -27,7 +27,7 @@ export const fetchErrors = () => async (dispatch) => {
   } = alertErrors;
 
   dispatch(isFetching());
-  fetch(`${config.serviceMapAPI.root}/${config.serviceMapAPI.version}/error_message/`)
+  fetch(`${config.serviceMapAPI.root}${config.serviceMapAPI.version}/error_message/`)
     .then(res => res.json())
     .then(data => dispatch(fetchSuccess(data.results)))
     .catch((e) => {

--- a/src/utils/fetch/constants.js
+++ b/src/utils/fetch/constants.js
@@ -12,14 +12,14 @@ export const APIHandlers = {
     envName: config.accessibilitySentenceAPI.id,
   },
   address: {
-    url: `${config.serviceMapAPI.root}/${config.serviceMapAPI.version}/address/`,
+    url: `${config.serviceMapAPI.root}${config.serviceMapAPI.version}/address/`,
     options: {
       page_size: 5,
     },
     envName: config.serviceMapAPI.id,
   },
   district: {
-    url: `${config.serviceMapAPI.root}/${config.serviceMapAPI.version}/administrative_division/`,
+    url: `${config.serviceMapAPI.root}${config.serviceMapAPI.version}/administrative_division/`,
     options: {
       geometry: true,
     },
@@ -33,7 +33,7 @@ export const APIHandlers = {
     envName: config.serviceMapAPI.id,
   },
   search: {
-    url: `${config.serviceMapAPI.root}/${config.serviceMapAPI.version}/search/`,
+    url: `${config.serviceMapAPI.root}${config.serviceMapAPI.version}/search/`,
     options: {
       page: 1,
       page_size: 200,
@@ -44,17 +44,17 @@ export const APIHandlers = {
     envName: config.serviceMapAPI.id,
   },
   service: {
-    url: id => `${config.serviceMapAPI.root}/${config.serviceMapAPI.version}/service/${id}/`,
+    url: id => `${config.serviceMapAPI.root}${config.serviceMapAPI.version}/service/${id}/`,
     options: {},
     envName: config.serviceMapAPI.id,
   },
   serviceRedirect: {
-    url: `${config.serviceMapAPI.root}/${config.serviceMapAPI.version}/redirect/unit/`,
+    url: `${config.serviceMapAPI.root}${config.serviceMapAPI.version}/redirect/unit/`,
     options: {},
     envName: config.serviceMapAPI.id,
   },
   unit: {
-    url: id => `${config.serviceMapAPI.root}/${config.serviceMapAPI.version}/unit/${id}/`,
+    url: id => `${config.serviceMapAPI.root}${config.serviceMapAPI.version}/unit/${id}/`,
     options: {
       accessibility_description: true,
       include: 'service_nodes,services,keywords,department,entrances',
@@ -63,7 +63,7 @@ export const APIHandlers = {
     envName: config.serviceMapAPI.id,
   },
   units: {
-    url: `${config.serviceMapAPI.root}/${config.serviceMapAPI.version}/unit/`,
+    url: `${config.serviceMapAPI.root}${config.serviceMapAPI.version}/unit/`,
     options: {
       page: 1,
       page_size: 200,
@@ -74,7 +74,7 @@ export const APIHandlers = {
     envName: config.serviceMapAPI.id,
   },
   idFetch: {
-    url: type => `${config.serviceMapAPI.root}/${config.serviceMapAPI.version}/${type}/`,
+    url: type => `${config.serviceMapAPI.root}${config.serviceMapAPI.version}/${type}/`,
     options: {
       page: 1,
       page_size: 500,

--- a/src/utils/fetch/constants.js
+++ b/src/utils/fetch/constants.js
@@ -12,14 +12,14 @@ export const APIHandlers = {
     envName: config.accessibilitySentenceAPI.id,
   },
   address: {
-    url: `${config.serviceMapAPI.root}/address/`,
+    url: `${config.serviceMapAPI.root}/${config.serviceMapAPI.version}/address/`,
     options: {
       page_size: 5,
     },
     envName: config.serviceMapAPI.id,
   },
   district: {
-    url: `${config.serviceMapAPI.root}/administrative_division/`,
+    url: `${config.serviceMapAPI.root}/${config.serviceMapAPI.version}/administrative_division/`,
     options: {
       geometry: true,
     },
@@ -33,7 +33,7 @@ export const APIHandlers = {
     envName: config.serviceMapAPI.id,
   },
   search: {
-    url: `${config.serviceMapAPI.root}/search/`,
+    url: `${config.serviceMapAPI.root}/${config.serviceMapAPI.version}/search/`,
     options: {
       page: 1,
       page_size: 200,
@@ -44,17 +44,17 @@ export const APIHandlers = {
     envName: config.serviceMapAPI.id,
   },
   service: {
-    url: id => `${config.serviceMapAPI.root}/service/${id}/`,
+    url: id => `${config.serviceMapAPI.root}/${config.serviceMapAPI.version}/service/${id}/`,
     options: {},
     envName: config.serviceMapAPI.id,
   },
   serviceRedirect: {
-    url: `${config.serviceMapAPI.root}/redirect/unit/`,
+    url: `${config.serviceMapAPI.root}/${config.serviceMapAPI.version}/redirect/unit/`,
     options: {},
     envName: config.serviceMapAPI.id,
   },
   unit: {
-    url: id => `${config.serviceMapAPI.root}/unit/${id}/`,
+    url: id => `${config.serviceMapAPI.root}/${config.serviceMapAPI.version}/unit/${id}/`,
     options: {
       accessibility_description: true,
       include: 'service_nodes,services,keywords,department,entrances',
@@ -63,7 +63,7 @@ export const APIHandlers = {
     envName: config.serviceMapAPI.id,
   },
   units: {
-    url: `${config.serviceMapAPI.root}/unit/`,
+    url: `${config.serviceMapAPI.root}/${config.serviceMapAPI.version}/unit/`,
     options: {
       page: 1,
       page_size: 200,
@@ -74,7 +74,7 @@ export const APIHandlers = {
     envName: config.serviceMapAPI.id,
   },
   idFetch: {
-    url: type => `${config.serviceMapAPI.root}/${type}/`,
+    url: type => `${config.serviceMapAPI.root}/${config.serviceMapAPI.version}/${type}/`,
     options: {
       page: 1,
       page_size: 500,

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -196,4 +196,23 @@ export const addSearchParametersToObject = (obj, params) => {
 };
 
 
+export const isMobileDevice = () => {
+  if (!window) {
+    return false;
+  }
+  const toMatch = [
+    /Android/i,
+    /webOS/i,
+    /iPhone/i,
+    /iPad/i,
+    /iPod/i,
+    /BlackBerry/i,
+    /Windows Phone/i,
+  ];
+
+  const { userAgent } = navigator;
+  return toMatch.some(toMatchItem => userAgent.match(toMatchItem));
+};
+
+
 export default isClient;

--- a/src/utils/newFetch/HTTPClient.js
+++ b/src/utils/newFetch/HTTPClient.js
@@ -179,11 +179,9 @@ export default class HttpClient {
     const postOptions = {
       method: 'POST',
       headers: {
-        // 'Content-Type': 'application/x-www-form-urlencoded',
-        'Content-Type': 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded',
       },
-      body: JSON.stringify(data),
-      // body: new URLSearchParams(data).toString(),
+      body: new URLSearchParams(data).toString(),
     };
     return this.handleFetch(endpoint, `${overrideBaseUrl || this.baseURL}/${endpoint}`, postOptions, 'post');
   }

--- a/src/utils/newFetch/ServiceMapAPI.js
+++ b/src/utils/newFetch/ServiceMapAPI.js
@@ -4,14 +4,20 @@ import HttpClient, { APIFetchError, serviceMapAPIName } from './HTTPClient';
 export default class ServiceMapAPI extends HttpClient {
   constructor() {
     if (
-      typeof config?.serviceMapAPI?.root === 'string'
-      && config.serviceMapAPI.root.indexOf('undefined') !== -1
-      && typeof config?.serviceMapAPI?.version === 'string'
-      && config.serviceMapAPI.version.indexOf('undefined') !== -1
+      typeof config?.serviceMapAPI?.root !== 'string'
+      || typeof config?.serviceMapAPI?.version !== 'string'
+      || (
+        typeof config?.serviceMapAPI?.root === 'string'
+        && config.serviceMapAPI.root.indexOf('undefined') !== -1
+      )
+      || (
+        typeof config?.serviceMapAPI?.version === 'string'
+        && config.serviceMapAPI.version.indexOf('undefined') !== -1
+      )
     ) {
       throw new APIFetchError('ServicemapAPI baseURL missing');
     }
-    super(`${config.serviceMapAPI.root}/${config.serviceMapAPI.version}`, serviceMapAPIName);
+    super(`${config.serviceMapAPI.root}${config.serviceMapAPI.version}`, serviceMapAPIName);
   }
 
   search = async (query, additionalOptions) => {

--- a/src/utils/newFetch/ServiceMapAPI.js
+++ b/src/utils/newFetch/ServiceMapAPI.js
@@ -6,10 +6,12 @@ export default class ServiceMapAPI extends HttpClient {
     if (
       typeof config?.serviceMapAPI?.root === 'string'
       && config.serviceMapAPI.root.indexOf('undefined') !== -1
+      && typeof config?.serviceMapAPI?.version === 'string'
+      && config.serviceMapAPI.version.indexOf('undefined') !== -1
     ) {
       throw new APIFetchError('ServicemapAPI baseURL missing');
     }
-    super(config.serviceMapAPI.root, serviceMapAPIName);
+    super(`${config.serviceMapAPI.root}/${config.serviceMapAPI.version}`, serviceMapAPIName);
   }
 
   search = async (query, additionalOptions) => {
@@ -121,10 +123,9 @@ export default class ServiceMapAPI extends HttpClient {
       page: 1,
       page_size: 500,
       geometry: true,
-      type: 'statistical_district'
+      type: 'statistical_district',
     };
     return this.getConcurrent('administrative_division', options);
-
   }
 
   areas = async (idList, geometry, additionalOptions) => {
@@ -197,5 +198,21 @@ export default class ServiceMapAPI extends HttpClient {
     };
 
     return this.getConcurrent('unit', options);
+  }
+
+  sendStats = async (data) => {
+    if (typeof data.embed === 'undefined' || typeof data.mobile_device === 'undefined') {
+      throw new APIFetchError('Invalid data provided for ServiceMapAPI sendStats fetch method');
+    }
+    if (
+      typeof config?.serviceMapAPI?.root === 'string'
+      && config.serviceMapAPI.root.indexOf('undefined') !== -1
+    ) {
+      throw new APIFetchError('ServicemapAPI missing serviceMapAPI root url in sendStats fetch');
+    }
+
+    const baseUrlOverride = config.serviceMapAPI.root;
+
+    return this.post('stats', data, baseUrlOverride);
   }
 }

--- a/src/utils/tracking.js
+++ b/src/utils/tracking.js
@@ -1,6 +1,7 @@
 import MatomoTracker from '@datapunt/matomo-tracker-js';
 import { isMobileDevice } from '.';
 import config from '../../config';
+import featureFlags from '../../config/featureFlags';
 import ServiceMapAPI from './newFetch/ServiceMapAPI';
 import { isEmbed } from './path';
 
@@ -18,11 +19,13 @@ const matomoTracker = (config.matomoSiteId && config.matomoUrl)
 // since Matomo can't be used in embed since it saves user specific data and requires user
 // permissions which causes issues with question box
 export const servicemapTrackPageView = () => {
-  const smAPI = new ServiceMapAPI();
-  smAPI.sendStats({
-    embed: isEmbed() ? 1 : 0,
-    mobile_device: isMobileDevice() ? 1 : 0,
-  });
+  if (featureFlags.servicemapPageTracking) {
+    const smAPI = new ServiceMapAPI();
+    smAPI.sendStats({
+      embed: isEmbed() ? 1 : 0,
+      mobile_device: isMobileDevice() ? 1 : 0,
+    });
+  }
 };
 
 export default matomoTracker;

--- a/src/utils/tracking.js
+++ b/src/utils/tracking.js
@@ -1,5 +1,8 @@
 import MatomoTracker from '@datapunt/matomo-tracker-js';
+import { isMobileDevice } from '.';
 import config from '../../config';
+import ServiceMapAPI from './newFetch/ServiceMapAPI';
+import { isEmbed } from './path';
 
 const matomoTracker = (config.matomoSiteId && config.matomoUrl)
   ? new MatomoTracker({
@@ -10,5 +13,16 @@ const matomoTracker = (config.matomoSiteId && config.matomoUrl)
     disabled: false, // optional, false by default. Makes all tracking calls no-ops if set to true.
     linkTracking: false, // optional, default value: true
   }) : null;
+
+// Simple servicemap page view tracking that tracks only visit count, embed, and mobile data
+// since Matomo can't be used in embed since it saves user specific data and requires user
+// permissions which causes issues with question box
+export const servicemapTrackPageView = () => {
+  const smAPI = new ServiceMapAPI();
+  smAPI.sendStats({
+    embed: isEmbed() ? 1 : 0,
+    mobile_device: isMobileDevice() ? 1 : 0,
+  });
+};
 
 export default matomoTracker;

--- a/src/views/ServiceTreeView/ServiceTreeView.js
+++ b/src/views/ServiceTreeView/ServiceTreeView.js
@@ -58,7 +58,7 @@ const ServiceTreeView = (props) => {
 
   const fetchRootNodes = () => (
     // Fetch all top level 0 nodes (root nodes)
-    fetch(`${config.serviceMapAPI.root}/${config.serviceMapAPI.version}/service_node/?level=0&page=1&page_size=100`)
+    fetch(`${config.serviceMapAPI.root}${config.serviceMapAPI.version}/service_node/?level=0&page=1&page_size=100`)
       .then(response => response.json())
       .then(data => data.results)
   );
@@ -71,7 +71,7 @@ const ServiceTreeView = (props) => {
 
   const fetchChildServices = async (service) => {
     // Fetch and set to state the child nodes of the opened node
-    fetch(`${config.serviceMapAPI.root}/${config.serviceMapAPI.version}/service_node/?parent=${service}&page=1&page_size=1000`)
+    fetch(`${config.serviceMapAPI.root}${config.serviceMapAPI.version}/service_node/?parent=${service}&page=1&page_size=1000`)
       .then(response => response.json())
       .then((data) => {
         setServices([...services, ...data.results]);

--- a/src/views/ServiceTreeView/ServiceTreeView.js
+++ b/src/views/ServiceTreeView/ServiceTreeView.js
@@ -58,7 +58,7 @@ const ServiceTreeView = (props) => {
 
   const fetchRootNodes = () => (
     // Fetch all top level 0 nodes (root nodes)
-    fetch(`${config.serviceMapAPI.root}/service_node/?level=0&page=1&page_size=100`)
+    fetch(`${config.serviceMapAPI.root}/${config.serviceMapAPI.version}/service_node/?level=0&page=1&page_size=100`)
       .then(response => response.json())
       .then(data => data.results)
   );
@@ -71,7 +71,7 @@ const ServiceTreeView = (props) => {
 
   const fetchChildServices = async (service) => {
     // Fetch and set to state the child nodes of the opened node
-    fetch(`${config.serviceMapAPI.root}/service_node/?parent=${service}&page=1&page_size=1000`)
+    fetch(`${config.serviceMapAPI.root}/${config.serviceMapAPI.version}/service_node/?parent=${service}&page=1&page_size=1000`)
       .then(response => response.json())
       .then((data) => {
         setServices([...services, ...data.results]);


### PR DESCRIPTION
There was a need for simple pageview tracking only tracking count, embedded, and mobile info. Since Matomo can't be used without user permissions and embeds don't work well with cookiehub window popping every time on top of embedded view. This solution adds tracking that sends info to backend which counts pageviews anonymously.

Feature is hidden behind a feature flag FEATURE_SERVICEMAP_PAGE_TRACKING which is false by default.

This change will require environment variable changes