### PR TITLE
Fix settings menu hidden overflow visibility

### DIFF
--- a/src/components/MenuButton/MenuButton/MenuButton.js
+++ b/src/components/MenuButton/MenuButton/MenuButton.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  Button, ButtonBase, ClickAwayListener, Divider, Typography,
+  Button, ButtonBase, ClickAwayListener, Container, Divider, Typography,
 } from '@mui/material';
 import { FormattedMessage } from 'react-intl';
 import styled from '@emotion/styled';
@@ -52,6 +52,8 @@ class MenuButton extends React.Component {
           id={panelID}
           aria-label={menuAriaLabel}
           role="region"
+          disableGutters
+          sx={{ overflowY: panelID === 'SettingsMenuPanel' ? 'visible' : 'auto' }}
         >
           <Typography sx={{
             textAlign: 'left', fontWeight: 700, fontSize: '1.03rem', pb: 1,
@@ -130,16 +132,14 @@ class MenuButton extends React.Component {
   }
 }
 
-const StyledMenuPanel = styled('div')(({ theme }) => ({
+const StyledMenuPanel = styled(Container)(({ theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   position: 'absolute',
-  overflowY: 'auto',
   maxHeight: `calc(100vh - ${config.topBarHeight}px)`,
   width: 450,
   padding: theme.spacing(2),
   paddingTop: theme.spacing(3),
-  paddingBottom: theme.spacing(2),
   boxSizing: 'border-box',
   backgroundColor: 'white',
   color: 'black',


### PR DESCRIPTION
https://trello.com/c/HcSI1DXm/1424-yläpalkin-asetusvalikon-korkeuden-korjaus

Yläpalkin omat asetukset -valikon select-elementit jäivät piiloon edellisten valikkokorjausten jäljiltä.

Valikon komponentti muutettiin div elementistä  MUI:n Container komponentiksi, jotta sx tyylit voidaan asettaa.
