### PR TITLE
Do not display unit source if unit is private service

### DIFF
--- a/src/views/UnitView/UnitView.js
+++ b/src/views/UnitView/UnitView.js
@@ -340,7 +340,7 @@ const UnitView = (props) => {
                 && `${contractText}. `
               }
               {
-                unit.data_source
+                unit.data_source && unit.contract_type.id !== 'PRIVATE_SERVICE'
                 && <FormattedMessage id="unit.data_source" defaultMessage="Source: {data_source}" values={{ data_source: unit.data_source }} />
               }
             </Typography>


### PR DESCRIPTION
No need to display unit source if unit type is private service.

[Refs](https://trello.com/c/UZfRKrit/1359-palvelukartalla-n%C3%A4ytett%C3%A4v%C3%A4t-tiedot-korjaus)