### PR TITLE
fix: build fails in ci PL-295

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # ============================================================
 FROM helsinki.azurecr.io/ubi9/nodejs-24-pnpm-builder-base AS appbase
 
-COPY --chown=default:root package.json pnpm-lock.yaml pnpm-workspace.yaml index.html vite.config.js .eslintrc.json .env ./
+COPY --chown=default:root package.json pnpm-lock.yaml pnpm-workspace.yaml index.html vite.config.js eslint.config.mjs .env ./
 COPY --chown=default:root ./scripts ./scripts
 COPY --chown=default:root ./client ./client
 COPY --chown=default:root ./config ./config


### PR DESCRIPTION

Change correct eslint conf file to docker

https://helsinkisolutionoffice.atlassian.net/browse/PL-295

Refs: PL-295

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s build configuration to use the current linting setup during dependency installation.
  * No changes to user-facing functionality or application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->