### PR TITLE
fix: Encode search query to handle special characters PL-60

### DIFF
--- a/src/components/SearchBar/SearchBarComponent.js
+++ b/src/components/SearchBar/SearchBarComponent.js
@@ -173,7 +173,8 @@ const SearchBar = ({
       }
 
       if (navigator) {
-        navigator.push('search', { q: searchQuery });
+        // Encode searchQuery to handle special characters in the URL
+        navigator.push('search', { q: encodeURIComponent(searchQuery) });
       }
     }
   };


### PR DESCRIPTION

Hakukentässä esim `hiihto & latu`  toimii muuten, mutta siirtyy haussa hakukentään muodossa `hiihto`. Johtuen siitä että urlissa & merkillä on oma merkityksensä. Muuten haku toimii tuolla ok. 
Tällä muutoksella pitäisi tuo hakukentän ongelma poistua, mutta muuten haku toimii samoin.

https://helsinkisolutionoffice.atlassian.net/browse/PL-60