### PR TITLE
fix: validate that units are real objects PL-114

### DIFF
--- a/src/views/AddressView/utils/fetchAdministrativeDistricts.js
+++ b/src/views/AddressView/utils/fetchAdministrativeDistricts.js
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react';
 import { districtFetch } from '../../../utils/fetch';
 
 const SORTED_DIVISIONS = [
@@ -59,6 +60,24 @@ const fetchAdministrativeDistricts = async (lnglat) => {
       } else {
         console.warn(
           `Faulty data. Type of unit should be an object, but got ${typeof u} instead.`
+        );
+
+        // Report to Sentry with context
+        Sentry.captureMessage(
+          `Invalid unit data in administrative districts`,
+          {
+            level: 'warning',
+            tags: {
+              component: 'fetchAdministrativeDistricts',
+              data_validation: 'unit_type_check'
+            },
+            extra: {
+              unitType: typeof u,
+              unitValue: u,
+              itemType: item.type,
+              coordinates: lnglat
+            }
+          }
         );
       }
     });

--- a/src/views/AddressView/utils/fetchAdministrativeDistricts.js
+++ b/src/views/AddressView/utils/fetchAdministrativeDistricts.js
@@ -53,7 +53,14 @@ const fetchAdministrativeDistricts = async (lnglat) => {
       item.unit.object_type = 'unit';
     }
     item.units?.forEach(u => {
-      u.object_type = 'unit';
+      // Ensure that each unit is a valid object
+      if (typeof u === 'object' && u !== null) {
+        u.object_type = 'unit';
+      } else {
+        console.warn(
+          `Faulty data. Type of unit should be an object, but got ${typeof u} instead.`
+        );
+      }
     });
     result.push(item);
     return result;


### PR DESCRIPTION

Validate that units are actual objects. If not then show warning in console, but keep the app working.

https://helsinkisolutionoffice.atlassian.net/browse/PL-114

<img width="765" height="477" alt="Screenshot 2025-07-17 at 15 46 36" src="https://github.com/user-attachments/assets/e6b68d1d-1e30-44c8-9946-ac596509220f" />
<img width="551" height="748" alt="Screenshot 2025-07-17 at 15 46 59" src="https://github.com/user-attachments/assets/5ba47099-e043-41be-96fe-c82d54e1b2b1" />
