### PR TITLE
Fix api url to allow stats post

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,8 @@ MODE=development
 
 DOMAIN="https://palvelukartta.hel.fi"
 ACCESSIBILITY_SENTENCE_API="https://www.hel.fi/palvelukarttaws/rest/v4"
-SERVICEMAP_API="https://api.hel.fi/servicemap/"
-SERVICEMAP_API_VERSION="v2"
+SERVICEMAP_API="https://api.hel.fi/servicemap"
+SERVICEMAP_API_VERSION="/v2"
 EVENTS_API="https://api.hel.fi/linkedevents/v1"
 RESERVATIONS_API="https://api.hel.fi/respa/v1"
 FEEDBACK_URL="https://api.hel.fi/servicemap/open311/"


### PR DESCRIPTION
Sending statistics to backend failed because of double slash (https://api.hel.fi/servicemap//stats instead of https://api.hel.fi/servicemap/stats).