### PR TITLE
Make keyword check case-insensitive for 'kuuluvuuskartta'

### DIFF
--- a/server/dataFetcher.js
+++ b/server/dataFetcher.js
@@ -125,7 +125,7 @@ export const fetchSelectedUnitData = (req, res, next) => {
       }
       data.complete = true;
       store.dispatch(changeSelectedUnit(data));
-      if (data.keywords.fi?.includes('kuuluvuuskartta')) {
+      if (data.keywords.fi?.some(keyword => keyword.toLowerCase() === 'kuuluvuuskartta')) {
         const hearingMapAPI = new HearingMapAPI();
         const {
           fetchSuccess, fetchError,

--- a/src/views/UnitView/UnitView.js
+++ b/src/views/UnitView/UnitView.js
@@ -137,7 +137,7 @@ const UnitView = (props) => {
     if (!stateUnit || !checkCorrectUnit(stateUnit) || !stateUnit.complete) {
       fetchSelectedUnit(unitId, (unit) => {
         setUnit(unit);
-        if (unit?.keywords?.fi?.includes('kuuluvuuskartta')) {
+        if (unit?.keywords?.fi?.some(keyword => keyword.toLowerCase() === 'kuuluvuuskartta')) {
           fetchHearingMaps(unitId);
         }
       });


### PR DESCRIPTION
Make keyword check case-insensitive for 'kuuluvuuskartta' to handle different capitalizations.

[Refs](https://trello.com/c/hjhRGf4A/1627-laajasalon-terveysasema-kuulokartat-puuttuvat)