### PR TITLE
Fix navigating from embedder view to info and feedback view

### DIFF
--- a/src/components/Navigator/Navigator.js
+++ b/src/components/Navigator/Navigator.js
@@ -120,7 +120,8 @@ class Navigator extends React.Component {
     const { params } = match;
     const locale = params && params.lng;
 
-    const embedValue = typeof embed !== 'undefined' ? embed : isEmbed();
+    const isEmbeddableView = target !== 'info' && target !== 'feedback';
+    const embedValue = isEmbeddableView ? (typeof embed !== 'undefined' ? embed : isEmbed()) : false;
 
     return generatePath(target, locale, data, embedValue);
   }


### PR DESCRIPTION
Navigating from the embedder view to the info or feedback view did not work as expected. Instead of navigating to the correct view, the user was redirected the embed view.

[Refs](https://trello.com/c/3IP94sge/1442-1-upotusty%C3%B6kalusta-siirtyminen-ei-toimi-oikein)