### PR TITLE
Remove unused configs and translations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,6 @@
 # production
 /build
 
-# external translations
-/src/i18n/externalTranslations
-
 # misc
 .DS_Store
 .env
@@ -29,5 +26,3 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-
-municipalities.json

--- a/config/default.js
+++ b/config/default.js
@@ -161,32 +161,27 @@ if (typeof settings.SLOW_FETCH_MESSAGE_TIMEOUT === 'undefined') {
   settings.SLOW_FETCH_MESSAGE_TIMEOUT = 3000;
 }
 
-let municipalities;
-try {
-  municipalities = require('./municipalities.json');
-} catch(e) {
-  municipalities = {
-    fi: {
-      espoo: 'Espoo',
-      helsinki: 'Helsinki',
-      kauniainen: 'Kauniainen',
-      vantaa: 'Vantaa',
-      kirkkonummi: 'Kirkkonummi'
-    },
-    en: {
-      espoo: 'Espoo',
-      helsinki: 'Helsinki',
-      kauniainen: 'Kauniainen',
-      vantaa: 'Vantaa',
-      kirkkonummi: 'Kirkkonummi'
-    },
-    sv: {
-      espoo: 'Esbo',
-      helsinki: 'Helsingfors',
-      kauniainen: 'Grankulla',
-      vantaa: 'Vanda',
-      kirkkonummi: 'Kyrkslätt'
-    }
+const municipalities = {
+  fi: {
+    espoo: 'Espoo',
+    helsinki: 'Helsinki',
+    kauniainen: 'Kauniainen',
+    vantaa: 'Vantaa',
+    kirkkonummi: 'Kirkkonummi'
+  },
+  en: {
+    espoo: 'Espoo',
+    helsinki: 'Helsinki',
+    kauniainen: 'Kauniainen',
+    vantaa: 'Vantaa',
+    kirkkonummi: 'Kirkkonummi'
+  },
+  sv: {
+    espoo: 'Esbo',
+    helsinki: 'Helsingfors',
+    kauniainen: 'Grankulla',
+    vantaa: 'Vanda',
+    kirkkonummi: 'Kyrkslätt'
   }
 }
 /**

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -1,5 +1,5 @@
 /* eslint-disable quote-props */
-const translations = {
+export default {
   'app.title': 'Service map',
   'app.description': 'Find services near your home',
   'app.og.image.alt': 'Servicemap logo',
@@ -730,16 +730,3 @@ const translations = {
   'opens.new.tab': '(new tab)',
   'alert.close': 'Close the notification',
 };
-
-let overridingExternalTranslations;
-
-// Read and merge external translations with current translations
-try {
-  // eslint-disable-next-line global-require,import/no-unresolved
-  overridingExternalTranslations = require('./externalTranslations/en.json');
-} catch (e) {
-  overridingExternalTranslations = {};
-}
-
-const englishTranslations = { ...translations, ...overridingExternalTranslations };
-export default englishTranslations;

--- a/src/i18n/fi.js
+++ b/src/i18n/fi.js
@@ -1,5 +1,5 @@
 /* eslint-disable quote-props */
-const translations = {
+export default {
   'app.title': 'Palvelukartta',
   'app.description': 'Pääkaupunkiseudun kaikki julkiset palvelut ulottuvillasi.',
   'app.og.image.alt': 'Palvelukartan logo',
@@ -733,16 +733,3 @@ const translations = {
   'opens.new.tab': '(uusi välilehti)',
   'alert.close': 'Sulje ilmoitus',
 };
-
-let overridingExternalTranslations;
-
-// Read and merge external translations with current translations
-try {
-  // eslint-disable-next-line global-require,import/no-unresolved
-  overridingExternalTranslations = require('./externalTranslations/fi.json');
-} catch (e) {
-  overridingExternalTranslations = {};
-}
-
-const finnishTranslations = { ...translations, ...overridingExternalTranslations };
-export default finnishTranslations;

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -1,5 +1,5 @@
 /* eslint-disable quote-props */
-const translations = {
+export default {
   'app.title': 'Servicekarta',
   'app.description': 'Alla tjänster i huvudstadsregionen inom räckhåll.',
   'app.og.image.alt': 'Servicekarta logo',
@@ -731,16 +731,3 @@ const translations = {
   'opens.new.tab': '(ny flik)',
   'alert.close': 'Stäng meddelande',
 };
-
-let overridingExternalTranslations;
-
-// Read and merge external translations with current translations
-try {
-  // eslint-disable-next-line global-require,import/no-unresolved
-  overridingExternalTranslations = require('./externalTranslations/sv.json');
-} catch (e) {
-  overridingExternalTranslations = {};
-}
-
-const swedishTranslations = { ...translations, ...overridingExternalTranslations };
-export default swedishTranslations;


### PR DESCRIPTION
Remove unused municipality configs and translations. These raised warnings in the logs and were not used anywhere in the project anymore.