### PR TITLE
Check for mapPane existence before resolving center coordinates

### DIFF
--- a/src/utils/dataVisualization.js
+++ b/src/utils/dataVisualization.js
@@ -30,7 +30,7 @@ class DataVisualization {
 
   POPULATION_FORECAST_STRING = '_population_forecast';
 
-  CURRENT_YEAR = new Date().getFullYear() - 1;
+  CURRENT_YEAR = new Date().getFullYear() - 2;
 
   FORECAST_YEAR = new Date().getFullYear() + 5;
 

--- a/src/views/MapView/MapView.js
+++ b/src/views/MapView/MapView.js
@@ -231,13 +231,13 @@ const MapView = (props) => {
     let center = mapOptions.initialPosition;
     let zoom = isMobile ? mapObject.options.mobileZoom : mapObject.options.zoom;
     if (prevMap && llMapHasMapPane(prevMap)) { // If changing map type, use viewport values of previous map
-      center = prevMap.getCenter() || prevMap.props.center;
+      center = prevMap.getCenter() || prevMap.options.center;
       /* Different map types have different zoom levels
       Use the zoom difference to calculate the new zoom level */
       const zoomDifference = mapObject.options.zoom - prevMap.defaultZoom;
       zoom = prevMap.getZoom()
         ? prevMap.getZoom() + zoomDifference
-        : prevMap.props.zoom + zoomDifference;
+        : prevMap.options.zoom + zoomDifference;
     }
 
     const showLoadingScreen = statisticalDistrictFetch.isFetching

--- a/src/views/MapView/MapView.js
+++ b/src/views/MapView/MapView.js
@@ -220,12 +220,17 @@ const MapView = (props) => {
     return null;
   };
 
+  const llMapHasMapPane = (leafLetMap) => {
+    // `getCenter()` call requires existence of mapPane (what ever that means). So check for that before calling it. Just another null check.
+    const panes = leafLetMap.getPanes();
+    return !!panes && !!panes.mapPane;
+  }
 
   if (global.rL && mapObject) {
     const { MapContainer, TileLayer, WMSTileLayer } = global.rL || {};
     let center = mapOptions.initialPosition;
     let zoom = isMobile ? mapObject.options.mobileZoom : mapObject.options.zoom;
-    if (prevMap) { // If changing map type, use viewport values of previuous map
+    if (prevMap && llMapHasMapPane(prevMap)) { // If changing map type, use viewport values of previous map
       center = prevMap.getCenter() || prevMap.props.center;
       /* Different map types have different zoom levels
       Use the zoom difference to calculate the new zoom level */


### PR DESCRIPTION
So our code failed on NPE because `this._mapPane` was `undefined` here https://github.com/Leaflet/Leaflet/blob/v1.7.1/src/map/Map.js#L1476 on atleast one instance of rerender after map type switch. Now the fix is to check for `mapPane` existence before resolving "center".

![image](https://user-images.githubusercontent.com/32292709/217775542-f5777335-50cb-4bf9-957c-89e9108eba50.png)

Could there be a more elegant solution by tweaking hooks? Probably yes.

Thoughts, questions and todo
- [x] `prevMap.props` seems to be always empty - Fixed to be `options` instead of `props`
- Why is this [src/redux/actions/map.js#](https://github.com/City-of-Helsinki/servicemap-ui/blob/develop/src/redux/actions/map.js#L4) `setMapRef` method used in `whenCreated` hook of leaflet map.
- [x] should fix browser tests - fixed