### PR TITLE
fix(map): refresh map size before every focus action

### DIFF
--- a/src/views/MapView/MapView.js
+++ b/src/views/MapView/MapView.js
@@ -56,7 +56,11 @@ import {
   selectDistrictLoadingReducer,
   selectServiceUnitSearchResultLoadingReducer,
 } from './utils/loadingReducerSelector';
-import { focusToPosition, getBoundsFromBbox } from './utils/mapActions';
+import {
+  focusToPosition,
+  getBoundsFromBbox,
+  refreshMapSize,
+} from './utils/mapActions';
 import MapUtility from './utils/mapUtility';
 import useMapUnits from './utils/useMapUnits';
 
@@ -235,43 +239,34 @@ function MapView(props) {
       }
 
       // Leaflet caches the container size at creation time to position markers/tiles.
-      // In embed iframes the container can still be resizing (e.g. a parent page
-      // auto-sizing the iframe) when the map is created, so markers can be
-      // positioned off-screen until something forces a recalculation. Observing
-      // the container and invalidating size on every dimension change fixes this
-      // regardless of when/why the size settles.
+      // In embed iframes the container can still be settling (e.g. the parent page
+      // just inserted the iframe) when the map is created, so markers can be
+      // positioned off-screen until something forces a recalculation.
+      const invalidate = () => refreshMapSize(mapElement);
+
       if (typeof ResizeObserver === 'undefined') {
         // No ResizeObserver support: fall back to window resize events, which
         // also fire when an embedding iframe itself is resized.
-        const invalidate = () => {
-          if (mapHasMapPane(mapElement)) {
-            mapElement.invalidateSize();
-          }
-        };
-        const frame = requestAnimationFrame(invalidate);
         window.addEventListener('resize', invalidate);
+        invalidate();
         return () => {
-          cancelAnimationFrame(frame);
           window.removeEventListener('resize', invalidate);
         };
       }
 
-      const container = mapElement.getContainer();
-      let frame;
-      const resizeObserver = new ResizeObserver(() => {
-        cancelAnimationFrame(frame);
-        frame = requestAnimationFrame(() => {
-          if (mapHasMapPane(mapElement)) {
-            mapElement.invalidateSize();
-          }
-        });
+      // ResizeObserver already coalesces notifications per frame, and it delivers
+      // an initial callback on observe, so invalidate directly instead of
+      // deferring to requestAnimationFrame, which never runs while the embedding
+      // iframe is not being rendered.
+      const resizeObserver = new ResizeObserver((entries) => {
+        // Invalidating a collapsed container would pan the map by half its size.
+        const { width, height } = entries[0]?.contentRect || {};
+        if (!width || !height) return;
+        invalidate();
       });
-      resizeObserver.observe(container);
+      resizeObserver.observe(mapElement.getContainer());
 
-      return () => {
-        cancelAnimationFrame(frame);
-        resizeObserver.disconnect();
-      };
+      return () => resizeObserver.disconnect();
     }
     return undefined;
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/views/MapView/utils/mapActions.js
+++ b/src/views/MapView/utils/mapActions.js
@@ -12,6 +12,15 @@ const useMapFocusDisabled = () => {
   return isEmbed() && !!searchParams.bbox;
 };
 
+// Leaflet derives view and marker pixel positions from the container size it
+// cached at init. In an embed iframe the container is often still settling then,
+// so refresh the size before every focus action to avoid focusing a stale size.
+const refreshMapSize = (map) => {
+  if (map && mapHasMapPane(map)) {
+    map.invalidateSize();
+  }
+};
+
 const fitUnitsToMap = (units, map) => {
   // Return early on server side
   if (typeof window === 'undefined') {
@@ -51,7 +60,7 @@ const fitUnitsToMap = (units, map) => {
     try {
       setTimeout(() => {
         if (!mapHasMapPane(map)) return;
-        map.invalidateSize();
+        refreshMapSize(map);
         map.fitBounds(bounds, { padding: [15, 15], maxZoom: maxZoom - 1 });
       }, 1);
     } catch (err) {
@@ -63,11 +72,13 @@ const fitUnitsToMap = (units, map) => {
 const focusToPosition = (map, coordinates, zoomOption) => {
   const zoom =
     typeof zoomOption === 'number' ? zoomOption : map.options.maxZoom - 1;
+  refreshMapSize(map);
   map.setView([coordinates[1], coordinates[0]], zoom);
 };
 
 const focusDistrict = (map, coordinates) => {
   const bounds = coordinates.map((area) => swapCoordinates(area));
+  refreshMapSize(map);
   map.fitBounds(bounds);
 };
 
@@ -76,6 +87,7 @@ const focusDistricts = (map, districts) => {
   const bounds = filteredData.map((district) =>
     district.boundary.coordinates.map((area) => swapCoordinates(area))
   );
+  refreshMapSize(map);
   map.fitBounds(bounds);
 };
 
@@ -99,6 +111,7 @@ const fitBbox = (map, bbox) => {
   }
   const bounds = getBoundsFromBbox(bbox);
 
+  refreshMapSize(map);
   map.fitBounds(bounds);
 };
 
@@ -130,5 +143,6 @@ export {
   focusToPosition,
   getBoundsFromBbox,
   panViewToBounds,
+  refreshMapSize,
   useMapFocusDisabled,
 };


### PR DESCRIPTION
Refresh map size both before every focus action and whenever the container changes.

Refs: [PL-299](https://helsinkisolutionoffice.atlassian.net/browse/PL-299)

[PL-299]: https://helsinkisolutionoffice.atlassian.net/browse/PL-299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map resizing when the map container changes size.
  * Improved map display after focusing or fitting the map to locations.
  * Removed delayed resizing behavior to provide more responsive map updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->