### PR TITLE
Add close button to address popup

### DIFF
--- a/src/views/MapView/components/AddressPopup/AddressPopup.js
+++ b/src/views/MapView/components/AddressPopup/AddressPopup.js
@@ -79,7 +79,7 @@ const AddressPopup = ({
   };
 
   return (
-    <Popup className="popup" key="addressPopup" closeButton={false} autoPan={false} position={[mapClickPoint.lat, mapClickPoint.lng]}>
+    <Popup className="popup" key="addressPopup" autoPan={false} position={[mapClickPoint.lat, mapClickPoint.lng]}>
       <StyledAddressPopupContainer>
         <Typography ref={addressTextRef} variant="subtitle2" component="p">
           <FormattedMessage id="map.address.searching" />


### PR DESCRIPTION
Add close button to address popup.

<img width="406" alt="close-button" src="https://github.com/user-attachments/assets/3a96b15e-8193-483b-b2e0-5aa24f307e63">

[Refs](https://trello.com/c/KrLgXDKO/1572-osoite-pop-up-sulje-rasti)