### PR TITLE
Switch CI to use active SonarQube Cloud action

### DIFF
--- a/.github/workflows/analyze-code.yml
+++ b/.github/workflows/analyze-code.yml
@@ -1,19 +1,19 @@
-name: SonarCloud Analysis
+name: SonarQube Cloud Analysis
 on:
   push:
     branches: [ main ]
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:
-  sonarcloud:
-    name: SonarCloud
+  sonarqube-cloud:
+    name: SonarQube Cloud
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+      - name: SonarQube Cloud Scan
+        uses: SonarSource/sonarqube-scan-action@v5.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.projectKey=City-of-Helsinki_servicemap-ui
 sonar.organization=city-of-helsinki
 
-# This is the name and version displayed in the SonarCloud UI.
+# This is the name and version displayed in the SonarQube Cloud UI.
 sonar.projectName=servicemap-ui
 sonar.projectVersion=1.0
 


### PR DESCRIPTION
Switched to the active SonarQube Cloud action as the previous one was deprecated. Also updated "SonarCloud" to "SonarQube Cloud" to reflect the service's name change.