### PR TITLE
Move route handlers inside useEffect-hook

### DIFF
--- a/src/views/MapView/components/ElevationControl/ElevationControl.js
+++ b/src/views/MapView/components/ElevationControl/ElevationControl.js
@@ -51,13 +51,6 @@ const ElevationControl = ({ unit, isMobile}) => {
         }
     }];
   }
-
-  const onRoute = event => {
-    control.mapMousemoveHandler(event, { showMapMarker: true });
-  }
-  const outRoute = event => {
-    control.mapMouseoutHandler(2000);
-  }
   
   useEffect(() => {
     if(!geometry?.coordinates) {
@@ -66,6 +59,13 @@ const ElevationControl = ({ unit, isMobile}) => {
     }
     
     const geoJson = constructProfileGeoJson(geometry?.coordinates);
+
+    const onRoute = event => {
+      control.mapMousemoveHandler(event, { showMapMarker: true });
+    }
+    const outRoute = event => {
+      control.mapMouseoutHandler(2000);
+    }
 
     const control = L.control.heightgraph({
       position: !isMobile ? 'bottomright' : 'topright',


### PR DESCRIPTION
Latest height profile refactoring efforts induced a new regression bug:
`Uncaught ReferenceError: control is not defined` when mouse is hovered on top of a line route.

Fix this by moving route handlers back inside the useEffect-hook.