### PR TITLE
Fix service producing wrong results

### DIFF
--- a/src/views/SearchView/SearchView.js
+++ b/src/views/SearchView/SearchView.js
@@ -170,8 +170,8 @@ function SearchView() {
     // Check if search query ends with number and fetch data without it.
     // This is for searching addresses with street number in case of no results.
     if (searchQuery && searchQuery.match(/\d$/)) {
-      const newSearchQuery = searchQuery.replace(/\d$/, '');
-      if (newSearchQuery !== searchQuery) {
+      const newSearchQuery = searchQuery.replace(/\d+$/, '');
+      if (newSearchQuery && newSearchQuery !== searchQuery) {
         dispatch(fetchSearchResults({ q: newSearchQuery }));
       }
     }

--- a/src/views/SearchView/SearchView.js
+++ b/src/views/SearchView/SearchView.js
@@ -335,7 +335,8 @@ function SearchView() {
       }
     } else {
       const { previousSearch, isFetching } = searchFetchState;
-      if (previousSearch && !isFetching) {
+      const options = getSearchParamData();
+      if (options.q && previousSearch && !isFetching) {
         // If no results found, try to fetch results without number
         fetchSearchResultsWithoutNumber(previousSearch);
       }


### PR DESCRIPTION
Primary issue was:

fetchSearchResultsWithoutNumber previously relied on previousSearch
value to perform the second search. However, previousSearch can take
many forms depending on the search that was done, for example it might
just be a number when searching for a specific service_id. This would
cause the second search to happen possibly search?q={service_id} instead
of unit?service_id={service_id}.

Also fixed the regex removing only one number at a time. 

https://helsinkisolutionoffice.atlassian.net/browse/PL-32