### PR TITLE
fix(hsl-icons): fix HSL TransitStop icon styles

### DIFF
--- a/src/hsl-icons.css
+++ b/src/hsl-icons.css
@@ -41,3 +41,26 @@
 .icon-icon-hsl-metro:before { content: "5"; }
 .icon-icon-hsl-ferry:before { content: "6"; }
 .icon-icon-hsl-bike:before { content: "7"; }
+
+.icon-icon-hsl-bus {
+  color: #007AC9;
+}
+.icon-icon-hsl-tram {
+  color: #00985F;
+}
+.icon-icon-hsl-train {
+  color: #8C4799;
+}
+.icon-icon-hsl-metro {
+  color: #FF6319;
+}
+.icon-icon-hsl-ferry {
+  color: #00B9E4;
+}
+.icon-icon-hsl-bike {
+  color: #00985F;
+}
+
+.leaflet-marker-icon {
+  font-size: 30px;
+}

--- a/src/views/MapView/components/TransitStops/TransitStops.js
+++ b/src/views/MapView/components/TransitStops/TransitStops.js
@@ -15,13 +15,14 @@ import { fetchBikeStations, fetchStops } from '../../utils/transitFetch';
 import TransitStopInfo from './TransitStopInfo';
 import getTypeAndClass from './util/util';
 
-const StyledTransitIconMap = styled.span(({ color }) => ({
+const StyledTransitIconMap = styled.span(({ color, className }) => ({
   fontSize: transitIconSize,
   height: transitIconSize,
   margin: 0,
   lineHeight: 1,
   textShadow: '-1px 0 #fff, 0 1px #fff, 1px 0 #fff, 0 -1px #fff',
   color,
+  className,
 }));
 
 const TransitStops = ({ mapObject }) => {
@@ -42,6 +43,7 @@ const TransitStops = ({ mapObject }) => {
     zIndex: theme.zIndex.behind,
     color: 'white',
     fontSize: transitIconSize,
+    marginTop: '8px',
   });
 
   const map = useMapEvents({
@@ -109,7 +111,7 @@ const TransitStops = ({ mapObject }) => {
   }, []);
 
   const getTransitIcon = (type) => {
-    const { divIcon } = require('leaflet');
+    const { divIcon } = global.L;
     const { color, className } = getTypeAndClass(type);
     return divIcon({
       html: renderToStaticMarkup(


### PR DESCRIPTION
Fix broken HSL TransitStop icon styles.

![hsl-icons-fixed](https://github.com/user-attachments/assets/30f2cc89-f83d-4907-b37b-8b02a00099b1)

Fixes [PL-35](https://helsinkisolutionoffice.atlassian.net/browse/PL-35)

[PL-35]: https://helsinkisolutionoffice.atlassian.net/browse/PL-35?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ