### PR TITLE
fix: auto retry for digitransit fetches and short-lived cache for stops

### DIFF
--- a/src/views/MapView/components/TransitStops/TransitStopInfo/TransitStopInfo.js
+++ b/src/views/MapView/components/TransitStops/TransitStopInfo/TransitStopInfo.js
@@ -104,14 +104,19 @@ function TransitStopInfo({ stop = {}, onCloseClick, type = null }) {
     fetchStopData(stop)
       .then((stopData) => {
         if (stopData) {
-          let departureTimes = stopData.data.stop.stoptimesWithoutPatterns;
-          departureTimes.sort(
-            (a, b) =>
-              a.realtimeDeparture +
-              a.serviceDay -
-              (b.realtimeDeparture + b.serviceDay)
-          );
-          departureTimes = departureTimes.slice(0, 5);
+          // Copy before sorting: fetchStopData caches and shares this object
+          // across popups within its TTL, so sorting in place would mutate
+          // shared state.
+          const departureTimes = [
+            ...stopData.data.stop.stoptimesWithoutPatterns,
+          ]
+            .sort(
+              (a, b) =>
+                a.realtimeDeparture +
+                a.serviceDay -
+                (b.realtimeDeparture + b.serviceDay)
+            )
+            .slice(0, 5);
 
           setStopData({
             departureTimes,

--- a/src/views/MapView/utils/transitFetch.js
+++ b/src/views/MapView/utils/transitFetch.js
@@ -6,6 +6,46 @@ const digitransitApiHeaders = () => ({
   'Content-Type': 'application/graphql',
 });
 
+// Digitransit enforces rate/quota limiting per subscription key and can return
+// 403 (or 429) during traffic peaks even for normal use. Retry those responses
+// with exponential backoff + jitter, as recommended by Digitransit.
+const MAX_RETRIES = 3;
+const BASE_DELAY = 500; // ms
+const RETRYABLE_STATUS = new Set([403, 429]);
+
+const delay = (ms) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+// POST a GraphQL query to the Digitransit proxy, retrying transient rate-limit
+// responses. Non-retryable responses (and the last retry) are returned as-is so
+// callers keep their existing response.ok handling.
+const digitransitFetch = async (body) => {
+  let response = null;
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    response = await fetch(`${config.digitransitAPI.root}`, {
+      method: 'post',
+      headers: digitransitApiHeaders(),
+      body,
+    });
+
+    if (
+      response.ok ||
+      !RETRYABLE_STATUS.has(response.status) ||
+      attempt === MAX_RETRIES
+    ) {
+      return response;
+    }
+
+    const backoff = BASE_DELAY * 2 ** attempt + Math.random() * BASE_DELAY;
+    // eslint-disable-next-line no-await-in-loop
+    await delay(backoff);
+  }
+  return response;
+};
+
 /* eslint-disable global-require */
 // Fetch list of stops
 const fetchStops = async (map) => {
@@ -36,10 +76,7 @@ const fetchStops = async (map) => {
   try {
     const [transitResponse, subwayResponse] = await Promise.all([
       // Fetch for transit stops
-      fetch(`${config.digitransitAPI.root}`, {
-        method: 'post',
-        headers: digitransitApiHeaders(),
-        body: `{
+      digitransitFetch(`{
           stopsByBbox(
             minLat: ${wideBounds.getSouthWest().lat},
             minLon: ${wideBounds.getSouthWest().lng},
@@ -58,8 +95,7 @@ const fetchStops = async (map) => {
               }
             }
           }
-        }`,
-      }).then((response) => {
+        }`).then((response) => {
         if (!response.ok) {
           throw new Error(
             `API error: ${response.status} ${response.statusText}`
@@ -121,9 +157,12 @@ const fetchStops = async (map) => {
         );
         // Create a new stop from the entrance
         // Give it the stop data of the corresponding station and add it to the list of stops
+        // The other-direction platform may be outside the search area, so guard
+        // against it being undefined. fetchStopData falls back to the primary
+        // stop when secondaryId is absent.
         const newStop = {
           gtfsId: closest.stop.gtfsId,
-          secondaryId: otherStop.gtfsId,
+          ...(otherStop && { secondaryId: otherStop.gtfsId }),
           lat: entrance.location.coordinates[1],
           lon: entrance.location.coordinates[0],
           name: entrance.name,
@@ -142,8 +181,17 @@ const fetchStops = async (map) => {
   return stopData;
 };
 
-// Fetch one stop data
-const fetchStopData = async (stop) => {
+// Short-lived cache for single-stop timetable data. Popups re-fetch every time
+// they open, so caching per stop reduces redundant requests (and in-flight
+// deduplication prevents parallel fetches for the same stop). The TTL is kept
+// short because departure times are time-sensitive.
+const STOP_DATA_TTL = 30 * 1000; // ms
+const stopDataCache = new Map(); // cache key -> { timestamp, promise }
+
+const getStopCacheKey = (stop) =>
+  `${stop.gtfsId}${stop.secondaryId ? `+${stop.secondaryId}` : ''}`;
+
+const fetchStopDataUncached = async (stop) => {
   const requestBody = (id) => `{
     stop(id: "${id}") {
       name
@@ -167,11 +215,7 @@ const fetchStopData = async (stop) => {
   }`;
 
   try {
-    const response = await fetch(`${config.digitransitAPI.root}`, {
-      method: 'post',
-      headers: digitransitApiHeaders(),
-      body: requestBody(stop.gtfsId),
-    });
+    const response = await digitransitFetch(requestBody(stop.gtfsId));
 
     if (!response.ok) {
       throw new Error(`API error: ${response.status} ${response.statusText}`);
@@ -180,11 +224,7 @@ const fetchStopData = async (stop) => {
     const data = await response.json();
 
     if (stop.secondaryId) {
-      const response2 = await fetch(`${config.digitransitAPI.root}`, {
-        method: 'post',
-        headers: digitransitApiHeaders(),
-        body: requestBody(stop.secondaryId),
-      });
+      const response2 = await digitransitFetch(requestBody(stop.secondaryId));
 
       if (!response2.ok) {
         return data; // Return primary data only
@@ -208,20 +248,41 @@ const fetchStopData = async (stop) => {
   }
 };
 
+const fetchStopData = (stop) => {
+  const key = getStopCacheKey(stop);
+  const cached = stopDataCache.get(key);
+  if (cached && Date.now() - cached.timestamp < STOP_DATA_TTL) {
+    return cached.promise;
+  }
+
+  const promise = fetchStopDataUncached(stop);
+  stopDataCache.set(key, { timestamp: Date.now(), promise });
+
+  // Single eviction path (skips if a newer request already replaced the entry):
+  // drop failures immediately so the next open retries, and drop successes
+  // after the TTL so payloads don't accumulate for the whole session.
+  const evict = () => {
+    if (stopDataCache.get(key)?.promise === promise) {
+      stopDataCache.delete(key);
+    }
+  };
+  promise.then(() => {
+    setTimeout(evict, STOP_DATA_TTL);
+  }, evict);
+
+  return promise;
+};
+
 const fetchBikeStations = async () => {
   try {
-    const response = await fetch(`${config.digitransitAPI.root}`, {
-      method: 'post',
-      headers: digitransitApiHeaders(),
-      body: `{
+    const response = await digitransitFetch(`{
       bikeRentalStations {
         name
         stationId
         lat
         lon
       }
-    }`,
-    });
+    }`);
 
     if (!response.ok) {
       throw new Error(`API error: ${response.status} ${response.statusText}`);


### PR DESCRIPTION
**Problem**

The Digitransit API intermittently returns 403 (Forbidden). Digitransit enforces rate/quota limiting per subscription key, and since all traffic goes through Helsinki's shared `digitransit-proxy` (one key for every user), aggregate traffic at peak times trips the limit — appearing as random 403s to individual users. This is not our AppGW rate limit.

**Jira** [PL-252](https://helsinkisolutionoffice.atlassian.net/browse/PL-252)

**Changes**

All Digitransit calls in `transitFetch.js` now go through a shared `digitransitFetch()` wrapper with two mitigations:

- **Retry with exponential backoff + jitter** on 403/429 responses (~0.5s → 1s → 2s, up to 3 retries). Jitter prevents users retrying in lockstep and re-tripping the shared limit. Matches Digitransit's own guidance to add a small delay between requests. Other statuses and successful responses return immediately, so existing `response.ok` handling is unchanged.
- **Short-lived cache for** `fetchStopData` (30s TTL, keyed per stop). Popups previously re-fetched on every open; caching the in-flight promise also dedupes concurrent/rapid re-opens. Failures are not cached, so the next open retries fresh.

**Notes**

This absorbs the transient 403s but doesn't raise the underlying quota ceiling on the shared proxy key — if 403s persist at peak, the quota needs raising on the proxy/HSL side (`digitransit-api@hsl.fi`).


[PL-252]: https://helsinkisolutionoffice.atlassian.net/browse/PL-252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when loading transit data by automatically retrying temporary rate-limit responses with backoff.
  * Reduced duplicate/parallel requests by caching short-lived stop timetable fetches while requests are in flight.
  * Improved stop/entrance handling by safely constructing optional secondary-direction details only when available.
  * Updated bike station and timetable loading to better tolerate intermittent API throttling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->