### PR TITLE
feat: migrate to DigiTransit Routing API v2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ RESERVATIONS_API="https://varaamo.hel.fi" # For production
 # RESERVATIONS_API="https://varaamo.dev.hel.ninja" # For local development
 
 FEEDBACK_URL="https://api.hel.fi/servicemap/open311/"
-DIGITRANSIT_API="https://digitransit-proxy.api.hel.fi/routing/v1/routers/hsl/index/graphql"
+DIGITRANSIT_API="https://digitransit-proxy.api.hel.fi/routing/v2/hsl/gtfs/v1"
 HEARING_MAP_API="https://kuulokuvat.fi/api/v1/servicemap-url"
 SERVICE_MAP_URL="https://tiles.hel.ninja/styles/hel-osm-bright/{z}/{x}/{y}"
 ACCESSIBLE_MAP_URL="https://tiles.hel.ninja/styles/turku-osm-high-contrast-pattern/{z}/{x}/{y}"

--- a/src/views/MapView/components/TransitStops/TransitStopInfo/TransitStopInfo.js
+++ b/src/views/MapView/components/TransitStops/TransitStopInfo/TransitStopInfo.js
@@ -118,7 +118,7 @@ const TransitStopInfo = ({
   }, []);
 
   const renderDepartureTimes = () => {
-    const { color, className } = getTypeAndClass(stop.vehicleType);
+    const { color, className } = getTypeAndClass(stop.vehicleMode);
     const icon = <TransitStopIcon color={useContrast ? '#000000' : color} className={className} />;
 
     if (stopData.departureTimes?.length) {

--- a/src/views/MapView/components/TransitStops/TransitStops.js
+++ b/src/views/MapView/components/TransitStops/TransitStops.js
@@ -25,7 +25,7 @@ const StyledTransitIconMap = styled.span(({ color, className }) => ({
   className,
 }));
 
-const TransitStops = ({ mapObject }) => {
+function TransitStops({ mapObject }) {
   const isMobile = useMobileStatus();
   const useContrast = useSelector(selectMapType) === 'accessible_map';
   const { Marker, Popup } = global.rL;
@@ -67,7 +67,7 @@ const TransitStops = ({ mapObject }) => {
 
   const fetchTransitStops = () => {
     fetchStops(map)
-      .then((stops) => {
+      .then(stops => {
         if (showTransitStops()) {
           setTransitStops(stops);
         }
@@ -110,7 +110,7 @@ const TransitStops = ({ mapObject }) => {
     loadBikeStations();
   }, []);
 
-  const getTransitIcon = (type) => {
+  const getTransitIcon = type => {
     const { divIcon } = global.L;
     const { color, className } = getTypeAndClass(type);
     return divIcon({
@@ -133,8 +133,8 @@ const TransitStops = ({ mapObject }) => {
 
   return (
     <>
-      {transitStops.map((stop) => {
-        const icon = getTransitIcon(stop.vehicleType);
+      {transitStops.map(stop => {
+        const icon = getTransitIcon(stop.vehicleMode);
         return (
           <Marker
             icon={icon}
@@ -153,7 +153,7 @@ const TransitStops = ({ mapObject }) => {
           </Marker>
         );
       })}
-      {rentalBikeStations.map((station) => {
+      {rentalBikeStations.map(station => {
         const icon = getTransitIcon(7);
         return (
           <Marker
@@ -176,7 +176,7 @@ const TransitStops = ({ mapObject }) => {
       })}
     </>
   );
-};
+}
 
 TransitStops.propTypes = {
   mapObject: PropTypes.objectOf(PropTypes.any).isRequired,

--- a/src/views/MapView/components/TransitStops/util/util.js
+++ b/src/views/MapView/components/TransitStops/util/util.js
@@ -1,18 +1,17 @@
-export default function getTypeAndClass(vehicleType) {
-  switch (vehicleType) {
-    case 0: // Tram stops
+export default function getTypeAndClass(vehicleMode) {
+  switch (vehicleMode) {
+    case 'TRAM': // Tram stops
       return { color: '#00985F', className: 'icon-icon-hsl-tram' };
-    case 109: // Train stops
-      return { color: '#8C4799', className: 'icon-icon-hsl-train' };
-    case 1: // Subway stops
+    case 'BUS': // Bus stops
+      return { color: '#007AC9', className: 'icon-icon-hsl-bus' };
+    case 'SUBWAY': // Subway stops
       return { color: '#FF6319', className: 'icon-icon-hsl-metro' };
     case 7: // Bike stations
       return { color: '#fcb919', className: 'icon-icon-hsl-bike' };
-    case -999:
-    case 4: // Ferry stops
+    case 'FERRY': // Ferry stops
       return { color: '#00B9E4', className: 'icon-icon-hsl-ferry' };
-    case 3: // Bus stops
+    case 'TRAIN': // Train stops
     default:
-      return { color: '#007AC9', className: 'icon-icon-hsl-bus' };
+      return { color: '#8C4799', className: 'icon-icon-hsl-train' };
   }
 }

--- a/src/views/MapView/utils/transitFetch.js
+++ b/src/views/MapView/utils/transitFetch.js
@@ -41,7 +41,7 @@ const fetchStops = async (map) => {
       body:
       `{
         stopsByBbox(minLat: ${wideBounds.getSouthWest().lat}, minLon: ${wideBounds.getSouthWest().lng}, maxLat: ${wideBounds.getNorthEast().lat}, maxLon: ${wideBounds.getNorthEast().lng} ) {
-          vehicleType
+          vehicleMode
           gtfsId
           name
           lat
@@ -65,10 +65,10 @@ const fetchStops = async (map) => {
     .then((data) => {
       // Handle subwaystops and return list of all stops
       const stops = data[0].data.stopsByBbox;
-      const subwayStations = stops.filter(stop => stop.vehicleType === 1);
+      const subwayStations = stops.filter(stop => stop.vehicleMode === 'SUBWAY');
 
       // Remove subwaystations from stops list since they will be replaced with subway entrances
-      const filteredStops = stops.filter(stop => stop.vehicleType !== 1);
+      const filteredStops = stops.filter(stop => stop.vehicleMode !== 'SUBWAY');
 
       const entrances = data[1].results;
 
@@ -104,7 +104,7 @@ const fetchStops = async (map) => {
             lon: entrance.location.coordinates[0],
             name: entrance.name,
             patterns: closest.stop.patterns,
-            vehicleType: closest.stop.vehicleType,
+            vehicleMode: closest.stop.vehicleMode,
           };
           filteredStops.push(newStop);
         }


### PR DESCRIPTION
![transit-stops-digitransit-v2-api](https://github.com/user-attachments/assets/978b04bd-2dad-4e56-9f39-917f2430f5c9)

Transit stops have different GraphQL-schema in API v2 compared to v1.
Update GraphQL-endpoint url and migrate to the new schema.

Details:
- Update GraphQL-endpoint url to v2
- Use `vehicleMode` instead of `vehicleType`
- Update vehicle type mappings

Refs: [PL-85](https://helsinkisolutionoffice.atlassian.net/browse/PL-85)

[PL-85]: https://helsinkisolutionoffice.atlassian.net/browse/PL-85?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ