### PR TITLE
Change address location marker icon

### DIFF
--- a/browserTests/views/addressTest.js
+++ b/browserTests/views/addressTest.js
@@ -72,7 +72,7 @@ test('AddressView map renders correctly', async (t) => {
 test('AddressView\'s area view link does take correct address to AreaView', async (t) => {
   const areaViewLink = Selector('#areaViewLink');
   const addressBar = Selector(addressSearchBarInput)
-  const addressMarker = Selector('div.leaflet-marker-icon .icon-icon-address')
+  const addressMarker = Selector('div[class*="AddressMarkerIcon"]');
 
   await t
     .click(areaViewLink)

--- a/src/assets/icons/addressLocation.svg
+++ b/src/assets/icons/addressLocation.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="29px" height="43px" viewBox="0 0 29 43" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 61.1 (89650) - https://sketch.com -->
+    <title>sijainti</title>
+    <desc>Created with Sketch.</desc>
+    <g id="sijainti" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Capa_1-Copy-2" transform="translate(1.000000, 1.000000)">
+            <g id="Group">
+                <path d="M26.4488778,13.3485556 C26.4488778,6.04516667 20.6110045,0.125611111 13.4073519,0.125611111 C6.20369927,0.125611111 0.366866883,6.04516667 0.366866883,13.3485556 C0.366866883,23.8122778 13.4073519,39.2962222 13.4073519,39.2962222 C13.4073519,39.2962222 26.4488778,23.7584444 26.4488778,13.3485556 Z M6.97611404,12.559 C6.97611404,8.95638889 9.85653409,6.03672222 13.4083929,6.03672222 C16.9602516,6.03672222 19.8406717,8.95638889 19.8406717,12.559 C19.8406717,16.1616111 16.9602516,19.0812778 13.4083929,19.0812778 C9.85653409,19.0812778 6.97611404,16.1616111 6.97611404,12.559 Z" id="Shape" stroke="#FFFDFD" stroke-width="2.5" fill="#2242C7" fill-rule="nonzero"></path>
+                <circle id="Oval" fill="#FFFFFF" cx="13.5" cy="12.5" r="5.5"></circle>
+                <ellipse id="Oval" stroke="#FFFCFC" fill="#2242C7" fill-rule="nonzero" cx="13.4073519" cy="12.559" rx="3.16252841" ry="3.20677778"></ellipse>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/components/SMIcon/index.js
+++ b/src/components/SMIcon/index.js
@@ -24,6 +24,7 @@ import closeIcon from '../../assets/icons/closeIcon.svg';
 import coordinateMarker from '../../assets/icons/CoordinateMarker.svg';
 import coordinateMarkerContrast from '../../assets/icons/CoordinateMarkerContrast.svg';
 import kirkkonummiIcon from '../../assets/icons/kirkkonummiIcon.svg';
+import addressLocationIcon from '../../assets/icons/addressLocation.svg';
 
 /**
  * Senses
@@ -146,6 +147,8 @@ export const getIcon = (key, props) => {
       return <img aria-hidden alt="" src={serviceIconDark} {...props} />;
     case 'locationMarker':
       return <img aria-hidden alt="" src={userLocationIcon} {...props} />;
+    case 'addresslocationMarker':
+      return <img aria-hidden alt="" src={addressLocationIcon} {...props} />;
 
     case 'noWheelchair':
       return <img aria-hidden alt="" src={noWheelchairIcon} {...props} />;

--- a/src/views/MapView/components/AddressMarker/AddressMarker.js
+++ b/src/views/MapView/components/AddressMarker/AddressMarker.js
@@ -8,7 +8,7 @@ import { useSelector } from 'react-redux';
 import { selectAddress } from '../../../../redux/selectors/address';
 import { getAddressText } from '../../../../utils/address';
 import useLocaleText from '../../../../utils/useLocaleText';
-import { StyledHslIcon } from '../styled/styled';
+import { getIcon } from '../../../../components';
 
 const AddressMarker = ({
   embeded,
@@ -36,15 +36,11 @@ const AddressMarker = ({
   // eslint-disable-next-line global-require
   const { divIcon } = require('leaflet');
   const addressIcon = divIcon({
-    className: addressIconClass,
+    className: `${addressIconClass} AddressMarkerIcon`,
+    'data-sm': 'AddressMarkerIcon',
     html: renderToStaticMarkup(
-      <>
-        <StyledHslIcon className="icon-icon-hsl-background" />
-        <span className="icon-icon-address" />
-      </>,
+      getIcon('addresslocationMarker'),
     ),
-    iconSize: [45, 45],
-    iconAnchor: [22, 42],
   });
 
   const { addressCoordinates, addressData } = address;


### PR DESCRIPTION
Update the icon of the address location marker to similar as used in user location marker.

Old marker:
<img width="361" alt="vanha" src="https://github.com/City-of-Helsinki/servicemap-ui/assets/10584178/93c090b8-e0a3-4c56-bca1-4f27140347bd">

New marker:
<img width="327" alt="uusi" src="https://github.com/City-of-Helsinki/servicemap-ui/assets/10584178/5ace7a8e-46d1-458b-812e-8e68708c1c14">

