### PR TITLE
Dynamic envs fixes Refs: PL-240

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ COPY --chown=default:root ./src ./src
 RUN pnpm install --frozen-lockfile --ignore-scripts && pnpm store prune
 
 COPY --chown=default:root ./.git ./.git
-RUN pnpm update-runtime-env
 # ============================================================
 # STAGE 2: Build
 # ============================================================
@@ -39,11 +38,20 @@ WORKDIR /servicemap-ui
 # Copy built server bundle and client assets
 COPY --from=builder --chown=1001:root /app/dist ./dist
 
+# Copy .env so update-runtime-env.js can use it as a fallback at container startup
+# for any variable not present in the Azure ConfigMap. process.env (ConfigMap) wins.
+COPY --from=appbase --chown=1001:root /app/.env ./.env
+
 # Copy scripts needed at container startup (update-runtime-env.js)
 COPY --from=appbase --chown=1001:root /app/scripts ./scripts
 
 # Copy node_modules for externalized runtime dependencies (react, react-dom, etc.)
 COPY --from=appbase --chown=1001:root /app/node_modules ./node_modules
+
+# OpenShift runs containers with a random UID in group 0 (root group).
+# Make dist/ group-writable so update-runtime-env.js can overwrite env-config.js
+# regardless of the actual runtime UID.
+RUN chmod -R g+w /servicemap-ui/dist
 
 ENV NODE_ENV=production
 
@@ -51,4 +59,8 @@ USER 1001
 
 EXPOSE 8080
 
-CMD ["node", "dist"]
+# Re-run the env script at startup so Azure configmap variables overwrite the
+# baked-in build-time defaults in dist/env-config.js before the server starts.
+# The existing dist/env-config.js serves as the fallback for any variable that
+# is not present in the runtime environment.
+CMD ["sh", "-c", "node scripts/update-runtime-env.js && exec node dist"]

--- a/config/default.js
+++ b/config/default.js
@@ -83,7 +83,7 @@ export function getSettings() {
   }
 
   // Server-side (SSR): apply process.env on top of defaults
-  dotenv.config({ path: ['.env', '.env.local'], override: true });
+  dotenv.config({ path: ['.env', '.env.local'] });
   return applyDefaults(process.env);
 }
 

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "whatwg-fetch": "^3.5.0"
   },
   "scripts": {
-    "build": "rm -rf dist && pnpm build:client && pnpm build:server && cp public/env-config.js dist/",
+    "build": "rm -rf dist && pnpm build:client && pnpm build:server && pnpm update-runtime-env",
     "build:test": "rm -rf dist && pnpm build:client --mode development && pnpm build:server --mode development",
     "build:client": "vite build",
     "build:server": "BUILD_TARGET=server vite build --ssr",

--- a/scripts/update-runtime-env.js
+++ b/scripts/update-runtime-env.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env ts-node-script
+#!/usr/bin/env node
 import dotenv from 'dotenv';
 import fs from 'fs';
 import * as path from 'path';
@@ -6,29 +6,31 @@ import * as path from 'path';
 const USE_TEST_ENV = process.env.NODE_ENV === 'test';
 const defaultNodeEnv = USE_TEST_ENV ? 'test' : 'development';
 
-/* @ts-ignore */
-import.meta.env = {};
-
-import.meta.env.NODE_ENV = process.env.NODE_ENV || defaultNodeEnv;
-
+// Load .env as defaults — process.env (e.g. Azure ConfigMap) always wins because
+// override is not set. At container startup the production stage also has .env,
+// so variables absent from the ConfigMap fall back to their committed defaults.
 dotenv.config({
-  processEnv: import.meta.env,
   path: ['.env', '.env.local'],
-  override: true,
 });
+
+process.env.NODE_ENV = process.env.NODE_ENV || defaultNodeEnv;
 
 // Prevent collision if app is running while tests are started
 const configFile = USE_TEST_ENV ? 'test-env-config.js' : 'env-config.js';
 
-// Always write to public/ — the build step copies this to dist/.
-const configurationFile = path.join(__dirname, '../public/' + configFile);
+// Tests require the file directly from public/ (see src/setupTests.js).
+// All other contexts write to dist/ — created if it doesn't exist yet (e.g. before first build in dev).
+const outputDir = path.resolve(process.cwd(), USE_TEST_ENV ? 'public' : 'dist');
+fs.mkdirSync(outputDir, { recursive: true });
+
+const configurationFile = path.join(outputDir, configFile);
 
 const start = async () => {
   try {
-    // Only expose client-safe keys — filter out server-only vars (PORT, SSR_FETCH_TIMEOUT, CSP_*, DOMAIN, etc.)
-    const allEnv = import.meta.env;
+    // Only expose client-safe keys — filter out server-only vars
+    // (PORT, SSR_FETCH_TIMEOUT, CSP_*, DOMAIN, SENTRY_DSN_SERVER, etc.)
     const envVariables = Object.fromEntries(
-      Object.entries(allEnv).filter(([ key ]) => key.startsWith('REACT_APP_') || key === 'NODE_ENV' || key === 'MODE')
+      Object.entries(process.env).filter(([ key ]) => key.startsWith('REACT_APP_') || key === 'NODE_ENV' || key === 'MODE')
     );
 
     fs.writeFile(

--- a/server/server.js
+++ b/server/server.js
@@ -44,7 +44,7 @@ import {
   unitRedirect,
 } from './utils';
 
-dotenv.config({ path: ['.env', '.env.local'], override: true });
+dotenv.config({ path: ['.env', '.env.local'] });
 
 // Initialize Sentry
 if (process.env.SENTRY_DSN_SERVER) {


### PR DESCRIPTION
Fixes several issues introduced with the dynamic runtime env script that prevented Azure ConfigMap variables from correctly overwriting build-time defaults.

 - __dirname in the script resolved to a temp directory when run via esrun, so env-config.js was never written to the correct location
 - dotenv.config({ override: true }) in server.js and config/default.js caused .env file values to overwrite already-set process.env values (i.e. ConfigMap vars)
 - import.meta.env hack in the original script was a no-op in a plain Node context
