### PR TITLE
fix: handle abort of previous fetch requests in search functionality

### DIFF
--- a/src/components/SearchBar/SearchBarComponent.js
+++ b/src/components/SearchBar/SearchBarComponent.js
@@ -20,10 +20,7 @@ import paths from '../../../config/paths';
 import fetchSearchResults from '../../redux/actions/search';
 import { changeSelectedUnit } from '../../redux/actions/selectedUnit';
 import { selectNavigator } from '../../redux/selectors/general';
-import {
-  selectResultsIsFetching,
-  selectResultsPreviousSearch,
-} from '../../redux/selectors/results';
+import { selectResultsPreviousSearch } from '../../redux/selectors/results';
 import { keyboardHandler, uppercaseFirst, useQuery } from '../../utils';
 import useLocaleText from '../../utils/useLocaleText';
 import BackButton from '../BackButton';
@@ -58,7 +55,6 @@ function SearchBar({
   const theme = useTheme();
   const dispatch = useDispatch();
   const navigator = useSelector(selectNavigator);
-  const isFetching = useSelector(selectResultsIsFetching);
   const previousSearch = useSelector(selectResultsPreviousSearch);
 
   const setSearchbarValue = (value) => {
@@ -168,7 +164,8 @@ function SearchBar({
   };
 
   const handleSubmit = (search) => {
-    if (isFetching) return;
+    // Do not block new submits while fetching: search action now aborts the
+    // previous request and ignores stale responses.
     let searchQuery;
     if (focusedSuggestion !== null) {
       const suggestion = document.getElementById(

--- a/src/redux/actions/__tests__/search.test.js
+++ b/src/redux/actions/__tests__/search.test.js
@@ -226,7 +226,17 @@ describe('fetchSearchResults', () => {
   });
 
   describe('when a fetch is already in progress', () => {
-    it('throws without dispatching', async () => {
+    it('starts a new fetch instead of throwing', async () => {
+      const { default: ServiceMapAPI } =
+        await import('../../../utils/newFetch/ServiceMapAPI');
+      ServiceMapAPI.mockImplementation(function () {
+        return {
+          setOnProgressUpdate: vi.fn(),
+          setAbortController: vi.fn(),
+          search: vi.fn().mockResolvedValue([]),
+        };
+      });
+
       const busyGetState = () => ({
         searchResults: { isFetching: true, previousSearch: 'kirjasto' },
         user: { locale: 'fi' },
@@ -234,11 +244,65 @@ describe('fetchSearchResults', () => {
 
       await expect(
         fetchSearchResults({ q: 'kirjasto' })(mockDispatch, busyGetState)
-      ).rejects.toThrow(
-        'Unable to fetch search results because previous fetch is still active'
+      ).resolves.toBeUndefined();
+
+      const dispatchedTypes = mockDispatch.mock.calls
+        .filter((call) => typeof call[0] === 'object')
+        .map((call) => call[0]?.type);
+
+      expect(dispatchedTypes).toContain('SEARCH_RESULTS_IS_FETCHING');
+      expect(dispatchedTypes).toContain('SEARCH_RESULTS_FETCH_DATA_SUCCESS');
+    });
+
+    it('ignores stale result from an older overlapping fetch', async () => {
+      const { default: ServiceMapAPI } =
+        await import('../../../utils/newFetch/ServiceMapAPI');
+
+      let firstResolve;
+      let secondResolve;
+      let callIndex = 0;
+
+      const firstPromise = new Promise((resolve) => {
+        firstResolve = resolve;
+      });
+      const secondPromise = new Promise((resolve) => {
+        secondResolve = resolve;
+      });
+
+      ServiceMapAPI.mockImplementation(function () {
+        return {
+          setOnProgressUpdate: vi.fn(),
+          setAbortController: vi.fn(),
+          search: vi.fn().mockImplementation(() => {
+            callIndex += 1;
+            return callIndex === 1 ? firstPromise : secondPromise;
+          }),
+        };
+      });
+
+      const firstThunkPromise = fetchSearchResults({ q: 'vanha' })(
+        mockDispatch,
+        mockGetState
+      );
+      const secondThunkPromise = fetchSearchResults({ q: 'uusi' })(
+        mockDispatch,
+        mockGetState
       );
 
-      expect(mockDispatch).not.toHaveBeenCalled();
+      secondResolve([{ id: 2, name: { fi: 'Uusi' }, object_type: 'unit' }]);
+      await secondThunkPromise;
+
+      firstResolve([{ id: 1, name: { fi: 'Vanha' }, object_type: 'unit' }]);
+      await firstThunkPromise;
+
+      const successActions = mockDispatch.mock.calls
+        .map((call) => call[0])
+        .filter(
+          (action) => action?.type === 'SEARCH_RESULTS_FETCH_DATA_SUCCESS'
+        );
+
+      expect(successActions).toHaveLength(1);
+      expect(successActions[0].data[0].id).toBe(2);
     });
   });
 });

--- a/src/redux/actions/search.js
+++ b/src/redux/actions/search.js
@@ -13,11 +13,26 @@ import { searchResults } from './fetchDataActions';
 const { isFetching, fetchSuccess, fetchProgressUpdateConcurrent, fetchError } =
   searchResults;
 
-const smFetch = async (dispatch, getState, options) => {
+let activeSearchController = null;
+let latestSearchRequestId = 0;
+
+const smFetch = async (
+  dispatch,
+  getState,
+  options,
+  requestId,
+  abortController
+) => {
   let results = [];
   const smAPI = new ServiceMapAPI();
+  if (typeof smAPI.setAbortController === 'function') {
+    smAPI.setAbortController(abortController);
+  }
 
   const onProgressUpdateConcurrent = (total, max) => {
+    if (requestId !== latestSearchRequestId) {
+      return;
+    }
     const currentCount = selectSearchResults(getState())?.count || 0;
     if (total < currentCount) {
       return;
@@ -68,6 +83,9 @@ const smFetch = async (dispatch, getState, options) => {
     results = smAPI.units(unitFetchOptions);
   } else if (options.events) {
     const eventsAPI = new LinkedEventsAPI();
+    if (typeof eventsAPI.setAbortController === 'function') {
+      eventsAPI.setAbortController(abortController);
+    }
     results = eventsAPI.eventsByKeyword(options.events);
   } else if (options.level) {
     results = smAPI.units(options);
@@ -79,16 +97,19 @@ const smFetch = async (dispatch, getState, options) => {
 const fetchSearchResults =
   (options = null) =>
   async (dispatch, getState) => {
-    const searchFetchState = selectSearchResults(getState());
     const locale = getLocale(getState());
 
     const searchQuery = optionsToSearchQuery(options);
 
-    if (searchFetchState.isFetching) {
-      throw Error(
-        'Unable to fetch search results because previous fetch is still active'
-      );
+    // Cancel previous in-flight search to avoid stale progress/success updates
+    // racing with the latest search results.
+    if (activeSearchController) {
+      activeSearchController.abort();
     }
+    const requestId = latestSearchRequestId + 1;
+    latestSearchRequestId = requestId;
+    const abortController = new AbortController();
+    activeSearchController = abortController;
 
     dispatch(isFetching(searchQuery));
 
@@ -107,14 +128,33 @@ const fetchSearchResults =
     };
     let results;
     try {
-      results = await smFetch(dispatch, getState, fetchOptions);
+      results = await smFetch(
+        dispatch,
+        getState,
+        fetchOptions,
+        requestId,
+        abortController
+      );
     } catch (e) {
       // Only silently handle genuine abort errors (user navigated away or 10s timeout
       // fired). Other APIFetchErrors — missing base URL, invalid input, etc. — should
       // still surface so they are visible in Sentry.
       if (!(e instanceof AbortAPIError)) throw e;
-      // Reset isFetching so subsequent searches are not permanently blocked.
-      dispatch(fetchError(null));
+      // Only reset fetch state if this is still the latest request.
+      if (requestId === latestSearchRequestId) {
+        dispatch(fetchError(null));
+      }
+      return;
+    } finally {
+      if (
+        requestId === latestSearchRequestId &&
+        activeSearchController === abortController
+      ) {
+        activeSearchController = null;
+      }
+    }
+
+    if (requestId !== latestSearchRequestId) {
       return;
     }
 
@@ -170,6 +210,12 @@ const fetchSearchResults =
           }
         });
       }
+    }
+
+    // A newer search may have started while we were normalizing results.
+    // Prevent stale payload from replacing fresh search results.
+    if (requestId !== latestSearchRequestId) {
+      return;
     }
 
     dispatch(fetchSuccess(results));

--- a/src/views/SearchView/SearchView.js
+++ b/src/views/SearchView/SearchView.js
@@ -222,10 +222,12 @@ function SearchView() {
     }
   }
 
-  // Check if view will fetch data because sreach params has changed
+  // Check if view will fetch data because search params have changed
   const shouldFetch = () => {
-    const { isFetching, previousSearch } = searchFetchState;
-    if (isFetching || isRedirectFetching) {
+    const { previousSearch } = searchFetchState;
+    // Search action aborts previous in-flight requests, so don't block a new
+    // search here when params change.
+    if (isRedirectFetching) {
       return false;
     }
     const data = getSearchParamData();

--- a/src/views/ServiceView/ServiceView.js
+++ b/src/views/ServiceView/ServiceView.js
@@ -55,7 +55,7 @@ function ServiceView(props) {
   const [mapMoved, setMapMoved] = useState(false);
   const [icon, setIcon] = useState(null);
 
-  // Check if view will fetch data because search params has changed
+  // Check if view will fetch data because search params have changed
   const shouldFetch = () => {
     const { current, isFetching } = serviceReducer;
     return !isFetching && (!current || `${current.id}` !== params?.service);


### PR DESCRIPTION
Refs: PL-296

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - New searches can start while a previous search is still in progress.
  - Starting a new search automatically cancels the previous request.
  - Results from older, overlapping searches are ignored to prevent stale data from appearing.

- **Bug Fixes**
  - Improved search behavior when requests overlap or complete out of order.
  - Preserved existing protections during redirect processing and invalid search parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->