### PR TITLE
Unit view: add route info on top and remove settings

### DIFF
--- a/browserTests/views/unitPageTest.js
+++ b/browserTests/views/unitPageTest.js
@@ -11,6 +11,7 @@ const testUrl = `${getBaseUrl()}/fi/unit/51342`
 const selectSettingsAndClose = async (t) => {
   if (t) {
     await t
+      .click(Selector('[data-sm="SettingsMenuButton"]'))
       .click(Selector(sensesDropdown))
       .click(Selector('[data-sm="senses-hearingAid"]'))
       .click(Selector('[data-sm="senses-visuallyImpaired"]'))

--- a/src/components/RouteBar/RouteBar.js
+++ b/src/components/RouteBar/RouteBar.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Link, Typography } from '@mui/material';
+import styled from '@emotion/styled';
+import RouteIcon from '@mui/icons-material/DirectionsBus';
+import { useIntl } from 'react-intl';
+import routeDetails from '../../views/UnitView/utils/routeDetails';
+
+function RouteBar({ unit, userLocation }) {
+  const intl = useIntl();
+
+  const { routeUrl, extraText } = routeDetails(unit, userLocation);
+  const text = intl.formatMessage({ id: 'unit.route' });
+  const linkText = `${text}${extraText}`;
+
+  return (
+    <StyledContainer>
+      <Link target="_blank" href={routeUrl}>
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          <StyledIcon />
+          <Typography style={{ textAlign: 'left' }}>
+            {linkText}
+          </Typography>
+        </div>
+      </Link>
+    </StyledContainer>
+  );
+}
+
+const StyledContainer = styled(Link)(({ theme }) => ({
+  display: 'flex',
+  background: 'paper',
+  padding: theme.spacing(1),
+  paddingLeft: theme.spacing(2),
+}));
+
+const StyledIcon = styled(RouteIcon)(({ theme }) => ({
+  marginRight: theme.spacing(1),
+}));
+
+export default RouteBar;

--- a/src/components/RouteBar/index.js
+++ b/src/components/RouteBar/index.js
@@ -1,0 +1,3 @@
+import RouteBar from './RouteBar';
+
+export default RouteBar;

--- a/src/components/SettingsComponent/SettingsComponent.js
+++ b/src/components/SettingsComponent/SettingsComponent.js
@@ -38,10 +38,9 @@ const SettingsComponent = ({ variant }) => {
   const chipLabel = intl.formatMessage({ id: 'settings.accordion.open' });
   return (
     <NoSsr>
-      <StyledContainer
+      <Container
         disableGutters
         sx={{ pb: 2, bgcolor: 'primary.main' }}
-        paddingtopsettings={+(variant === 'paddingTopSettings')}
       >
         <StyledAccordion
           settingsVisible={settingsVisible}
@@ -71,14 +70,10 @@ const SettingsComponent = ({ variant }) => {
           }
           collapseContent={(<SettingsDropdowns />)}
         />
-      </StyledContainer>
+      </Container>
     </NoSsr>
   );
 };
-
-const StyledContainer = styled(Container)(({ theme, paddingtopsettings }) => (
-  paddingtopsettings ? { paddingTop: theme.spacing(2) } : {}
-));
 
 const StyledAccordion = styled(SMAccordion)(({ theme, settingsVisible }) => ({
   height: settingsVisible ? 32 : '100%',

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -18,6 +18,7 @@ import Loading from './Loading';
 import MobileComponent from './MobileComponent';
 import ReadSpeakerButton from './ReadSpeakerButton';
 import ResultOrderer from './ResultOrderer';
+import RouteBar from './RouteBar/RouteBar';
 import SettingsComponent from './SettingsComponent';
 import SMButton from './ServiceMapButton';
 import SMRadio from './SMRadio';
@@ -78,6 +79,7 @@ export {
   ResultItem,
   ResultList,
   ResultOrderer,
+  RouteBar,
   ServiceItem,
   SettingsComponent,
   SimpleListItem,

--- a/src/views/UnitView/UnitView.js
+++ b/src/views/UnitView/UnitView.js
@@ -18,7 +18,6 @@ import {
   LinkSettingsDialog,
   ReadSpeakerButton,
   SearchBar,
-  SettingsComponent,
   SimpleListItem,
   SMButton,
   TabLists,
@@ -580,7 +579,6 @@ const UnitView = (props) => {
                     ? renderUnitLocation()
                     : renderPicture()
                 }
-                <SettingsComponent variant="paddingTopSettings" />
               </>
           )}
           />
@@ -595,7 +593,6 @@ const UnitView = (props) => {
           <Typography color="primary" variant="body1">
             <FormattedMessage id="unit.details.notFound" />
           </Typography>
-          <SettingsComponent />
         </div>
       </StyledRootContainer>
     );

--- a/src/views/UnitView/UnitView.js
+++ b/src/views/UnitView/UnitView.js
@@ -17,6 +17,7 @@ import {
   Container,
   LinkSettingsDialog,
   ReadSpeakerButton,
+  RouteBar,
   SearchBar,
   SimpleListItem,
   SMButton,
@@ -514,7 +515,10 @@ const UnitView = (props) => {
           titleComponent="h3"
           shareLink={elem}
         />
-      </>
+        {unit?.location?.coordinates && 
+          <RouteBar unit={unit} userLocation={userLocation} />
+        }
+      </> 
     );
 
     if (unitFetching) {

--- a/src/views/UnitView/components/ContactInfo/ContactInfo.js
+++ b/src/views/UnitView/components/ContactInfo/ContactInfo.js
@@ -6,9 +6,9 @@ import {
   ButtonBase, Divider, ListItem, Typography,
 } from '@mui/material';
 import { useHistory, useLocation } from 'react-router-dom';
-import config from '../../../../../config';
 import InfoList from '../InfoList';
 import unitSectionFilter from '../../utils/unitSectionFilter';
+import routeDetails from '../../utils/routeDetails';
 import { getAddressFromUnit } from '../../../../utils/address';
 import useLocaleText from '../../../../utils/useLocaleText';
 import { parseSearchParams, stringifySearchParams } from '../../../../utils';
@@ -213,31 +213,8 @@ const ContactInfo = ({ unit, userLocation, headingLevel }) => {
 
   // Add route info to data in location exists
   const unitLocation = unit.location;
-
   if (unitLocation?.coordinates) {
-    // Temporary link implementation for route info
-    let currentLocationString = ' ';
-
-    if (userLocation?.addressData) {
-      const { street, number } = userLocation.addressData;
-      const { latitude, longitude } = userLocation.coordinates;
-
-      const userAddress = `${getLocaleText(street.name)} ${number}, ${street.municipality}`;
-      currentLocationString = `${userAddress}::${latitude},${longitude}`;
-    }
-    let url = '';
-    let extraText = '';
-
-    if (config.hslRouteGuideCities?.includes(unit.municipality)) {
-      url = config.hslRouteGuideURL;
-      extraText = intl.formatMessage({ id: 'unit.route.extra.hslRouteGuide' });
-    } else {
-      url = config.reittiopasURL;
-      extraText = intl.formatMessage({ id: 'unit.route.extra.routeGuide' });
-    }
-
-    const destinationString = `${getLocaleText(unit.name)}, ${unit.municipality}::${unitLocation.coordinates[1]},${unitLocation.coordinates[0]}`;
-    const routeUrl = `${url}${currentLocationString}/${destinationString}?locale=${intl.locale}`;
+    const { routeUrl, extraText } = routeDetails(unit, userLocation);
 
     const route = {
       type: 'ROUTE',

--- a/src/views/UnitView/utils/routeDetails.js
+++ b/src/views/UnitView/utils/routeDetails.js
@@ -1,0 +1,37 @@
+import { useIntl } from 'react-intl';
+import config from '../../../../config';
+import useLocaleText from '../../../utils/useLocaleText';
+
+const routeDetails = (unit, userLocation) => {
+  const intl = useIntl();
+  const getLocaleText = useLocaleText();
+
+  const unitLocation = unit.location;
+
+  let currentLocationString = ' ';
+
+  if (userLocation?.addressData) {
+    const { street, number } = userLocation.addressData;
+    const { latitude, longitude } = userLocation.coordinates;
+
+    const userAddress = `${getLocaleText(street.name)} ${number}, ${street.municipality}`;
+    currentLocationString = `${userAddress}::${latitude},${longitude}`;
+  }
+  let url = '';
+  let extraText = '';
+
+  if (config.hslRouteGuideCities?.includes(unit.municipality)) {
+    url = config.hslRouteGuideURL;
+    extraText = intl.formatMessage({ id: 'unit.route.extra.hslRouteGuide' });
+  } else {
+    url = config.reittiopasURL;
+    extraText = intl.formatMessage({ id: 'unit.route.extra.routeGuide' });
+  }
+
+  const destinationString = `${getLocaleText(unit.name)}, ${unit.municipality}::${unitLocation.coordinates[1]},${unitLocation.coordinates[0]}`;
+  const routeUrl = `${url}${currentLocationString}/${destinationString}?locale=${intl.locale}`;
+
+  return { routeUrl, extraText };
+};
+
+export default routeDetails;


### PR DESCRIPTION
- Give more space to unit details by removing the settings from the unit view. The settings can be found in the navigation bar. 
- Add route info on top of the unit view (above the picture) to make it easier to find. 
 
<img width="446" alt="route_details" src="https://github.com/City-of-Helsinki/servicemap-ui/assets/10584178/60fa0c0b-3e6e-41cc-8a0c-8283afedb5b3">


[Refs](https://trello.com/c/MDzsMF6l/1579-poistetaan-omat-asetukset-toimipisteen-sivulta) & [Refs](https://trello.com/c/fpXSRI44/1569-siirret%C3%A4%C3%A4n-reittihaku-kuvan-ylle)
