### PR TITLE
fix: inject client env variables correctly Ref: PL-89

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -35,25 +35,26 @@ if (config.sentryDSN) {
 }
 
 const getPreloadedState = () => {
-  const state = window.PRELOADED_STATE || {};
+  const state = window.PRELOADED_STATE;
 
   // Allow the passed state to be garbage-collected
   delete window.PRELOADED_STATE;
 
-  // Handle settings fetch from localStorage
-  const settings = SettingsUtility.getSettingsFromLocalStorage();
+  if (state) {
+    // Handle settings fetch from localStorage
+    const settings = SettingsUtility.getSettingsFromLocalStorage();
+    state.settings = settings;
 
-  state.settings = settings;
-
-  // Set correct theme from localStorage
-  // TODO dark mode is broken after refresh
-  // const theme = LocalStorageUtility.getItem('theme');
-  const theme = 'default';
-  if (theme) {
-    if (!state.user) {
-      state.user = {};
+    // Set correct theme from localStorage
+    // TODO dark mode is broken after refresh
+    // const theme = LocalStorageUtility.getItem('theme');
+    const theme = 'default';
+    if (theme) {
+      if (!state.user) {
+        state.user = {};
+      }
+      state.user.theme = theme;
     }
-    state.user.theme = theme;
   }
 
   return state;

--- a/config/default.js
+++ b/config/default.js
@@ -75,7 +75,7 @@ function applyDefaults(envObj) {
 
   // Override defaults with actual env values
   Object.keys(envObj).forEach(key => {
-    if (envObj[key] !== undefined && envObj[key] !== null && envObj[key] !== '') {
+    if (envObj[key] !== undefined && envObj[key] !== null && envObj[key] !== '' && envObj[key] !== 'undefined') {
       result[key] = envObj[key];
     }
   });
@@ -84,7 +84,12 @@ function applyDefaults(envObj) {
 }
 
 export function getSettings() {
-  // Use Vite's import.meta.env for client-side
+  // Check for server-injected environment variables first (for runtime env overrides)
+  if (typeof window !== 'undefined' && typeof window.nodeEnvSettings !== 'undefined') {
+    return applyDefaults(window.nodeEnvSettings);
+  }
+  
+  // Use Vite's import.meta.env for client-side (build-time variables)
   if (typeof window !== 'undefined' && typeof import.meta !== 'undefined' && import.meta.env) {
     return applyDefaults(import.meta.env);
   }


### PR DESCRIPTION
Injecting environment variables was removed in the during Vite migration, bringing the functionality back.