### PR TITLE
Make AddressSearchBar more accessible

### DIFF
--- a/src/components/AddressSearchBar/AddressSearchBar.js
+++ b/src/components/AddressSearchBar/AddressSearchBar.js
@@ -167,17 +167,19 @@ const AddressSearchBar = ({ title, handleAddressChange }) => {
 
   return (
     <StyledContainer>
-      <Typography color="inherit">{title}</Typography>
       <form action="" onSubmit={e => handleSubmit(e)}>
+        <label htmlFor="address-search-bar">
+          <Typography color="inherit">{title}</Typography>
+        </label>
         <StyledFlexContainer>
           <StyledInputBase
+            id="address-search-bar"
             data-sm="AddressSearchBar"
             autoComplete="off"
             inputRef={inputRef}
             inputProps={{
               role: 'combobox',
               'aria-haspopup': !!showSuggestions,
-              'aria-label': `${intl.formatMessage({ id: 'search.searchField' })} ${intl.formatMessage({ id: 'address.search' })}`,
               'aria-owns': showSuggestions ? 'address-results' : null,
               'aria-activedescendant': showSuggestions && resultIndex !== null ? `address-suggestion${resultIndex}` : null,
             }}


### PR DESCRIPTION
Previously used aria-label was not descriptive enough. Use label with the title instead.

[Refs](https://trello.com/c/C1qbbfYr/1281-1-osoitehakukent%C3%A4n-aria-labelin-selvitys)