### PR TITLE
Fix: Handle all areas of MultiPolygon in UnitGeometry

### DIFF
--- a/src/views/MapView/components/UnitGeometry/UnitGeometry.js
+++ b/src/views/MapView/components/UnitGeometry/UnitGeometry.js
@@ -26,7 +26,7 @@ const UnitGeometry = ({ data }) => {
               break;
             }
             case 'MultiPolygon': {
-              unitGeometry = swapCoordinates(coordinates[0]);
+              unitGeometry = coordinates.map(polygon => swapCoordinates(polygon));
               break;
             }
             default:


### PR DESCRIPTION
The issue was that only the first area of a MultiPolygon was used in the UnitGeometry, meaning that only part of some areas were shown in the map. Updated the MultiPolygon case to iterate over all polygons.

Before the fix:
<img width="500" alt="before" src="https://github.com/user-attachments/assets/e20f6ef6-185b-40ef-99f6-c0f7935a4732">

And after:
<img width="500" alt="after" src="https://github.com/user-attachments/assets/3d38966b-725e-4593-9f55-383a3d939b70">


[Refs](https://trello.com/c/FpimYvAi/1553-luonnonsuojelualueiden-alue-geometrian-p%C3%A4ivitys-toimipisteisiin)