### PR TITLE
feat(digitransit-api): utilize digitransit-proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,11 +15,7 @@ RESERVATIONS_API="https://tilavaraus.hel.fi" # For production
 # RESERVATIONS_API="https://tilavaraus.dev.hel.ninja" # For local development
 
 FEEDBACK_URL="https://api.hel.fi/servicemap/open311/"
-DIGITRANSIT_API="https://api.digitransit.fi/routing/v1/routers/hsl/index/graphql"
-# This is key for DIGITRANSIT API. There are separate urls and keys for prod (api.digitransit.fi) and dev (dev-api.digitransit.fi) digitransit apis. Developer should generate own
-# api-keys. It is preferred to register keys for prod in portal (https://portal-api.digitransit.fi/) but in case dev api and key is needed then dev-protal is in
-# (https://portal-dev-api.digitransit.fi/)
-DIGITRANSIT_API_KEY=
+DIGITRANSIT_API="https://digitransit-proxy.api.hel.fi/routing/v1/routers/hsl/index/graphql"
 HEARING_MAP_API="https://kuulokuvat.fi/api/v1/servicemap-url"
 SERVICE_MAP_URL="https://tiles.hel.ninja/styles/hel-osm-bright/{z}/{x}/{y}"
 ACCESSIBLE_MAP_URL="https://tiles.hel.ninja/styles/turku-osm-high-contrast-pattern/{z}/{x}/{y}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,7 @@ jobs:
       EVENTS_API: https://api.hel.fi/linkedevents/v1
       RESERVATIONS_API: https://tilavaraus.hel.fi
       PRODUCTION_PREFIX: SM
-      DIGITRANSIT_API: https://api.digitransit.fi/routing/v1/routers/hsl/index/graphql
-      DIGITRANSIT_API_KEY: a9219bfb875d4cc79b5f69123b57d0db
+      DIGITRANSIT_API: https://digitransit-proxy.api.hel.fi/routing/v1/routers/hsl/index/graphql
       FEEDBACK_URL: https://api.hel.fi/servicemap/open311/
       HEARING_MAP_API: https://kuulokuvat.fi/api/v1/servicemap-url
       MODE: production

--- a/config/default.js
+++ b/config/default.js
@@ -222,10 +222,6 @@ const defaultConfig = {
     "root": settings.DIGITRANSIT_API,
     "id": 'DIGITRANSIT_API',
   },
-  "digitransitApiKey": {
-    "root": settings.DIGITRANSIT_API_KEY,
-    "id": 'DIGITRANSIT_API_KEY',
-  },
   "feedbackURL": {
     "root": settings.FEEDBACK_URL,
     "id": 'FEEDBACK_URL',

--- a/server/server.js
+++ b/server/server.js
@@ -207,7 +207,6 @@ const htmlTemplate = (req, reactDom, preloadedState, css, cssString, emotionCss,
         window.nodeEnvSettings.RESERVATIONS_API = "${process.env.RESERVATIONS_API}";
         window.nodeEnvSettings.PRODUCTION_PREFIX = "${process.env.PRODUCTION_PREFIX}";
         window.nodeEnvSettings.DIGITRANSIT_API = "${process.env.DIGITRANSIT_API}";
-        window.nodeEnvSettings.DIGITRANSIT_API_KEY = "${process.env.DIGITRANSIT_API_KEY}";
         window.nodeEnvSettings.FEEDBACK_URL = "${process.env.FEEDBACK_URL}";
         window.nodeEnvSettings.HEARING_MAP_API = "${process.env.HEARING_MAP_API}";
         window.nodeEnvSettings.HSL_ROUTE_GUIDE_URL = "${process.env.HSL_ROUTE_GUIDE_URL}";

--- a/src/views/MapView/utils/transitFetch.js
+++ b/src/views/MapView/utils/transitFetch.js
@@ -4,7 +4,6 @@ import { getBboxFromBounds } from '../../../utils/mapUtility';
 
 const digitransitApiHeaders = () => ({
   'Content-Type': 'application/graphql',
-  'digitransit-subscription-key': `${config.digitransitApiKey.root}`,
 });
 
 /* eslint-disable global-require */


### PR DESCRIPTION
Use Helsinki's own digitransit-proxy for DigiTransit queries.
Move api-key behind proxy.

Refs [PL-59](https://helsinkisolutionoffice.atlassian.net/browse/PL-59)

[PL-59]: https://helsinkisolutionoffice.atlassian.net/browse/PL-59?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ