### PR TITLE
feat: mapView enable loading indicator for service unit search PL-71

### DIFF
--- a/src/views/MapView/MapView.js
+++ b/src/views/MapView/MapView.js
@@ -125,10 +125,10 @@ function MapView(props) {
   const serviceUnitSearchResultReducerData = useSelector(
     selectServiceUnitSearchResultLoadingReducer
   );
+
   const { showLoadingScreen, loadingReducer, hideLoadingNumbers } =
     resolveCombinedReducerData(
       districtLoadingReducerData,
-      embedded,
       serviceUnitSearchResultReducerData
     );
   // This unassigned selector is used to trigger re-render after events are fetched
@@ -312,6 +312,7 @@ function MapView(props) {
       outline: '2px solid transparent',
       boxShadow: `0 0 0 3px ${theme.palette.primary.highContrast}, 0 0 0 4px ${theme.palette.focusBorder.main}`,
     });
+
     return (
       <MapContainer
         tap={false} // This should fix leaflet safari double click bug

--- a/src/views/MapView/utils/loadingReducerSelector.js
+++ b/src/views/MapView/utils/loadingReducerSelector.js
@@ -85,13 +85,12 @@ export const selectServiceUnitSearchResultLoadingReducer = createSelector(
 
 export function resolveCombinedReducerData(
   districtLoadingReducerData,
-  embedded,
   serviceUnitSearchResultReducerData
 ) {
   if (districtLoadingReducerData.showLoadingScreen) {
     return districtLoadingReducerData;
   }
-  if (embedded && serviceUnitSearchResultReducerData.showLoadingScreen) {
+  if (serviceUnitSearchResultReducerData.showLoadingScreen) {
     return serviceUnitSearchResultReducerData;
   }
   return {


### PR DESCRIPTION
Enable loading indicator for service units search map view.

https://helsinkisolutionoffice.atlassian.net/browse/PL-71

![PL-71](https://github.com/user-attachments/assets/7c730c40-512f-441e-8857-fc35d73c148e)


[PL-71]: https://helsinkisolutionoffice.atlassian.net/browse/PL-71?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ