### PR TITLE
Fix: show parking units in embedder tool

### DIFF
--- a/src/components/ToolMenu/ToolMenu.js
+++ b/src/components/ToolMenu/ToolMenu.js
@@ -53,10 +53,24 @@ const ToolMenu = ({
       ? `services=${selectedDistrictServices}` : null;
     const parkingSpaces = selectedParkingAreaIds.length
       ? `parkingSpaces=${selectedParkingAreaIds.join(',')}` : null;
-    const units = parkingUnits.length
-      ? 'parkingUnits=true' : null;
     const addressCoordinates = districtAddressData.address
       ? `lat=${districtAddressData.address.location.coordinates[1]}&lng=${districtAddressData.address.location.coordinates[0]}` : null;
+
+    let unitsParams = []
+    if (parkingUnits) {
+      const keyMap = {
+        'helsinki-531': 'parkingGarages=true',
+        'vantaa-2204': 'sharedCarParking=true',
+        'vantaa-2207': 'accessibleStreetParking=true'
+      };
+    
+      Object.keys(parkingUnits).forEach((key) => {
+        if (parkingUnits[key].length && keyMap[key]) {
+          unitsParams.push(keyMap[key]);
+        }
+      });
+    }
+    const units = unitsParams.join('&')
 
     const params = [
       ...(selected ? [selected] : []),

--- a/src/redux/actions/district.js
+++ b/src/redux/actions/district.js
@@ -235,6 +235,8 @@ export const fetchParkingUnits = (parkingCategoryId) => (
 );
 
 export const fetchParkingGarages = () => fetchParkingUnits('helsinki-531');
+export const fetchSharedCarParking = () => fetchParkingUnits('vantaa-2204');
+export const fetchAccessibleStreetParking = () => fetchParkingUnits('vantaa-2207');
 
 export const handleOpenItems = id => (
   (dispatch, getState) => {

--- a/src/views/AreaView/AreaView.js
+++ b/src/views/AreaView/AreaView.js
@@ -8,6 +8,8 @@ import {
   fetchDistrictUnitList,
   fetchParkingAreaGeometry,
   fetchParkingGarages,
+  fetchSharedCarParking,
+  fetchAccessibleStreetParking,
   handleOpenItems,
   setDistrictAddressData,
   setSelectedDistrictServices,
@@ -161,7 +163,9 @@ const AreaView = ({ embed }) => {
   useEffect(() => {
     if (searchParams.selected
       || searchParams.parkingSpaces
-      || searchParams.parkingUnits
+      || searchParams.parkingGarages
+      || searchParams.sharedCarParking
+      || searchParams.accessibleStreetParking
     ) { // Arriving to page, with url parameters
       if (!embed) {
         /* Remove selected area parameter from url, otherwise it will override
@@ -199,8 +203,16 @@ const AreaView = ({ embed }) => {
           dispatch(fetchParkingAreaGeometry(area));
         });
       }
-      if (searchParams.parkingUnits) {
+
+      // Fetch unit parking data from url parameters
+      if (searchParams.parkingGarages) {
         dispatch(fetchParkingGarages());
+      }
+      if (searchParams.sharedCarParking) {
+        dispatch(fetchSharedCarParking());
+        }
+      if (searchParams.accessibleStreetParking) {
+        dispatch(fetchAccessibleStreetParking());
       }
 
       // Set selected geographical districts from url parameters and handle map focus


### PR DESCRIPTION
Parking spaces are mostly area data, but there are few category exceptions that are units added to the area view:
- parking garages
- shared car parking
- accessible street parking

The issue was that these units were not shown in the embedder tool when selected from the area list. This fix adds parameters to the embedder tool to show these units when their category is selected.

Screenshot of a working scenario:
<img width="806" alt="parking_spaces" src="https://github.com/City-of-Helsinki/servicemap-ui/assets/10584178/b88e40a9-8f56-4c57-aab0-b4b575a9b525">

[Refs](https://trello.com/c/d1B3dJqK/1560-vantaan-pys%C3%A4k%C3%B6intialueisiin-t%C3%A4pp%C3%A4-my%C3%B6s-upotukseen-mukaan)
