### PR TITLE
Fix zooming when selecting area from list

### DIFF
--- a/src/views/AreaView/AreaView.js
+++ b/src/views/AreaView/AreaView.js
@@ -28,11 +28,9 @@ import {
   selectParkingUnitsMap
 } from '../../redux/selectors/district';
 import { selectMapRef } from '../../redux/selectors/general';
-import { selectCities } from '../../redux/selectors/settings';
 import { parseSearchParams } from '../../utils';
 import { getAddressText } from '../../utils/address';
 import { districtFetch } from '../../utils/fetch';
-import { filterByCitySettings, resolveCitySettings } from '../../utils/filters';
 import useLocaleText from '../../utils/useLocaleText';
 import fetchAddress from '../MapView/utils/fetchAddress';
 import { fitUnitsToMap, focusDistrict, focusDistricts, useMapFocusDisabled } from '../MapView/utils/mapActions';
@@ -58,16 +56,13 @@ const AreaView = ({ embed }) => {
   const districtAddressData = useSelector(selectDistrictAddressData);
   const subdistrictUnits = useSelector(selectSubdistrictUnits);
   const selectedSubdistricts = useSelector(selectSelectedSubdistricts);
-  const citySettings = useSelector(selectCities);
   const unitsFetching = useSelector(state => selectDistrictUnitFetch(state).nodesFetching);
-  const districtData = useSelector(selectDistrictDataBySelectedType);
+  const selectedDistrictData = useSelector(selectDistrictDataBySelectedType);
   const map = useSelector(selectMapRef);
   const addressDistrict = useSelector(getAddressDistrict);
   const parkingUnitsMap = useSelector(selectParkingUnitsMap);
   const getLocaleText = useLocaleText();
 
-  const cityFilter = filterByCitySettings(resolveCitySettings(citySettings, location, embed));
-  const selectedDistrictData = districtData.filter(cityFilter);
   const parkingAreas = useSelector(selectSelectedParkingAreas);
   const geometryLoaded = !!selectedDistrictData[0]?.boundary || !!parkingAreas[0]?.boundary;
 


### PR DESCRIPTION
When selecting a neighborhood, postcode or major district from the area list, the map should zoom to the selected area. Fix issue where the map did zoom but only momentarily and then zoomed back to the original view.

![zoom](https://github.com/City-of-Helsinki/servicemap-ui/assets/10584178/851e02db-63ff-448d-a341-735c3b5b9639)

[Refs](https://trello.com/c/uEDYl6iL/1578-bugi-kun-valitsee-postinumeron-listasta-n%C3%A4kym%C3%A4-zoomaa-vain-hetkellisesti)