### PR TITLE
fix: replace react-router-dom with react-router

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "react-markdown": "^10.1.0",
     "react-redux": "^9.3.0",
     "react-router": "^8.3.0",
-    "react-router-dom": "^6.30.3",
     "redux": "^5.0.1",
     "redux-thunk": "^3.1.0",
     "regenerator-runtime": "^0.13.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,9 +167,6 @@ importers:
       react-router:
         specifier: ^8.3.0
         version: 8.3.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react-router-dom:
-        specifier: ^6.30.3
-        version: 6.30.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       redux:
         specifier: ^5.0.1
         version: 5.0.1
@@ -1745,10 +1742,6 @@ packages:
     resolution: {integrity: sha512-iNWvuzEwANttpQpdlu8nPBtdHb0mcCMj1ZTH//iRB5E/14IAnyRlR25rxH7pNLyzHINsPGEKnWvpwDMCT6vziQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  '@remix-run/router@1.23.2':
-    resolution: {integrity: sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==}
-    engines: {node: '>=14.0.0'}
 
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
@@ -4837,19 +4830,6 @@ packages:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
-  react-router-dom@6.30.3:
-    resolution: {integrity: sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
-
-  react-router@6.30.3:
-    resolution: {integrity: sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      react: '>=16.8'
-
   react-router@8.3.0:
     resolution: {integrity: sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==}
     engines: {node: '>=22.22.0'}
@@ -7431,8 +7411,6 @@ snapshots:
   '@react-types/shared@3.35.0(react@19.2.7)':
     dependencies:
       react: 19.2.7
-
-  '@remix-run/router@1.23.2': {}
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
@@ -11114,18 +11092,6 @@ snapshots:
       redux: 5.0.1
 
   react-refresh@0.18.0: {}
-
-  react-router-dom@6.30.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
-    dependencies:
-      '@remix-run/router': 1.23.2
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      react-router: 6.30.3(react@19.2.7)
-
-  react-router@6.30.3(react@19.2.7):
-    dependencies:
-      '@remix-run/router': 1.23.2
-      react: 19.2.7
 
   react-router@8.3.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:

--- a/server/server.js
+++ b/server/server.js
@@ -15,7 +15,7 @@ import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import { HelmetProvider } from 'react-helmet-async';
 import { Provider } from 'react-redux';
-import { StaticRouter } from 'react-router-dom/server';
+import { StaticRouter } from 'react-router';
 import { applyMiddleware, createStore } from 'redux';
 import { thunk } from 'redux-thunk';
 

--- a/src/App.js
+++ b/src/App.js
@@ -23,10 +23,10 @@ import {
   createBrowserRouter,
   createRoutesFromElements,
   Route,
-  RouterProvider,
   Routes,
   useLocation,
-} from 'react-router-dom';
+} from 'react-router';
+import { RouterProvider } from 'react-router/dom';
 
 import config from '../config';
 import featureFlags from '../config/featureFlags';

--- a/src/components/BottomNav/BottomNav.js
+++ b/src/components/BottomNav/BottomNav.js
@@ -10,7 +10,7 @@ import {
 import React, { useState } from 'react';
 import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import config from '../../../config';
 import {

--- a/src/components/DataFetchers/DataFetcher.js
+++ b/src/components/DataFetchers/DataFetcher.js
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import fetchSearchResults from '../../redux/actions/search';
 import { selectMapRef } from '../../redux/selectors/general';

--- a/src/components/DataFetchers/UnitFetcher.js
+++ b/src/components/DataFetchers/UnitFetcher.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import { useCallback, useEffect } from 'react';
 import { connect } from 'react-redux';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import {
   changeSelectedUnit,

--- a/src/components/DataFetchers/__tests__/UnitFetcher.test.js
+++ b/src/components/DataFetchers/__tests__/UnitFetcher.test.js
@@ -1,7 +1,7 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 import { Provider } from 'react-redux';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { createStore } from 'redux';
 
 const minimalReducer = () => ({
@@ -9,8 +9,8 @@ const minimalReducer = () => ({
   mapRef: null,
 });
 
-// Mock react-router-dom's useParams so we control the unit param in each test
-vi.mock('react-router-dom', async (importOriginal) => {
+// Mock react-router's useParams so we control the unit param in each test
+vi.mock('react-router', async (importOriginal) => {
   const actual = await importOriginal();
   return { ...actual, useParams: vi.fn() };
 });
@@ -50,7 +50,7 @@ vi.mock('../../../redux/actions/selectedUnitAccessibility', () => ({
     mockFetchAccessibilitySentences(...args),
 }));
 
-const { useParams } = await import('react-router-dom');
+const { useParams } = await import('react-router');
 const { default: UnitFetcher } = await import('../UnitFetcher');
 
 const renderComponent = (store = createStore(minimalReducer)) => {

--- a/src/components/Dialog/DownloadDialog/DownloadDialog.js
+++ b/src/components/Dialog/DownloadDialog/DownloadDialog.js
@@ -12,7 +12,7 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import { selectResultsPreviousSearch } from '../../../redux/selectors/results';
 import { getSelectedUnit } from '../../../redux/selectors/selectedUnit';

--- a/src/components/Lists/PaginatedList/PaginatedList.js
+++ b/src/components/Lists/PaginatedList/PaginatedList.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useRef, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import { selectNavigator } from '../../../redux/selectors/general';
 import { parseSearchParams, stringifySearchParams } from '../../../utils';

--- a/src/components/Navigator/Navigator.js
+++ b/src/components/Navigator/Navigator.js
@@ -7,7 +7,7 @@ import {
   useRef,
 } from 'react';
 import { connect } from 'react-redux';
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router';
 
 import {
   breadcrumbPop,

--- a/src/components/RouterPrompt/RouterPrompt.js
+++ b/src/components/RouterPrompt/RouterPrompt.js
@@ -2,7 +2,7 @@ import { Button, Dialog } from 'hds-react';
 import PropTypes from 'prop-types';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useIntl } from 'react-intl';
-import { useBlocker } from 'react-router-dom';
+import { useBlocker } from 'react-router';
 
 const RouterPrompt = ({ when, onOK, onCancel, title, content }) => {
   const [showPrompt, setShowPrompt] = useState(false);

--- a/src/components/SearchBar/SearchBarComponent.js
+++ b/src/components/SearchBar/SearchBarComponent.js
@@ -14,7 +14,7 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import paths from '../../../config/paths';
 import fetchSearchResults from '../../redux/actions/search';

--- a/src/components/TabLists/TabLists.js
+++ b/src/components/TabLists/TabLists.js
@@ -6,7 +6,7 @@ import { visuallyHidden } from '@mui/utils';
 import PropTypes from 'prop-types';
 import React, { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import config from '../../../config';
 import { selectNavigator } from '../../redux/selectors/general';

--- a/src/components/ToolMenu/ToolMenu.js
+++ b/src/components/ToolMenu/ToolMenu.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import React, { useContext } from 'react';
 import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import URI from 'urijs';
 
 import PrintContext from '../../context/PrintContext';

--- a/src/components/TopBar/LanguageMenu/LanguageMenuComponent.js
+++ b/src/components/TopBar/LanguageMenu/LanguageMenuComponent.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { useSelector } from 'react-redux';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import { getLocale } from '../../../redux/selectors/user';
 import LocaleUtility from '../../../utils/locale';

--- a/src/components/TopBar/LanguageMenu/__tests__/LanguageMenu.test.js
+++ b/src/components/TopBar/LanguageMenu/__tests__/LanguageMenu.test.js
@@ -1,6 +1,6 @@
 // Link.react.test.js
 import React from 'react';
-import * as reactRouterDom from 'react-router-dom';
+import * as reactRouter from 'react-router';
 
 import { initialState } from '../../../../redux/reducers/user';
 import { getRenderWithProviders } from '../../../../testUtils';
@@ -21,7 +21,7 @@ const renderWithProviders = getRenderWithProviders({
 
 describe('<LanguageMenu />', () => {
   beforeEach(() => {
-    vi.spyOn(reactRouterDom, 'useLocation').mockReturnValue(mockUseLocation);
+    vi.spyOn(reactRouter, 'useLocation').mockReturnValue(mockUseLocation);
   });
 
   afterEach(() => {

--- a/src/components/TopBar/SMLogo/SMLogoComponent.js
+++ b/src/components/TopBar/SMLogo/SMLogoComponent.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import { selectThemeMode } from '../../../redux/selectors/user';
 import useMobileStatus from '../../../utils/isMobile';

--- a/src/components/TopBar/SMLogo/__tests__/SMLogo.test.js
+++ b/src/components/TopBar/SMLogo/__tests__/SMLogo.test.js
@@ -1,7 +1,7 @@
 // Link.react.test.js
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import * as reactRouterDom from 'react-router-dom';
+import * as reactRouter from 'react-router';
 
 import englishTranslations from '../../../../i18n/en';
 import { initialState } from '../../../../redux/reducers/user';
@@ -23,7 +23,7 @@ const renderWithProviders = getRenderWithProviders({
 
 describe('<SMLogo />', () => {
   beforeEach(() => {
-    vi.spyOn(reactRouterDom, 'useLocation').mockReturnValue(mockUseLocation);
+    vi.spyOn(reactRouter, 'useLocation').mockReturnValue(mockUseLocation);
   });
 
   afterEach(() => {

--- a/src/components/TopBar/TopBar.js
+++ b/src/components/TopBar/TopBar.js
@@ -12,7 +12,7 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import config from '../../../config';
 import { setMapType } from '../../redux/actions/settings';

--- a/src/layouts/DefaultLayout.js
+++ b/src/layouts/DefaultLayout.js
@@ -3,7 +3,7 @@ import { visuallyHidden } from '@mui/utils';
 import React, { Suspense, useEffect, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import config from '../../config';
 import {

--- a/src/layouts/EmbedLayout.js
+++ b/src/layouts/EmbedLayout.js
@@ -5,7 +5,7 @@ import { visuallyHidden } from '@mui/utils';
 import React, { Suspense, useEffect, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import {
   Dialog,

--- a/src/layouts/components/ViewTitle/ViewTitle.js
+++ b/src/layouts/components/ViewTitle/ViewTitle.js
@@ -3,7 +3,7 @@ import { visuallyHidden } from '@mui/utils';
 import PropTypes from 'prop-types';
 import React, { useEffect, useRef } from 'react';
 import { FormattedMessage } from 'react-intl';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router';
 
 import { viewTitleID } from '../../../utils/accessibility';
 import { COOKIE_MODAL_ROOT_ID } from '../../../utils/constants';

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 
 import { ErrorTrigger } from '../components';
 import PageHandler from '../layouts/components/PageHandler';

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -102,9 +102,9 @@ Object.defineProperty(window, 'matchMedia', {
   }),
 });
 
-// Mock react-router-dom for Vitest
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
+// Mock react-router for Vitest
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
   return {
     ...actual,
     useLocation: vi.fn(() => ({

--- a/src/testUtils.js
+++ b/src/testUtils.js
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react';
 import React from 'react';
 import { IntlProvider } from 'react-intl';
 import { Provider } from 'react-redux';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 // eslint-disable-next-line import-x/no-named-as-default
 import configureStore from 'redux-mock-store';
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import URI from 'urijs';
 
 const isClient = () => typeof window !== 'undefined';

--- a/src/utils/path.js
+++ b/src/utils/path.js
@@ -1,4 +1,4 @@
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import config from '../../config';
 import paths from '../../config/paths';

--- a/src/views/AddressView/AddressView.js
+++ b/src/views/AddressView/AddressView.js
@@ -6,7 +6,7 @@ import React, { useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router';
 
 import config from '../../../config';
 import {

--- a/src/views/AreaView/AreaView.js
+++ b/src/views/AreaView/AreaView.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 
 import {
   fetchAccessibleStreetParking,

--- a/src/views/AreaView/components/SideBar/SideBar.js
+++ b/src/views/AreaView/components/SideBar/SideBar.js
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
 import React, { useCallback, useEffect, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import {
   AddressSearchBar,

--- a/src/views/DivisionView/DivisionView.js
+++ b/src/views/DivisionView/DivisionView.js
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router';
 
 import { setHighlightedDistrict } from '../../redux/actions/district';
 import fetchSearchResults from '../../redux/actions/search';

--- a/src/views/EventDetailView/EventDetailView.js
+++ b/src/views/EventDetailView/EventDetailView.js
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { AccessTime, Event, Phone } from '@mui/icons-material';
 import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import {
   DescriptionText,

--- a/src/views/FeedbackView/FeedbackView.js
+++ b/src/views/FeedbackView/FeedbackView.js
@@ -16,7 +16,7 @@ import { visuallyHidden } from '@mui/utils';
 import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import config from '../../../config';
 import { DesktopComponent, SMButton, TitleBar } from '../../components';

--- a/src/views/MapView/MapView.js
+++ b/src/views/MapView/MapView.js
@@ -9,7 +9,7 @@ import { useIntl } from 'react-intl';
 import * as ReactLeaflet from 'react-leaflet';
 import { useMapEvents } from 'react-leaflet';
 import { useDispatch, useSelector } from 'react-redux';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import { Loading } from '../../components';
 import { setBounds } from '../../redux/actions/map';

--- a/src/views/MapView/components/AddressPopup/AddressPopup.js
+++ b/src/views/MapView/components/AddressPopup/AddressPopup.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import React, { useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useMapEvents } from 'react-leaflet';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import { SMButton } from '../../../../components';
 import { getAddressText, useNavigationParams } from '../../../../utils/address';

--- a/src/views/MapView/components/Districts/Districts.js
+++ b/src/views/MapView/components/Districts/Districts.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import config from '../../../../../config';
 import {

--- a/src/views/MapView/components/EventMarkers/EventMarkers.js
+++ b/src/views/MapView/components/EventMarkers/EventMarkers.js
@@ -5,7 +5,7 @@ import React, { useEffect, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useMap } from 'react-leaflet';
 import { useDispatch, useSelector } from 'react-redux';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import { changeSelectedEvent } from '../../../../redux/actions/event';
 import { selectNavigator } from '../../../../redux/selectors/general';

--- a/src/views/MapView/components/MapLegend/MapLegend.js
+++ b/src/views/MapView/components/MapLegend/MapLegend.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { useMemo, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import { getIcon } from '../../../../components';
 import {

--- a/src/views/MapView/components/StatisticalDistricts/StatisticalDistrictsComponent.js
+++ b/src/views/MapView/components/StatisticalDistricts/StatisticalDistrictsComponent.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import {
   getSelectedStatisticalDistricts,

--- a/src/views/MapView/utils/mapActions.js
+++ b/src/views/MapView/utils/mapActions.js
@@ -1,5 +1,5 @@
 import pointOnFeature from '@turf/point-on-feature';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import { parseSearchParams } from '../../../utils';
 import { mapHasMapPane } from '../../../utils/mapUtility';

--- a/src/views/MapView/utils/useMapUnits.js
+++ b/src/views/MapView/utils/useMapUnits.js
@@ -1,7 +1,7 @@
 import distance from '@turf/distance';
 import flip from '@turf/flip';
 import { useSelector } from 'react-redux';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import {
   selectAddressAdminDistricts,

--- a/src/views/PrintView/PrintView.js
+++ b/src/views/PrintView/PrintView.js
@@ -14,7 +14,7 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useRef, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import paths from '../../../config/paths';
 import { SMButton } from '../../components';

--- a/src/views/SearchView/SearchView.js
+++ b/src/views/SearchView/SearchView.js
@@ -4,7 +4,7 @@ import { visuallyHidden } from '@mui/utils';
 import React, { useEffect, useMemo, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router';
 
 import config from '../../../config';
 import {

--- a/src/views/ServiceView/ServiceView.js
+++ b/src/views/ServiceView/ServiceView.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router';
 
 import {
   Container,

--- a/src/views/UnitView/UnitView.js
+++ b/src/views/UnitView/UnitView.js
@@ -8,7 +8,7 @@ import React, { Suspense, useEffect, useRef, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router';
 
 import config from '../../../config';
 import paths from '../../../config/paths';

--- a/src/views/UnitView/components/ContactInfo/ContactInfo.js
+++ b/src/views/UnitView/components/ContactInfo/ContactInfo.js
@@ -3,7 +3,7 @@ import { ButtonBase, Divider, ListItem, Typography } from '@mui/material';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 
 import { SMAccordion } from '../../../../components';
 import { parseSearchParams, stringifySearchParams } from '../../../../utils';

--- a/src/views/UnitView/components/ExtendedData/ExtendedData.js
+++ b/src/views/UnitView/components/ExtendedData/ExtendedData.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React, { useEffect } from 'react';
 import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import {
   EventItem,

--- a/src/views/UnitView/components/UnitDataList/UnitDataList.js
+++ b/src/views/UnitView/components/UnitDataList/UnitDataList.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import { useSelector } from 'react-redux';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import {
   EventItem,

--- a/src/views/UnitView/components/UnitDataList/__tests__/UnitDataList.test.js
+++ b/src/views/UnitView/components/UnitDataList/__tests__/UnitDataList.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import * as reactRouterDom from 'react-router-dom';
+import * as reactRouter from 'react-router';
 
 import { getRenderWithProviders } from '../../../../../testUtils';
 import UnitDataList from '../UnitDataList';
@@ -137,7 +137,7 @@ const renderWithProviders = getRenderWithProviders({
 
 describe('<UnitDataList />', () => {
   beforeEach(() => {
-    vi.spyOn(reactRouterDom, 'useLocation').mockReturnValue(mockUseLocation);
+    vi.spyOn(reactRouter, 'useLocation').mockReturnValue(mockUseLocation);
   });
 
   afterEach(() => {


### PR DESCRIPTION
- react-router-dom is deprecated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated application routing to use the current routing package interface.
  * Removed the legacy routing package dependency.
  * Preserved existing navigation, URL handling, route definitions, and server-rendered behavior.

* **Tests**
  * Updated routing test utilities and mocks to match the revised routing setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->