### PR TITLE
Embedded view fixes

### DIFF
--- a/src/components/Dialog/Dialog.js
+++ b/src/components/Dialog/Dialog.js
@@ -9,6 +9,7 @@ import { useIntl } from 'react-intl';
 import styled from '@emotion/styled';
 import SMButton from '../ServiceMapButton';
 import CloseButton from '../CloseButton';
+import useMobileStatus from '../../utils/isMobile';
 
 const Dialog = ({
   title,
@@ -21,6 +22,7 @@ const Dialog = ({
 }) => {
   const intl = useIntl();
   const dialogRef = useRef();
+  const isMobile = useMobileStatus();
 
   const handleClose = () => {
     setOpen(false);
@@ -59,9 +61,10 @@ const Dialog = ({
         open={open}
         onClose={handleClose}
         aria-labelledby="form-dialog-title"
-        classes={{
-          root: muiRootClass,
-        }}
+        fullScreen={isMobile}
+        classes={
+          !isMobile ? { root: muiRootClass } : null
+        }
       >
         <StyledRoot>
           {/* Empty element that makes keyboard focus loop in dialog */}

--- a/src/components/Navigator/Navigator.js
+++ b/src/components/Navigator/Navigator.js
@@ -92,13 +92,16 @@ class Navigator extends React.Component {
    * Generate url based on path string and data
    * @param target - Key string for path config
    * @param data - Data for path used if target is path key
+   * @param embed - Override isEmbed() check
    */
-  generatePath = (target, data) => {
+  generatePath = (target, data, embed) => {
     const { match } = this.props;
     const { params } = match;
     const locale = params && params.lng;
 
-    return generatePath(target, locale, data, isEmbed());
+    const embedValue = typeof embed !== 'undefined' ? embed : isEmbed();
+
+    return generatePath(target, locale, data, embedValue);
   }
 
 
@@ -122,7 +125,7 @@ class Navigator extends React.Component {
       this.trackPageView({ mobility, senses });
       breadcrumbPop();
     } else {
-      history.push(this.generatePath('home'));
+      history.push(this.generatePath('home', null, false));
       breadcrumbPush({ location });
     }
   }

--- a/src/layouts/EmbedLayout.js
+++ b/src/layouts/EmbedLayout.js
@@ -152,7 +152,7 @@ const EmbedLayout = ({ intl }) => {
             messageID="unit.showInformation"
             onClick={() => {
               const { origin } = window.location;
-              const path = navigator.generatePath('unit', { id: selectedUnitData.id });
+              const path = navigator.generatePath('unit', { id: selectedUnitData.id }, false);
               window.open(`${origin}${path}`);
             }}
           />

--- a/src/utils/newFetch/ServiceMapAPI.js
+++ b/src/utils/newFetch/ServiceMapAPI.js
@@ -1,4 +1,5 @@
 import config from '../../../config';
+import { isEmbed } from '../path';
 import HttpClient, { APIFetchError, serviceMapAPIName } from './HTTPClient';
 
 export default class ServiceMapAPI extends HttpClient {
@@ -57,10 +58,14 @@ export default class ServiceMapAPI extends HttpClient {
     if (!['string', 'number'].includes(typeof idList)) {
       throw new APIFetchError('Invalid query string provided to ServiceMapAPI serviceNodeSearch method');
     }
+
+    let onlyValues = ['street_address', 'location', 'name', 'municipality', 'accessibility_shortcoming_count', 'service_nodes', 'contract_type', 'organizer_type'];
+    if (isEmbed()) onlyValues = [...onlyValues, 'connections', 'phone', 'call_charge_info', 'email', 'www', 'address_zip'];
+
     const options = {
       page: 1,
       page_size: 200,
-      only: 'street_address,location,name,municipality,accessibility_shortcoming_count,service_nodes,contract_type,organizer_type',
+      only: onlyValues,
       geometry: true,
       include: 'service_nodes,services,accessibility_properties,department,root_department',
       service_node: idList,
@@ -76,11 +81,14 @@ export default class ServiceMapAPI extends HttpClient {
       throw new APIFetchError('Invalid id string provided to ServiceMapAPI serviceUnits method');
     }
 
+    let onlyValues = ['street_address', 'location', 'name', 'municipality', 'accessibility_shortcoming_count', 'service_nodes', 'contract_type', 'organizer_type', 'department', 'root_department'];
+    if (isEmbed()) onlyValues = [...onlyValues, 'connections', 'phone', 'call_charge_info', 'email', 'www', 'address_zip'];
+
     const options = {
       service: serviceId,
       page: 1,
       page_size: 200,
-      only: 'street_address,name,accessibility_shortcoming_count,location,municipality,contract_type,department,root_department,organizer_type',
+      only: onlyValues,
       geometry: true,
       ...additionalOptions,
     };
@@ -98,7 +106,7 @@ export default class ServiceMapAPI extends HttpClient {
       service: idList,
       page_size: 200,
       geometry: true,
-      only: 'street_address,phone,call_charge_info,email,www,name,accessibility_shortcoming_count,location,municipality,contract_type,connections,picture_url,organizer_type',
+      only: 'street_address,phone,call_charge_info,email,www,name,accessibility_shortcoming_count,location,municipality,contract_type,connections,picture_url,organizer_type,address_zip',
       ...additionalOptions,
     };
 
@@ -170,11 +178,14 @@ export default class ServiceMapAPI extends HttpClient {
       throw new APIFetchError('Invalid nodeID string provided to ServiceMapAPI area unit fetch method');
     }
 
+    let onlyValues = ['street_address', 'location', 'name', 'municipality', 'accessibility_shortcoming_count', 'service_nodes', 'contract_type'];
+    if (isEmbed()) onlyValues = [...onlyValues, 'connections', 'phone', 'call_charge_info', 'email', 'www', 'address_zip'];
+
     const options = {
       page: 1,
       page_size: 200,
       division: nodeID,
-      only: 'street_address,location,name,municipality,accessibility_shortcoming_count,service_nodes,contract_type',
+      only: onlyValues,
       include: 'services',
     };
 
@@ -194,9 +205,12 @@ export default class ServiceMapAPI extends HttpClient {
   }
 
   units = async (additionalOptions) => {
+    let onlyValues = ['street_address', 'location', 'name', 'municipality', 'accessibility_shortcoming_count', 'service_nodes', 'contract_type', 'organizer_type'];
+    if (isEmbed()) onlyValues = [...onlyValues, 'connections', 'phone', 'call_charge_info', 'email', 'www', 'address_zip'];
+
     const options = {
       page_size: 200,
-      only: 'street_address,location,name,municipality,accessibility_shortcoming_count,service_nodes,contract_type,organizer_type',
+      only: onlyValues,
       include: 'service_nodes,services,accessibility_properties,department',
       geometry: true,
       ...additionalOptions,

--- a/src/views/MapView/styles.js
+++ b/src/views/MapView/styles.js
@@ -225,7 +225,9 @@ const styles = theme => ({
     ...theme.typography.body2,
     paddingTop: theme.spacing(1),
     textAlign: 'center',
-    color: theme.palette.primary.link,
+    color: theme.palette.link.main,
+    textDecoration: 'underline',
+    cursor: 'pointer',
   },
   unitTooltipWrapper: {
     padding: theme.spacing(3),


### PR DESCRIPTION
Korjattiin seuraavat bugit:

- Tällä hetkellä unit-rajapinnan kutsujen only-parametrit rajaavat tuloksista perustiedot perushaun nopeuttamiseksi. Näitä tietoja tarvitaan tosin upotusnäkymissä. Lisättiin nämä puuttuvat tiedot upotuksissa hakuun. [Trellokortti](https://trello.com/c/jCSAXzwQ/1429-upotus-riippuen-hakulinkin-tekotavasta-tulee-eri-tiedot-näkyville)
- Uporustyökalusta poistuessa ja upotusnäkymän toimipistedialogin "näytä toimipisteen tiedot" painike ohjasivat virheellisesti upotusnäkymään normaalin näkymä sijasta [Trellokortti](https://trello.com/c/vHcZPzZk/1434-upotustyökalusta-poistuminen-ei-toimi-oikein)
- Pienillä näytöillä upotuksen toimipisteen tiedot -dialogi ei näy kunnolla. Näytetään dialogi fullScreen-tilassa näissä tapauksissa.
- Korjattiin toimipisteen popupin linkin hajonneet tyylit.

