### PR TITLE
Helsinki parking areas: add more details to the popup 

### DIFF
--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -184,6 +184,7 @@ const translations = {
   'parkingArea.popup.info4': 'The fees and restrictions do not apply to those who possess a resident or business parking permit if the parking area is a designated resident parking area.',
   'parkingArea.popup.info5': 'The fees and restrictions do not apply to those who possess a resident or business parking permit if the parking area is a designated resident parking area.',
   'parkingArea.popup.info6': 'The fees and restrictions do not apply to those who possess a resident or business parking permit if the parking area is a designated resident parking area.',
+  'parkingArea.popup.info7': 'Parking prohibited',
 
   'parkingArea.popup.vantaa.neighbourhood': 'City District: {value}',
   'parkingArea.popup.vantaa.name': 'Name: {value}',

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -164,6 +164,7 @@ const translations = {
   'parkingArea.popup.payment4': 'Paid parking',
   'parkingArea.popup.payment5': 'Paid parking',
   'parkingArea.popup.payment6': 'Paid parking',
+  'parkingArea.popup.payment7': 'Parking ban',
   'parkingArea.popup.duration1': 'Maximum duration of parking: {duration}',
   'parkingArea.popup.duration2': 'Maximum duration of parking: {duration}',
   'parkingArea.popup.duration3': '',

--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -164,6 +164,7 @@ const translations = {
   'parkingArea.popup.payment4': 'Maksullinen pysäköinti',
   'parkingArea.popup.payment5': 'Maksullinen pysäköinti',
   'parkingArea.popup.payment6': 'Maksullinen pysäköinti',
+  'parkingArea.popup.payment7': 'Pysäköintikielto',
   'parkingArea.popup.duration1': 'Pysäköinti sallittu enintään: {duration}',
   'parkingArea.popup.duration2': 'Pysäköinti sallittu enintään: {duration}',
   'parkingArea.popup.duration3': '',

--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -184,6 +184,7 @@ const translations = {
   'parkingArea.popup.info4': 'Maksut ja rajoitukset eivät koske asukas- ja yrityspysäköintitunnusten omistajia, jos pysäköintipaikka on merkitty asukaspysäköintipaikaksi.',
   'parkingArea.popup.info5': 'Maksut ja rajoitukset eivät koske asukas- ja yrityspysäköintitunnusten omistajia, jos pysäköintipaikka on merkitty asukaspysäköintipaikaksi.',
   'parkingArea.popup.info6': 'Maksut ja rajoitukset eivät koske asukas- ja yrityspysäköintitunnusten omistajia, jos pysäköintipaikka on merkitty asukaspysäköintipaikaksi.',
+  'parkingArea.popup.info7': 'Pysäköinti kielletty',
 
   'parkingArea.popup.vantaa.neighbourhood': 'Kaupunginosa: {value}',
   'parkingArea.popup.vantaa.name': 'Nimi: {value}',

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -165,6 +165,7 @@ const translations = {
   'parkingArea.popup.payment4': 'Parkering mot avgift',
   'parkingArea.popup.payment5': 'Parkering mot avgift',
   'parkingArea.popup.payment6': 'Parkering mot avgift',
+  'parkingArea.popup.payment7': 'Parkeringsförbud',
   'parkingArea.popup.duration1': 'Parkering tillåten högst: {duration}',
   'parkingArea.popup.duration2': 'Parkering tillåten högst: {duration}',
   'parkingArea.popup.duration3': '',

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -185,6 +185,7 @@ const translations = {
   'parkingArea.popup.info4': 'Avgifterna och begränsningarna gäller inte personer med boende- eller företagsparkeringstillstånd om parkeringsplatsen har markerats som boendeparkeringsplats.',
   'parkingArea.popup.info5': 'Avgifterna och begränsningarna gäller inte personer med boende- eller företagsparkeringstillstånd om parkeringsplatsen har markerats som boendeparkeringsplats.',
   'parkingArea.popup.info6': 'Avgifterna och begränsningarna gäller inte personer med boende- eller företagsparkeringstillstånd om parkeringsplatsen har markerats som boendeparkeringsplats.',
+  'parkingArea.popup.info7': 'Parkering förbjuden',
 
   'parkingArea.popup.vantaa.neighbourhood': 'Stadsdelen: {value}',
   'parkingArea.popup.vantaa.name': 'Namn: {value}',

--- a/src/views/MapView/components/Districts/ParkingAreas.js
+++ b/src/views/MapView/components/Districts/ParkingAreas.js
@@ -110,6 +110,16 @@ const ParkingAreas = () => {
     zIndex: theme.zIndex.infront,
   });
 
+  function getHelsinkiTooltipText(extraData) {
+    const messages = [
+      intl.formatMessage({ id: `parkingArea.popup.payment${extraData.class}` }),
+      extraData.max_duration ? intl.formatMessage({ id: `parkingArea.popup.duration${extraData.class}` }, { duration: extraData.max_duration }) : '',
+      extraData.validity_period ? intl.formatMessage({ id: `parkingArea.popup.validity${extraData.class}` }, { validity: extraData.validity_period }) : '',
+      extraData.class === '5' ? intl.formatMessage({ id: 'parkingArea.popup.duration5' }) : ''
+    ];
+    return messages.filter(message => message).join(' - ');
+  }
+
   function resolveTooltipText(area) {
     const type = area?.type;
     if (type === 'park_and_ride_area') {
@@ -122,8 +132,12 @@ const ParkingAreas = () => {
       return `${area.extra?.area_key ?? ''}${getLocaleText(area.name)} - ${intl.formatMessage({ id: 'area.list.heavy_traffic' })}`;
     }
     if (area.name) {
-      const translationKey = `area.list.${type}`;
-      return `${area.extra?.area_key ?? ''}${getLocaleText(area.name)} - ${intl.formatMessage({ id: translationKey })}`;
+      if (area.municipality === 'helsinki') {
+        return getHelsinkiTooltipText(area.extra);
+      } else {
+        const translationKey = `area.list.${type}`;
+        return `${area.extra?.area_key ?? ''}${getLocaleText(area.name)} - ${intl.formatMessage({ id: translationKey })}`;
+      }
     }
     return null;
   }


### PR DESCRIPTION
Add payment, duration and other details to the parking area popup forHelsinki parking areas.

Example of popup details before change: 
<img width="390" alt="before" src="https://github.com/user-attachments/assets/18af849b-7cd6-4bb8-bf5f-a25af1ceba09">

After:
<img width="698" alt="after" src="https://github.com/user-attachments/assets/0698c98b-6886-4137-8db5-acc01a37f18d">


Also, add some missing translations in popups.

[Refs](https://trello.com/c/6d6G6U6F/1556-pys%C3%A4k%C3%B6intialuiden-tietojen-n%C3%A4ytt%C3%A4minen-ilman-hiiren-n%C3%A4p%C3%A4ytyst%C3%A4?filter=*) & [Refs](https://trello.com/c/4wPSZvtc/1602-pys%C3%A4k%C3%B6intikieltojen-popuppien-tekstit-osin-rikki)