### PR TITLE
Allow unit MultiLineString scrolling

### DIFF
--- a/browserTests/generic/mapTest.js
+++ b/browserTests/generic/mapTest.js
@@ -40,7 +40,7 @@ test('Unit geometry is drawn on map', async (t) => {
   const listItem = Selector('#paginatedList-Toimipisteet-results li[role="link"]').nth(0);
   await t
     .click(listItem)
-    .expect(polygon.exists).ok('Unit geometry not drawn on map');
+    .expect(polygon.exists).ok('Unit geometry is drawn on map');
 });
 
 fixture`Unit page geometry test`
@@ -54,4 +54,34 @@ test('Unit geometry is drawn on map', async (t) => {
   const polygon = Selector('.leaflet-pane .leaflet-overlay-pane').find('svg');
   await t
     .expect(polygon.exists).ok();
+});
+
+test('Height profile is drawn on map', async (t) => {
+  const heightProfile = Selector('.heightgraph').find('svg');
+  await t
+    .expect(heightProfile.exists).ok();
+});
+
+test('Height profile browse buttons exist', async (t) => {
+  const heightProfilePrevButton = Selector('.height-profile-prev-button');
+  const heightProfileNextButton = Selector('.height-profile-next-button');
+  await t
+    .expect(heightProfilePrevButton.exists).ok()
+    .expect(heightProfileNextButton.exists).ok()
+});
+
+test('Height profile geometry browsing', async (t) => {
+  const heightProfilePrevButton = Selector('.height-profile-prev-button');
+  const heightProfileNextButton = Selector('.height-profile-next-button');
+  const polygon = Selector('.leaflet-pane .leaflet-overlay-pane').find('svg');
+  await t
+    .expect(polygon.exists).ok('Unit geometry is drawn on map');
+  
+  await t
+    .click(heightProfileNextButton)
+    .expect(polygon.exists).ok('Unit next geometry is drawn on map');
+  
+  await t
+    .click(heightProfilePrevButton)
+    .expect(polygon.exists).ok('Unit previous geometry is drawn on map');
 });

--- a/src/assets/icons/icon-arrow-next.svg
+++ b/src/assets/icons/icon-arrow-next.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#000000"><path d="m321-80-71-71 329-329-329-329 71-71 400 400L321-80Z"/></svg>

--- a/src/assets/icons/icon-arrow-previous.svg
+++ b/src/assets/icons/icon-arrow-previous.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#000000"><path d="M640-80 240-480l400-400 71 71-329 329 329 329-71 71Z"/></svg>

--- a/src/index.css
+++ b/src/index.css
@@ -97,6 +97,49 @@ input[type="search"]::-webkit-search-cancel-button{
   user-select: none;
 }
 
+.height-profile-buttons {
+  display: flex;
+  margin-left: 5px;
+}
+
+.height-profile-prev-button {
+  background: url(assets/icons/icon-arrow-previous.svg) no-repeat center center;
+  width: 26px;
+  height: 26px;
+  margin-top: -34px;
+  border: 1px solid #ccc;
+  box-shadow: 0 0px 2px rgba(0, 0, 0, 0.6);
+  border-radius: 2px;
+
+  &:hover,
+  &:active {
+    color: #0072c6;
+  }
+
+  &:hover {
+    cursor: pointer;
+  }
+}
+
+.height-profile-next-button {
+  background: url(assets/icons/icon-arrow-next.svg) no-repeat center center;
+  width: 26px;
+  height: 26px;
+  margin-top: -34px;
+  border: 1px solid #ccc;
+  box-shadow: 0 0px 2px rgba(0, 0, 0, 0.6);
+  border-radius: 2px;
+
+  &:hover,
+  &:active {
+    color: #0072c6;
+  }
+
+  &:hover {
+    cursor: pointer;
+  }
+}
+
 .heightgraph-toggle {
   cursor: pointer;
   box-shadow: 0 1px 7px rgba(0, 0, 0, .4);

--- a/src/views/MapView/MapView.js
+++ b/src/views/MapView/MapView.js
@@ -353,7 +353,7 @@ const MapView = (props) => {
           )}
 
           {!disableInteraction && currentPage === 'unit' && unitHasLineStringLocationAndGeometry(highlightedUnit) && (
-            <ElevationControl data={highlightedUnit} isMobile={isMobile}/>
+            <ElevationControl unit={highlightedUnit} isMobile={isMobile}/>
           )}
 
           {!hideUserMarker && userLocation && (

--- a/src/views/MapView/components/ElevationControl/ElevationControl.js
+++ b/src/views/MapView/components/ElevationControl/ElevationControl.js
@@ -1,91 +1,101 @@
 import { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
 import { useMap } from 'react-leaflet';
 import { getPage } from '../../../../redux/selectors/user';
 
-const ElevationControl = ({ data, isMobile}) => {
+const ElevationControl = ({ unit, isMobile}) => {
   const intl = useIntl();
   const map = useMap();
   const currentPage = useSelector(getPage);
-  const [geometryData, setGeometryData] = useState(null);
+  const [geometryIndex, setGeometryIndex] = useState(0);
+  const [geometry, setGeometry] = useState(null);
 
-  useEffect(() => {
-    const getUnitGeometry = (unit) => {
-      if (currentPage !== 'unit') {
-        return null;
-      }
-      const { geometry_3d } = unit;
-      if (geometry_3d) {
-        const coordinates = geometry_3d?.coordinates;
-        if (coordinates && geometry_3d.type === 'MultiLineString') {
-          return {
-            ...geometry_3d,
-            coordinates: coordinates[0],
-          };
-        }
-      }
+  const getUnitGeometry = (unitData) => {
+    if (currentPage !== 'unit') {
       return null;
-    };
-
-    setGeometryData(getUnitGeometry(data));
-  }, [data]);
+    }
+    const { geometry_3d } = unitData;
+    if (geometry_3d) {
+      const coordinates = geometry_3d?.coordinates;
+      if (coordinates && geometry_3d.type === 'MultiLineString') {
+        const lineString = coordinates[geometryIndex];
+        return {
+          coordinates: lineString,
+        };
+      }
+    }
+    return null;
+  };
 
   useEffect(() => {
-    if(!geometryData || !geometryData.coordinates) {
-        return;
+    setGeometry(getUnitGeometry(unit));
+  }, [unit, geometryIndex, currentPage]);
+
+  function constructProfileGeoJson(coordinates) {
+    return [{
+      'type': 'FeatureCollection',
+      'features': [{
+        'type': 'Feature',
+        'geometry': {
+          'type': 'LineString',
+          'coordinates': coordinates
+        },
+        'properties': {
+          'attributeType': 'flat'
+        }}],
+        'properties': {
+          'summary': 'HeightProfile',
+          'label': intl.formatMessage({ id: 'map.heightProfile.title' }),
+        }
+    }];
+  }
+
+  const onRoute = event => {
+    control.mapMousemoveHandler(event, { showMapMarker: true });
+  }
+  const outRoute = event => {
+    control.mapMouseoutHandler(2000);
+  }
+  
+  useEffect(() => {
+    if(!geometry?.coordinates) {
+      setGeometryIndex(0);
+      return;
     }
-    function constructProfileGeoJson(coordinates) {
-        return [{
-            'type': 'FeatureCollection',
-            'features': [{
-                'type': 'Feature',
-                'geometry': {
-                    'type': 'LineString',
-                    'coordinates': coordinates
-                },
-                'properties': {
-                    'attributeType': 'flat'
-                }
-            }],
-            'properties': {
-                "summary": 'HeightProfile',
-                'label': intl.formatMessage({ id: 'map.heightProfile.title' }),
-            }
-        }];
-    }
-    const geoJson = constructProfileGeoJson(geometryData.coordinates);
     
-    const onRoute = event => {
-        control.mapMousemoveHandler(event, { showMapMarker: true });
-    }
-    const outRoute = event => {
-        control.mapMouseoutHandler(2000);
-    }
+    const geoJson = constructProfileGeoJson(geometry?.coordinates);
 
     const control = L.control.heightgraph({
-        position: !isMobile ? 'bottomright' : 'topright',
-        mappings: {
-            'HeightProfile': {
-                'flat': {
-                    text: intl.formatMessage({ id: 'map.heightProfile.title' }),
-                    color: '#FD4F00'
-                }
-            }
-        },
-        graphStyle: {
-            opacity: 0.8,
-            'fill-opacity': 0.5,
-            'stroke-width': '3px'
-        },
-        translation: {
-            distance: intl.formatMessage({ id: 'map.heightProfile.distance' }),
-            elevation: intl.formatMessage({ id: 'map.heightProfile.elevation' }),
-            segment_length: intl.formatMessage({ id: 'map.heightProfile.segmentLength' }),
-            type: intl.formatMessage({ id: 'map.heightProfile.type' }),
-            legend: intl.formatMessage({ id: 'map.heightProfile.legend' }),
-        },
-        expandControls: true
+      position: !isMobile ? 'bottomright' : 'topright',
+      mappings: {
+        'HeightProfile': {
+          'flat': {
+            text: intl.formatMessage({ id: 'map.heightProfile.title' }),
+            color: '#FD4F00'
+          }
+        }
+      },
+      graphStyle: {
+        opacity: 0.8,
+        'fill-opacity': 0.5,
+        'stroke-width': '3px'
+      },
+      translation: {
+        distance: intl.formatMessage({ id: 'map.heightProfile.distance' }),
+        elevation: intl.formatMessage({ id: 'map.heightProfile.elevation' }),
+        segment_length: intl.formatMessage({ id: 'map.heightProfile.segmentLength' }),
+        type: intl.formatMessage({ id: 'map.heightProfile.type' }),
+        legend: intl.formatMessage({ id: 'map.heightProfile.legend' }),
+      },
+      expandControls: true,
+      expandCallback: function(expanded) {
+        const heightProfileButtons = L.DomUtil.get("height-profile-buttons");
+        if (heightProfileButtons) {
+          heightProfileButtons.style.visibility = expanded ? "visible" : "hidden";
+        }
+      }
     });
 
     const displayGroup = new L.LayerGroup();
@@ -94,37 +104,59 @@ const ElevationControl = ({ data, isMobile}) => {
     control.addData(geoJson);
 
     const layer = L.geoJson(geoJson, {
-        style: {
-            color: '#FD4F00',
-            opacity: 0.8,
-            weight: 3,
-            fillOpacity: 0.5
-        }
+      style: {
+        color: '#FD4F00',
+        opacity: 0.8,
+        weight: 6,
+        fillOpacity: 0.5
+      }
     });
-    layer
-        .on({
-            'mousemove': onRoute,
-            'mouseout': outRoute,
-        })
-        .addTo(displayGroup);
+    layer.on({
+      'mousemove': onRoute,
+      'mouseout': outRoute,
+    }).addTo(displayGroup);
     
     if (isMobile) {
-        control.getContainer().style.marginTop = '80px';
-        control.getContainer().style.marginRight = '-108px';
-        control._button.style.marginRight = '154px';
-        control._button.style.marginTop = '210px';
-        control.resize({width:370, height:200});
+      control.getContainer().style.marginTop = '80px';
+      control.getContainer().style.marginRight = '-108px';
+      control._button.style.marginRight = '154px';
+      control._button.style.marginTop = '210px';
+      control.resize({width:370, height:200});
     } else {
-        control.resize({width:800, height:300});
+      control.resize({width:800, height:300});
     }
 
+    const buttonsDiv = L.DomUtil.create("div", "height-profile-buttons", control.getContainer());
+    buttonsDiv.id = "height-profile-buttons";
+    const prevButton = L.DomUtil.create("button", "height-profile-prev-button", buttonsDiv);
+    const nextButton = L.DomUtil.create("button", "height-profile-next-button", buttonsDiv);
+  
+    L.DomEvent.on(prevButton, "mousedown dblclick", L.DomEvent.stopPropagation)
+      .on(prevButton, "click", (event) => {
+      if (geometryIndex > 0) {
+        setGeometryIndex(geometryIndex - 1);
+      }
+    });
+  
+    L.DomEvent.on(nextButton, "mousedown dblclick", L.DomEvent.stopPropagation)
+      .on(nextButton, "click", (event) => {
+      if (unit?.geometry_3d && geometryIndex < unit?.geometry_3d?.coordinates?.length - 1) {
+        setGeometryIndex(geometryIndex + 1);
+      }
+    });
+
     return () => {
-        map.removeControl(control);
-        map.removeLayer(displayGroup);
+      map.removeControl(control);
+      map.removeLayer(displayGroup);
     }
-  });
+  }, [geometry, geometryIndex]);
 
   return null;
 }
+
+ElevationControl.propTypes = {
+  unit: PropTypes.objectOf(PropTypes.any),
+  isMobile: PropTypes.bool,
+};
 
 export default ElevationControl;


### PR DESCRIPTION
Allow unit MultiLineString scrolling when unit geometry has multiple line segments in it.
Browsing segments happen through new next- and previous-buttons in the height profile component's left bottom corner.

Also added TestCafe browser tests for the height profile.

Desktop-layout:
![servicemap-height-profile](https://github.com/user-attachments/assets/f340736d-e00d-481f-b3f5-1e561a7a3df0)

Mobile-layout:
![servicemap-height-profile-mobile](https://github.com/user-attachments/assets/4d8155d5-1835-4f34-8f01-f7e36120a175)

Refs: [PL-41](https://helsinkisolutionoffice.atlassian.net/browse/PL-41)

[PL-41]: https://helsinkisolutionoffice.atlassian.net/browse/PL-41?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ