### PR TITLE
Docker: Change node image source to ECR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22
+FROM public.ecr.aws/docker/library/node:22
 
 # Create app directory
 WORKDIR /servicemap-ui


### PR DESCRIPTION
Change the node image source to Amazon ECR to avoid hitting the Docker Hub pull rate limit.

[Refs](https://trello.com/c/EB2AQhjj/1586-vaihtoehtoja-dockerhubille)