### PR TITLE
Remove settings from the home view

### DIFF
--- a/browserTests/views/settingsTest.js
+++ b/browserTests/views/settingsTest.js
@@ -23,17 +23,6 @@ fixture`Settings view tests`
 
 test('Settings does opens and closes correctly', async (t) => {
   await t
-    .expect(sensesDropdownSelector.visible).ok()
-    .expect(mobilityDropdownSelector.visible).ok()
-    .expect(cityDropdownSelector.visible).ok()
-    .expect(organisationDropdownSelector.visible).ok()
-  ;
-
-  await t
-    .click(Selector('#settings-accordion'))
-  ;
-
-  await t
     .expect(sensesDropdownSelector.visible).notOk()
     .expect(mobilityDropdownSelector.visible).notOk()
     .expect(cityDropdownSelector.visible).notOk()
@@ -41,7 +30,7 @@ test('Settings does opens and closes correctly', async (t) => {
   ;
 
   await t
-    .click(Selector('#settings-accordion'))
+    .click(Selector('[data-sm="SettingsMenuButton"]'))
   ;
 
   await t

--- a/src/views/HomeView/HomeView.js
+++ b/src/views/HomeView/HomeView.js
@@ -48,7 +48,6 @@ const HomeView = (props) => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
       <SearchBar hideBackButton header />
-      <SettingsComponent />
       {renderNavigationOptions()}
     </div>
   );


### PR DESCRIPTION
As the setting can be found also in the navigation bar, remove them from the home view to give the news etc. more space.

Previously:
<img width="400" alt="old" src="https://github.com/City-of-Helsinki/servicemap-ui/assets/10584178/76ba875f-d6e4-4aed-8db0-b695102e1ade">

Now:
<img width="400" alt="new" src="https://github.com/City-of-Helsinki/servicemap-ui/assets/10584178/f7fda196-13a3-4367-9450-cf71c0370948">


[Refs](https://trello.com/c/DauOldpG/1571-poistetaan-toinen-omat-asetukset-kohta)