### PR TITLE
fix: yarn install on docker PL-92

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ WORKDIR /servicemap-ui
 
 USER root
 
-RUN curl --silent --proto "=https" --tlsv1.2 --location https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo
+RUN curl --fail --silent --proto '=https' --tlsv1.2 https://dl.yarnpkg.com/rpm/yarn.repo \
+  --output /etc/yum.repos.d/yarn.repo
 RUN yum -y install yarn
 
 RUN chown -R default:root /servicemap-ui


### PR DESCRIPTION
In [previous PR](https://github.com/City-of-Helsinki/servicemap-ui/pull/1251) for npm to yarn migration the docker build was broken probably because yarn is not installed.
Copied how yarn is installed in linkedcomponents + adjusted that so sonar doesn't complain about enforcing https.

related ticket: https://helsinkisolutionoffice.atlassian.net/browse/PL-92

