### PR TITLE
fix: Accessibility fix line height PL-26

### DIFF
--- a/src/components/TopBar/TopBar.js
+++ b/src/components/TopBar/TopBar.js
@@ -378,12 +378,10 @@ const StyledToolbarBlue = styled(Toolbar)(({ theme, mobile }) => {
     // override breakpoints
     [theme.breakpoints.up('xs')]: {
       minHeight: 32,
-      height: 32,
       paddingLeft: theme.spacing(3),
       paddingRight: theme.spacing(3),
     },
     minHeight: 32,
-    height: 32,
     backgroundColor: theme.palette.primary.main,
     padding: 0,
     paddingLeft: theme.spacing(3),
@@ -402,7 +400,7 @@ const StyledToolbarWhite = styled(Toolbar)(({ theme, mobile }) =>
     ? {
         boxShadow: '0px 4px 4px rgba(0, 0, 0, 0.25)',
         paddingLeft: theme.spacing(1.5),
-        height: 78,
+        minHeight: 78,
         backgroundColor: '#fff',
       }
     : {
@@ -411,7 +409,7 @@ const StyledToolbarWhite = styled(Toolbar)(({ theme, mobile }) =>
         flexDirection: 'row',
         alignItems: 'center',
         paddingLeft: theme.spacing(3),
-        height: 60,
+        minHeight: 60,
         backgroundColor: '#fff',
         zIndex: theme.zIndex.infront,
       }


### PR DESCRIPTION

Jos WCAG kriteerin mukaan säätää line height asetusta, niin ylimmän valikon tekstit menee piiloon. 

https://helsinkisolutionoffice.atlassian.net/browse/PL-26

Voi testata esim:
https://dylanb.github.io/bookmarklets.html
tai stylus pluginilla

Ennen:
<img width="1326" height="484" alt="Screenshot 2025-09-26 at 15 56 40" src="https://github.com/user-attachments/assets/c25a6c1f-91c6-4414-926e-c7d060e3c4d4" />

Korjattu:
<img width="1353" height="156" alt="Screenshot 2025-09-26 at 16 01 02" src="https://github.com/user-attachments/assets/d6f68501-adf1-4b6e-9dda-57d68c46794f" />

