### PR TITLE
feat: add CSP support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,10 @@ CITIES="helsinki,espoo,vantaa,kauniainen,kirkkonummi"
 ORGANIZATIONS='[{ "id": "83e74666-0836-4c1d-948a-4b34a8b90301", "name": { "fi": "Helsingin kaupunki", "sv": "Helsingfors stad", "en": "City of Helsinki" } },{ "id": "520a4492-cb78-498b-9c82-86504de88dce", "name": { "fi": "Espoon kaupunki", "sv": "Esbo stad", "en": "City of Espoo" } },{ "id": "6d78f89c-9fd7-41d9-84e0-4b78c0fa25ce", "name": { "fi": "Vantaan kaupunki", "sv": "Vanda stad", "en": "City of Vantaa" } },{ "id": "6f0458d4-42a3-434a-b9be-20c19fcfa5c3", "name": { "fi": "Kauniaisten kaupunki", "sv": "Grankulla stad", "en": "Town of Kauniainen" } },{ "id": "015fd5cd-b280-4d24-a5b4-0ba6ecb4c8a4", "name": { "fi": "Kirkkonummi", "sv": "Kyrkslätt", "en": "Kirkkonummi" } },{ "id": "0c8e4f99-3d52-47b9-84df-395716bd8b11", "name": { "fi": "Länsi-Uudenmaan hyvinvointialue", "sv": "Västra Nylands välfärdsområde", "en": "Western Uusimaa Wellbeing Services County" } },{ "id": "5de91045-92ab-484b-9f96-7010ff7fb35e", "name": { "fi": "Vantaan ja Keravan hyvinvointialue", "sv": "Vanda och Kervo välfärdsområde", "en": "Wellbeing services county of Vantaa and Kerava" } }]'
 FEATURE_SERVICEMAP_PAGE_TRACKING="false"
 HELSINKI_MAPTILES_ENABLED="true"
+CSP_ENABLED="false"
+CSP_REPORT_ONLY="false"
+CSP_CONNECT_SRC="https://api.hel.fi https://www.hel.fi https://digitransit-proxy.api.hel.fi https://varaamo.hel.fi"
+CSP_IMG_SRC="https://helsinki-maptiles.dev.hel.ninja https://kartta.hel.fi https://mml-tiles.hel.ninja https://kartta.hsy.fi"
 # SERVER_TYPE="staging" This is used to disable search engine crawlers on staging server
 # SENTRY_DSN_SERVER=
 

--- a/config/default.js
+++ b/config/default.js
@@ -168,6 +168,17 @@ if (typeof settings.SLOW_FETCH_MESSAGE_TIMEOUT === 'undefined') {
   settings.SLOW_FETCH_MESSAGE_TIMEOUT = 3000;
 }
 
+settings.CSP_ENABLED = settings.CSP_ENABLED === "true"
+settings.CSP_REPORT_ONLY = settings.CSP_ENABLED === "true"
+
+if (!settings.CSP_CONNECT_SRC) {
+  settings.CSP_CONNECT_SRC = ""
+}
+
+if (!settings.CSP_IMG_SRC) {
+  settings.CSP_IMG_SRC = ""
+}
+
 const municipalities = {
   fi: {
     espoo: 'Espoo',
@@ -314,7 +325,11 @@ const defaultConfig = {
   "matomoSiteId": settings.MATOMO_SITE_ID,
   "matomoEnabled": settings.MATOMO_ENABLED,
   "slowFetchMessageTimeout": Number(settings.SLOW_FETCH_MESSAGE_TIMEOUT),
-  "helsinkiMaptilesEnabled": settings.HELSINKI_MAPTILES_ENABLED
+  "helsinkiMaptilesEnabled": settings.HELSINKI_MAPTILES_ENABLED,
+  "cspEnabled": settings.CSP_ENABLED,
+  "cspReportOnly": settings.CSP_REPORT_ONLY,
+  "cspConnectSrc": settings.CSP_CONNECT_SRC,
+  "cspImgSrc": settings.CSP_IMG_SRC
 }
 
 export default defaultConfig;

--- a/server/createEmotionCache.js
+++ b/server/createEmotionCache.js
@@ -1,5 +1,5 @@
 import createCache from '@emotion/cache';
 
-export default function createEmotionCache() {
-  return createCache({ key: 'css' });
+export default function createEmotionCache(nonce) {
+  return createCache({ key: 'css', nonce: nonce });
 }


### PR DESCRIPTION
Adds support for CSP headers. 4 environment variables exist to control the behaviour:

* CSP_ENABLED - feature flag, true to enable adding CSP headers
* CSP_REPORT_ONLY - set to true to report only (no enforce)
* CSP_CONNECT_SRC - additional urls to allow connections to
* CSP_IMG_SRC - additional urls to allow images from

refs: PL-110

Co-PR (environment variables): https://dev.azure.com/City-of-Helsinki/palvelukartta/_git/palvelukartta-pipelines/pullrequest/12058

Depends on: https://github.com/City-of-Helsinki/smbackend/pull/322