### PR TITLE
fix: change defaultProps to JS default parameters

### DIFF
--- a/src/components/ErrorBoundary/ErrorBoundary.js
+++ b/src/components/ErrorBoundary/ErrorBoundary.js
@@ -28,8 +28,4 @@ ErrorBoundary.propTypes = {
   errorComponent: PropTypes.node,
 };
 
-ErrorBoundary.defaultProps = {
-  errorComponent: null,
-};
-
 export default ErrorBoundary;

--- a/src/components/MapSettings/MapSettings.js
+++ b/src/components/MapSettings/MapSettings.js
@@ -15,7 +15,7 @@ import MobileSettingsHeader from '../MobileSettingsHeader/MobileSettingsHeader';
 import SMButton from '../ServiceMapButton';
 import ExternalMapUrlCreator from './externalMapUrlCreator';
 
-function MapSettings({ onClose }) {
+function MapSettings({ onClose = null }) {
   const intl = useIntl();
   const dispatch = useDispatch();
 
@@ -111,10 +111,6 @@ const Styled3DMapLinkButton = styled(SMButton)(({ theme }) => ({
 
 MapSettings.propTypes = {
   onClose: PropTypes.func,
-};
-
-MapSettings.defaultProps = {
-  onClose: null,
 };
 
 export default MapSettings;

--- a/src/components/MobileSettingsHeader/MobileSettingsHeader.js
+++ b/src/components/MobileSettingsHeader/MobileSettingsHeader.js
@@ -5,7 +5,7 @@ import React from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 
-function MobileSettingsHeader({ textId, onClose }) {
+function MobileSettingsHeader({ textId, onClose = null }) {
   const intl = useIntl();
 
   return (
@@ -51,10 +51,6 @@ const StyledCloseButton = styled(IconButton)(() => ({
 MobileSettingsHeader.propTypes = {
   textId: PropTypes.string.isRequired,
   onClose: PropTypes.func,
-};
-
-MobileSettingsHeader.defaultProps = {
-  onClose: null,
 };
 
 export default MobileSettingsHeader;

--- a/src/components/SettingsDropdowns/SettingsDropdowns.js
+++ b/src/components/SettingsDropdowns/SettingsDropdowns.js
@@ -33,7 +33,7 @@ import SMButton from '../ServiceMapButton';
 import constants from '../SettingsComponent/constants';
 import SMAutocomplete from '../SMAutocomplete';
 
-function SettingsDropdowns({ variant }) {
+function SettingsDropdowns({ variant = 'default' }) {
   const intl = useIntl();
   const dispatch = useDispatch();
   const getLocaleText = useLocaleText();
@@ -291,10 +291,6 @@ const StyledAutocomplete = styled(SMAutocomplete)(({ theme, ownsettings, colormo
   };
   return { ...styles, ...ownSettingsStyles };
 });
-
-SettingsDropdowns.defaultProps = {
-  variant: 'default',
-};
 
 SettingsDropdowns.propTypes = {
   variant: PropTypes.oneOf(['default', 'ownSettings']),

--- a/src/components/TabLists/TabLists.js
+++ b/src/components/TabLists/TabLists.js
@@ -20,10 +20,10 @@ import PaginatedList from '../Lists/PaginatedList';
 function TabLists({
   location,
   data,
-  onTabChange,
-  focusClass,
-  focusText,
-  headerComponents,
+  onTabChange = null,
+  focusClass = null,
+  focusText = null,
+  headerComponents = null,
 }) {
   const isMobile = useMobileStatus();
   const theme = useTheme();
@@ -406,13 +406,6 @@ TabLists.propTypes = {
   location: PropTypes.objectOf(PropTypes.any).isRequired,
   focusClass: PropTypes.string,
   focusText: PropTypes.string,
-};
-
-TabLists.defaultProps = {
-  onTabChange: null,
-  focusClass: null,
-  focusText: null,
-  headerComponents: null,
 };
 
 export default TabLists;

--- a/src/views/UnitView/components/ContactInfo/ContactInfo.js
+++ b/src/views/UnitView/components/ContactInfo/ContactInfo.js
@@ -16,7 +16,10 @@ import { parseSearchParams, stringifySearchParams } from '../../../../utils';
 import { SMAccordion } from '../../../../components';
 
 function ContactInfo({
-  unit, userLocation, headingLevel, accessiblityTabRef,
+  unit,
+  userLocation = null,
+  headingLevel = 'h4',
+  accessiblityTabRef = null,
 }) {
   const intl = useIntl();
   const history = useHistory();
@@ -289,12 +292,6 @@ ContactInfo.propTypes = {
   userLocation: PropTypes.objectOf(PropTypes.any),
   headingLevel: PropTypes.string,
   accessiblityTabRef: PropTypes.shape({ current: PropTypes.any }),
-};
-
-ContactInfo.defaultProps = {
-  userLocation: null,
-  headingLevel: 'h4',
-  accessiblityTabRef: null,
 };
 
 export default ContactInfo;


### PR DESCRIPTION
defaultProps are deprecated in React v18.
Therefore change defaultProps to JS default parameters.

Refs [PL-54](https://helsinkisolutionoffice.atlassian.net/browse/PL-54)

[PL-54]: https://helsinkisolutionoffice.atlassian.net/browse/PL-54?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ